### PR TITLE
fix: Pass wiki page name as filter instead of route

### DIFF
--- a/wiki/wiki/doctype/wiki_page/wiki_page.py
+++ b/wiki/wiki/doctype/wiki_page/wiki_page.py
@@ -182,7 +182,7 @@ class WikiPage(WebsiteGenerator):
 		sidebar = frappe.get_all(
 			doctype="Wiki Sidebar Item",
 			fields=["name", "parent"],
-			filters=[["item", "=", self.route]],
+			filters=[["item", "=", self.name]],
 		)
 		topmost = ""
 		if sidebar:


### PR DESCRIPTION
**Before:**
<img width="1440" alt="Screenshot 2022-05-26 at 11 35 03 AM" src="https://user-images.githubusercontent.com/13928957/170428206-91ec96a1-b49f-4ad7-836e-71883dfd41ac.png">


**After:**
<img width="1434" alt="Screenshot 2022-05-26 at 11 41 16 AM" src="https://user-images.githubusercontent.com/13928957/170428219-e3d2f5fd-ecc6-4e74-a19e-a769255ad511.png">

