### PR TITLE
fix: use semantic left right link placeholders

### DIFF
--- a/wiki/wiki/doctype/wiki_page/templates/show.html
+++ b/wiki/wiki/doctype/wiki_page/templates/show.html
@@ -22,8 +22,8 @@
 	</div>
 
 	<div class = "forward-back">
-		<a href="/left" class="btn left">Left</a>
-		<a href="/right" class="btn pull-right right">Right</a>
+		<a href="#" class="btn left">Left</a>
+		<a href="#" class="btn pull-right right">Right</a>
 	</div>
 
 </div>


### PR DESCRIPTION
Broken links checked considers `/left` and `/right` link placeholders to be broken replacing them with `#`