### PR TITLE
feat: editable route from desk

### DIFF
--- a/wiki/patches.txt
+++ b/wiki/patches.txt
@@ -1,3 +1,4 @@
 wiki.wiki.doctype.wiki_page.patches.set_allow_guest
 wiki.wiki.doctype.wiki_page.patches.delete_is_new
 wiki.wiki.doctype.wiki_page_revision.patches.add_usernames
+wiki.wiki.doctype.wiki_sidebar_item.patches.fetch_route

--- a/wiki/public/js/edit_asset.js
+++ b/wiki/public/js/edit_asset.js
@@ -510,7 +510,7 @@ window.EditAsset = class EditAsset {
 			title_input.addClass("hide");
 			title_span.text(title_input.val());
 		});
-		title_input.on('keypress', (e) => {
+		title_input.on('change', (e) => {
 			$(".doc-sidebar .sidebar-items a.active").text(title_input.val())
 		});
 	}

--- a/wiki/wiki/doctype/wiki_page/wiki_page.json
+++ b/wiki/wiki/doctype/wiki_page/wiki_page.json
@@ -2,6 +2,8 @@
  "actions": [],
  "allow_guest_to_view": 1,
  "allow_import": 1,
+ "allow_rename": 1,
+ "autoname": "hash",
  "creation": "2020-09-26 15:53:44.849581",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -42,7 +44,6 @@
    "in_standard_filter": 1,
    "label": "Route",
    "reqd": 1,
-   "set_only_once": 1,
    "unique": 1
   },
   {
@@ -86,10 +87,11 @@
    "link_fieldname": "wiki_page"
   }
  ],
- "modified": "2021-09-14 14:39:13.174629",
+ "modified": "2021-12-12 16:50:44.703450",
  "modified_by": "Administrator",
  "module": "Wiki",
  "name": "Wiki Page",
