### PR TITLE
fix: Wiki /new and /edit route conflicting with webform routes

### DIFF
--- a/wiki/hooks.py
+++ b/wiki/hooks.py
@@ -14,8 +14,8 @@ app_license = "MIT"
 page_renderer = "wiki.wiki.doctype.wiki_page.wiki_renderer.WikiPageRenderer"
 
 website_route_rules = [
-	{"from_route": "/<path:wiki_page>/edit", "to_route": "/edit"},
-	{"from_route": "/<path:wiki_page>/new", "to_route": "/new"},
+	{"from_route": "/<path:wiki_page>/edit-wiki", "to_route": "/edit"},
+	{"from_route": "/<path:wiki_page>/new-wiki", "to_route": "/new"},
 	{"from_route": "/<path:wiki_page>/revisions", "to_route": "/revisions"},
 ]
 

--- a/wiki/wiki/doctype/wiki_page/templates/show.html
+++ b/wiki/wiki/doctype/wiki_page/templates/show.html
@@ -16,8 +16,8 @@
 			<li><a href="/{{ path }}/revisions">{{ number_of_revisions }} Revisions</a>&nbsp;</li>
 			{%- endif -%}
 			{%- endif -%}
-			<li><a href="/{{ path }}/edit">Edit Page</a>&nbsp;</li>
-			<li><a href="/{{ path }}/new">New Page</a>&nbsp;</li>
+			<li><a href="/{{ path }}/edit-wiki">Edit Page</a>&nbsp;</li>
+			<li><a href="/{{ path }}/new-wiki">New Page</a>&nbsp;</li>
 		</ul>
 	</div>
 


### PR DESCRIPTION
**Issue:** Wiki routes `/<wiki-page>/new` & `/<wiki-page>/edit` is conflicting with webform routes `<web-form>/new` & `<web-form>/edit`.

changing the wiki route to `/<wiki-page>/new-wiki` & `/<wiki-page>/edit-wiki`