### PR TITLE
fix: reroute to original page breaks

### DIFF
--- a/wiki/wiki/doctype/wiki_page/wiki_page.py
+++ b/wiki/wiki/doctype/wiki_page/wiki_page.py
@@ -305,7 +305,7 @@ def update(
 	if hasattr(patch, 'new_wiki_page'):
 		out.route = patch.new_wiki_page.route
 	else:
-		out.route = patch.wiki_page_doc.route
+		out.route = patch.wiki_page
 
 	return out
 


### PR DESCRIPTION
reroute to original page breaks when the patch was not submitted