### PR TITLE
refactor(Wiki Page Revision): wiki pages in table

### DIFF
--- a/wiki/patches.txt
+++ b/wiki/patches.txt
@@ -1,4 +1,8 @@
+[pre_model_sync]
 wiki.wiki.doctype.wiki_page.patches.set_allow_guest
 wiki.wiki.doctype.wiki_page.patches.delete_is_new
 wiki.wiki.doctype.wiki_page_revision.patches.add_usernames
 wiki.wiki.doctype.wiki_sidebar_item.patches.fetch_route
+
+[post_model_sync]
+wiki.wiki.doctype.wiki_sidebar_item.patches.wiki_page_revision_item_table

--- a/wiki/wiki/doctype/wiki_page_revision/wiki_page_revision.json
+++ b/wiki/wiki/doctype/wiki_page_revision/wiki_page_revision.json
@@ -6,10 +6,12 @@
  "engine": "InnoDB",
  "field_order": [
   "message",
-  "content",
-  "wiki_page",
   "raised_by",
-  "raised_by_username"
+  "raised_by_username",
+  "column_break_4",
+  "content",
+  "section_break_6",
+  "wiki_pages"
  ],
  "fields": [
   {
@@ -21,16 +23,7 @@
    "fieldname": "content",
    "fieldtype": "Code",
    "label": "Content",
-   "options": "Markdown",
-   "reqd": 1
-  },
-  {
-   "fieldname": "wiki_page",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Wiki Page",
-   "options": "Wiki Page",
-   "reqd": 1
+   "options": "Markdown"
   },
   {
    "fieldname": "raised_by",
@@ -44,11 +37,25 @@
    "fieldtype": "Data",
    "label": "Raised By Username",
    "read_only": 1
+  },
+  {
+   "fieldname": "column_break_4",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_6",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "wiki_pages",
+   "fieldtype": "Table",
+   "label": "Wiki Pages",
+   "options": "Wiki Page Revision Item"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-11-08 19:23:41.207213",
+ "modified": "2022-02-07 20:19:45.226793",
  "modified_by": "Administrator",
  "module": "Wiki",
  "name": "Wiki Page Revision",
@@ -82,6 +89,7 @@
  "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "title_field": "message",
  "track_changes": 1
 }

--- a/wiki/wiki/doctype/wiki_page_revision_item/wiki_page_revision_item.json
+++ b/wiki/wiki/doctype/wiki_page_revision_item/wiki_page_revision_item.json
@@ -1,0 +1,33 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "hash",
+ "creation": "2022-02-07 19:42:12.146504",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "wiki_page"
+ ],
+ "fields": [
+  {
+   "fieldname": "wiki_page",
+   "fieldtype": "Link",
+   "label": "Wiki Page",
+   "options": "Wiki Page"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2022-02-07 19:42:12.146504",
+ "modified_by": "Administrator",
+ "module": "Wiki",
+ "name": "Wiki Page Revision Item",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/wiki/wiki/doctype/wiki_page_revision_item/wiki_page_revision_item.py
+++ b/wiki/wiki/doctype/wiki_page_revision_item/wiki_page_revision_item.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2022, Frappe and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class WikiPageRevisionItem(Document):
+	pass

--- a/wiki/wiki/doctype/wiki_sidebar_item/patches/wiki_page_revision_item_table.py
+++ b/wiki/wiki/doctype/wiki_sidebar_item/patches/wiki_page_revision_item_table.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
+# MIT License. See license.txt
+
+from __future__ import unicode_literals
+import frappe
+
+
+def execute():
+	frappe.db.sql('''
+		INSERT INTO `tabWiki Page Revision Item`
+			(name, creation, modified,modified_by,owner,docstatus,parent,parentfield,parenttype,idx,wiki_page)
+
+		SELECT name, modified, modified, modified_by, owner,
+			docstatus, name , 'wiki_pages', 'Wiki Page Revision', 1, wiki_page
+		FROM `tabWiki Page Revision`
+	''')

--- a/wiki/www/revisions.py
+++ b/wiki/www/revisions.py
@@ -17,7 +17,7 @@ def get_context(context):
 
 	revisions = frappe.db.get_all(
 		"Wiki Page Revision",
-		filters={"wiki_page": wiki_page_name},
+		filters=[['Wiki Page Revision Item', 'wiki_page','=', wiki_page_name]],
 		fields=["message", "creation", "owner", "name", "raised_by", "raised_by_username"],
 	)
 	context.revisions = revisions


### PR DESCRIPTION
Wiki Page Revision will have a list of links that will point to the wiki pages
This was done to ensure saving space when the revision history of two pages are same