+ "naming_rule": "Random",
  "owner": "Administrator",
  "permissions": [
   {

--- a/wiki/wiki/doctype/wiki_page/wiki_page.py
+++ b/wiki/wiki/doctype/wiki_page/wiki_page.py
@@ -17,8 +17,6 @@ from urllib.parse import urlencode
 
 
 class WikiPage(WebsiteGenerator):
-	def autoname(self):
-		self.name = self.route
 
 	def after_insert(self):
 		revision = frappe.new_doc("Wiki Page Revision")
@@ -160,7 +158,7 @@ class WikiPage(WebsiteGenerator):
 		sidebar = frappe.get_all(
 			doctype="Wiki Sidebar Item",
 			fields=["name", "parent"],
-			filters=[["item", "=", self.route]],
+			filters=[["item", "=", self.name]],
 		)
 		sidebar_html = ""
 		topmost = "/"

--- a/wiki/wiki/doctype/wiki_sidebar/wiki_sidebar.py
+++ b/wiki/wiki/doctype/wiki_sidebar/wiki_sidebar.py
@@ -49,12 +49,12 @@ class WikiSidebar(Document):
 		items = frappe.get_all(
 			"Wiki Sidebar Item",
 			filters={"parent": self.name, "type": "Wiki Page"},
-			fields=["title", "item", "name", "type"],
+			fields=["title", "item", "name", "type", "route"],
 			order_by="idx asc",
 		)
 
 		for item in items:
-			item.item = "/" + item.item
+			item.item = "/" + str(item.route)
 			items_without_group.append(item)
 
 		# return [{"group_title": "Topics", "group_items": items_without_group}] if items else []

--- a/wiki/wiki/doctype/wiki_sidebar_item/patches/fetch_route.py
+++ b/wiki/wiki/doctype/wiki_sidebar_item/patches/fetch_route.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
+# MIT License. See license.txt
+
+from __future__ import unicode_literals
+import frappe
+
+
+def execute():
+	frappe.reload_doc('Wiki', 'doctype', 'Wiki Sidebar')
+	frappe.reload_doc('Wiki', 'doctype', 'Wiki Sidebar Item')
+	frappe.db.sql('''
+		UPDATE `tabWiki Sidebar Item` as target
+		INNER JOIN `tabWiki Page` as source
+		ON `target`.`item` = `source`.`name`
+		SET `target`.`route` = `source`.`route`
+		WHERE `target`.`type` = 'Wiki Page'
+	''')
+	frappe.db.commit()

--- a/wiki/wiki/doctype/wiki_sidebar_item/wiki_sidebar_item.json
+++ b/wiki/wiki/doctype/wiki_sidebar_item/wiki_sidebar_item.json
@@ -7,7 +7,8 @@
  "field_order": [
   "type",
   "item",
-  "title"
+  "title",
+  "route"
  ],
  "fields": [
   {
@@ -34,11 +35,17 @@
    "options": "type",
    "reqd": 1,
    "search_index": 1
+  },
+  {
+   "fetch_from": "item.route",
+   "fieldname": "route",
+   "fieldtype": "Data",
+   "label": "Route"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2021-06-11 12:26:56.953302",
+ "modified": "2021-12-12 17:39:44.502039",
  "modified_by": "Administrator",
  "module": "Wiki",
  "name": "Wiki Sidebar Item",

--- a/wiki/www/compare.py
+++ b/wiki/www/compare.py
@@ -12,8 +12,10 @@ def get_context(context):
 	context.can_edit = can_edit
 	context.show_my_account = False
 
-	context.doc = frappe.get_doc("Wiki Page", frappe.form_dict.wiki_page)
-	context.doc.set_breadcrumbs(context)
+	wiki_page_name = frappe.db.get_value("Wiki Page",
+		filters={'route':frappe.form_dict.wiki_page},
+		fieldname='name')
+	context.doc = frappe.get_doc("Wiki Page", wiki_page_name)
 
 	from ghdiff import diff
 

--- a/wiki/www/edit.py
+++ b/wiki/www/edit.py
@@ -8,7 +8,10 @@ from frappe import _
 def get_context(context):
 	context.no_cache = 1
 	frappe.form_dict.edit = True
-	context.doc = frappe.get_doc("Wiki Page", frappe.form_dict.wiki_page)
+	wiki_page_name = frappe.db.get_value("Wiki Page",
+		filters={'route':frappe.form_dict.wiki_page},
+		fieldname='name')
+	context.doc = frappe.get_doc("Wiki Page", wiki_page_name)
 
 	context.doc.verify_permission("read")
 

--- a/wiki/www/new.py
+++ b/wiki/www/new.py
@@ -7,7 +7,10 @@ def get_context(context):
 	context.no_cache = 1
 	frappe.form_dict.edit = True
 	frappe.form_dict.new = "true"
-	context.doc = frappe.get_doc("Wiki Page", frappe.form_dict.wiki_page)
+	wiki_page_name = frappe.db.get_value("Wiki Page",
+		filters={'route':frappe.form_dict.wiki_page},
+		fieldname='name')
+	context.doc = frappe.get_doc("Wiki Page", wiki_page_name)
 	# context = context.doc.get_context(context)
 
 	context.doc.verify_permission("read")

--- a/wiki/www/revisions.py
+++ b/wiki/www/revisions.py
@@ -11,15 +11,18 @@ def get_context(context):
 	can_edit = frappe.session.user != "Guest"
 	context.can_edit = can_edit
 	context.show_my_account = False
+	wiki_page_name = frappe.db.get_value("Wiki Page",
+		filters={'route':frappe.form_dict.wiki_page},
+		fieldname='name')
 
 	revisions = frappe.db.get_all(
 		"Wiki Page Revision",
-		filters={"wiki_page": frappe.form_dict.wiki_page},
+		filters={"wiki_page": wiki_page_name},
 		fields=["message", "creation", "owner", "name", "raised_by", "raised_by_username"],
 	)
 	context.revisions = revisions
 	context.no_cache = 1
-	context.doc = frappe.get_doc("Wiki Page", frappe.form_dict.wiki_page)
+	context.doc = frappe.get_doc("Wiki Page", wiki_page_name)
 	context.title = "Revisions: " + context.doc.title
 
 	context.doc.set_breadcrumbs(context)


### PR DESCRIPTION
A route was not allowed to be edited from the desk because it was linked with a name. 
Names are random now. 
Routes can be edited from desk