### PR TITLE
fix: use font variables

### DIFF
--- a/wiki/public/scss/wiki.scss
+++ b/wiki/public/scss/wiki.scss
@@ -11,15 +11,12 @@
 @import "frappe/public/css/octicons/octicons.css";
 
 body {
-	font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto",
-		"Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
-		sans-serif;
+	font-family: $font-family-sans-serif
 }
 
 // diff
 textarea.wiki-content {
-	font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, Courier,
-		monospace;
+	font-family: $font-family-monospace;
 	font-size: $font-size-sm;
 }
 
@@ -44,8 +41,7 @@ textarea.wiki-content {
 	max-width: 700px;
 
 	.diff {
-		font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, Courier,
-			monospace;
+		font-family: $font-family-monospace;
 		font-size: $font-size-sm;
 		border: 1px solid $border-color;
 		border-radius: 0.5rem;

--- a/wiki/public/scss/wiki.scss
+++ b/wiki/public/scss/wiki.scss
@@ -11,7 +11,7 @@
 @import "frappe/public/css/octicons/octicons.css";
 
 body {
-	font-family: $font-family-sans-serif
+	font-family: $font-family-sans-serif;
 }
 
 // diff


### PR DESCRIPTION
Wiki provided its own font, thus disrespecting the settings in **Website Theme**.