### PR TITLE
fix: Misc fixes

### DIFF
--- a/wiki/www/contributions.html
+++ b/wiki/www/contributions.html
@@ -70,15 +70,16 @@
 	frappe.ready(
 		() => {
 			$('.get_contributions').click(() => {
+				let start = $(".list-jobs tbody tr").length;
 				frappe.call({
 					method: "wiki.www.contributions.get_contributions",
 					args: {
+						start: start,
 						limit: parseInt($('[name="limit"]').val()) + 10,
 					},
 					callback: (response) => {
 
 						if (response.message) {
-							$('.list-jobs tbody').empty()
 							$('[name="limit"]').val(parseInt($('[name="limit"]').val()) + 10)
 							for (contribution of response.message.contributions) {
 								$('.list-jobs tbody').append($(`	<tr>

--- a/wiki/www/contributions.py
+++ b/wiki/www/contributions.py
@@ -26,9 +26,9 @@ def get_context(context):
 	for contribution in contributions:
 		route = frappe.db.get_value("Wiki Page", contribution.wiki_page, "route")
 		if contribution.new:
-			contribution.edit_link = f"/{route}/new?wiki_page_patch={contribution.name}"
+			contribution.edit_link = f"/{route}/new-wiki?wiki_page_patch={contribution.name}"
 		else:
-			contribution.edit_link = f"/{route}/edit?wiki_page_patch={contribution.name}"
+			contribution.edit_link = f"/{route}/edit-wiki?wiki_page_patch={contribution.name}"
 		contribution.color = color_map[contribution.status]
 		contribution.creation = frappe.utils.pretty_date(contribution.creation)
 		context.contributions.extend([contribution])
@@ -76,9 +76,9 @@ def get_contributions(limit):
 	for contribution in contributions:
 		route = frappe.db.get_value("Wiki Page", contribution.wiki_page, "route")
 		if contribution.new:
-			contribution.edit_link = f"/{route}/new?wiki_page_patch={contribution.name}"
+			contribution.edit_link = f"/{route}/new-wiki?wiki_page_patch={contribution.name}"
 		else:
-			contribution.edit_link = f"/{route}/edit?wiki_page_patch={contribution.name}"
+			contribution.edit_link = f"/{route}/edit-wiki?wiki_page_patch={contribution.name}"
 		contribution.color = color_map[contribution.status]
 		contribution.creation = frappe.utils.pretty_date(contribution.creation)
 		context.contributions.extend([contribution])

--- a/wiki/www/contributions.py
+++ b/wiki/www/contributions.py
@@ -35,7 +35,7 @@ def get_user_contributions(limit):
 
 
 def get_context(context):
-	context.pilled_title = "Contributions  " + get_open_contributions()
+	context.pilled_title = "My Contributions"
 	context.no_cache = 1
 	context.no_sidebar = 1
 	context.contributions = get_user_contributions(10)

--- a/wiki/www/contributions.py
+++ b/wiki/www/contributions.py
@@ -12,28 +12,6 @@ color_map = {
 }
 
 
-def get_user_contributions(limit):
-	contributions = []
-	wiki_page_patches = frappe.get_list(
-		"Wiki Page Patch",
-		["message", "status", "name", "wiki_page", "creation", "new"],
-		order_by="modified desc",
-		limit=cint(limit),
-		filters=[["status", "!=", "Draft"], ["owner", '=', frappe.session.user]],
-	)
-	for wiki_page_patch in wiki_page_patches:
-		route = frappe.db.get_value("Wiki Page", wiki_page_patch.wiki_page, "route")
-		if wiki_page_patch.new:
-			wiki_page_patch.edit_link = f"/{route}/new-wiki?wiki_page_patch={wiki_page_patch.name}"
-		else:
-			wiki_page_patch.edit_link = f"/{route}/edit-wiki?wiki_page_patch={wiki_page_patch.name}"
-		wiki_page_patch.color = color_map[wiki_page_patch.status]
-		wiki_page_patch.creation = frappe.utils.pretty_date(wiki_page_patch.creation)
-		contributions.extend([wiki_page_patch])
-
-	return contributions
-
-
 def get_context(context):
 	context.pilled_title = "My Contributions"
 	context.no_cache = 1
@@ -58,3 +36,25 @@ def get_context(context):
 @frappe.whitelist()
 def get_contributions(limit):
 	return {"contributions": get_user_contributions(limit)}
+
+
+def get_user_contributions(limit):
+	contributions = []
+	wiki_page_patches = frappe.get_list(
+		"Wiki Page Patch",
+		["message", "status", "name", "wiki_page", "creation", "new"],
+		order_by="modified desc",
+		limit=cint(limit),
+		filters=[["status", "!=", "Draft"], ["owner", '=', frappe.session.user]],
+	)
+	for wiki_page_patch in wiki_page_patches:
+		route = frappe.db.get_value("Wiki Page", wiki_page_patch.wiki_page, "route")
+		if wiki_page_patch.new:
+			wiki_page_patch.edit_link = f"/{route}/new-wiki?wiki_page_patch={wiki_page_patch.name}"
+		else:
+			wiki_page_patch.edit_link = f"/{route}/edit-wiki?wiki_page_patch={wiki_page_patch.name}"
+		wiki_page_patch.color = color_map[wiki_page_patch.status]
+		wiki_page_patch.creation = frappe.utils.pretty_date(wiki_page_patch.creation)
+		contributions.extend([wiki_page_patch])
+
+	return contributions

--- a/wiki/www/contributions.py
+++ b/wiki/www/contributions.py
@@ -15,7 +15,7 @@ def get_context(context):
 	context.pilled_title = "My Contributions"
 	context.no_cache = 1
 	context.no_sidebar = 1
-	context.contributions = get_user_contributions(10)
+	context.contributions = get_user_contributions(0, 10)
 	context = context.update(
 		{
 			"post_login": [
@@ -33,16 +33,17 @@ def get_context(context):
 
 
 @frappe.whitelist()
-def get_contributions(limit):
-	return {"contributions": get_user_contributions(limit)}
+def get_contributions(start, limit):
+	return {"contributions": get_user_contributions(start, limit)}
 
 
-def get_user_contributions(limit):
+def get_user_contributions(start, limit):
 	contributions = []
 	wiki_page_patches = frappe.get_list(
 		"Wiki Page Patch",
 		["message", "status", "name", "wiki_page", "creation", "new"],
 		order_by="modified desc",
+		start=cint(start),
 		limit=cint(limit),
 		filters=[["status", "!=", "Draft"], ["owner", '=', frappe.session.user]],
 	)

--- a/wiki/www/contributions.py
+++ b/wiki/www/contributions.py
@@ -1,7 +1,6 @@
 import frappe
 from frappe import _
 from frappe.utils.data import cint
-from wiki.wiki.doctype.wiki_page.wiki_page import get_open_contributions
 from wiki.wiki.doctype.wiki_page.wiki_page import get_open_drafts
 
 color_map = {

--- a/wiki/www/contributions.py
+++ b/wiki/www/contributions.py
@@ -3,18 +3,18 @@ from frappe import _
 from wiki.wiki.doctype.wiki_page.wiki_page import get_open_contributions
 from wiki.wiki.doctype.wiki_page.wiki_page import get_open_drafts
 
+color_map = {
+	"Changes Requested": "blue",
+	"Under Review": "orange",
+	"Rejected": "red",
+	"Approved": "green",
+}
+
 
 def get_context(context):
 	context.pilled_title = "Contributions  " + get_open_contributions()
 	context.no_cache = 1
 	context.no_sidebar = 1
-	color_map = {
-		"Changes Requested": "blue",
-		"Under Review": "orange",
-		"Rejected": "red",
-		"Approved": "green",
-	}
-
 	context.contributions = []
 	contributions = frappe.get_list(
 		"Wiki Page Patch",
@@ -56,13 +56,6 @@ def get_context(context):
 @frappe.whitelist()
 def get_contributions(limit):
 	context = frappe._dict()
-	color_map = {
-		"Changes Requested": "blue",
-		"Under Review": "orange",
-		"Rejected": "red",
-		"Approved": "green",
-	}
-
 	context.contributions = []
 	contributions = frappe.get_list(
 		"Wiki Page Patch",

--- a/wiki/www/contributions.py
+++ b/wiki/www/contributions.py
@@ -21,7 +21,7 @@ def get_context(context):
 		["message", "status", "name", "wiki_page", "creation", "new"],
 		order_by="modified desc",
 		limit=10,
-		filters=[["status", "!=", "Approved"]],
+		filters=[["status", "!=", "Draft"], ["owner", '=', frappe.session.user]],
 	)
 	for contribution in contributions:
 		route = frappe.db.get_value("Wiki Page", contribution.wiki_page, "route")
@@ -56,8 +56,6 @@ def get_context(context):
 @frappe.whitelist()
 def get_contributions(limit):
 	context = frappe._dict()
-	context.no_cache = 1
-	context.no_sidebar = 1
 	color_map = {
 		"Changes Requested": "blue",
 		"Under Review": "orange",

--- a/wiki/www/contributions.py
+++ b/wiki/www/contributions.py
@@ -45,10 +45,6 @@ def get_context(context):
 				{"label": _("My Account"), "url": "/me"},
 				{"label": _("Logout"), "url": "/?cmd=web_logout"},
 				{
-					"label": _("Contributions ") + get_open_contributions(),
-					"url": "/contributions",
-				},
-				{
 					"label": _("My Drafts ") + get_open_drafts(),
 					"url": "/drafts",
 				},

--- a/wiki/www/contributions.py
+++ b/wiki/www/contributions.py
@@ -57,6 +57,4 @@ def get_context(context):
 
 @frappe.whitelist()
 def get_contributions(limit):
-	context = frappe._dict()
-	context.contributions = get_user_contributions(limit)
-	return context
+	return {"contributions": get_user_contributions(limit)}

--- a/wiki/www/drafts.html
+++ b/wiki/www/drafts.html
@@ -70,15 +70,16 @@
 	frappe.ready(
 		() => {
 			$('.get_contributions').click(() => {
+				let start = $(".list-jobs tbody tr").length;
 				frappe.call({
 					method: "wiki.www.drafts.get_drafts",
 					args: {
+						start: start,
 						limit: parseInt($('[name="limit"]').val()) + 10,
 					},
 					callback: (response) => {
 
 						if (response.message) {
-							$('.list-jobs tbody').empty()
 							$('[name="limit"]').val(parseInt($('[name="limit"]').val()) + 10)
 							for (contribution of response.message.contributions) {
 								$('.list-jobs tbody').append($(`	<tr>
@@ -86,7 +87,7 @@
 										${contribution.status}</span></td>
 									<td>${contribution.message}</td>
 									<td>${contribution.creation}</td>
-									<td> <a class="btn btn-default btn-xs center" href="${contribution.edit_link}">Open Contribution</a>
+									<td> <a class="btn btn-default btn-xs center" href="${contribution.edit_link}">Open Draft</a>
 									</td>
 								</tr>
 

--- a/wiki/www/drafts.py
+++ b/wiki/www/drafts.py
@@ -50,6 +50,4 @@ def get_context(context):
 
 @frappe.whitelist()
 def get_drafts(limit):
-	context = frappe._dict()
-	context.contributions = get_user_drafts(limit)
-	return context
+	return {"contributions": get_user_drafts(limit)}

--- a/wiki/www/drafts.py
+++ b/wiki/www/drafts.py
@@ -2,7 +2,6 @@ import frappe
 from frappe import _
 from frappe.utils.data import cint
 from wiki.wiki.doctype.wiki_page.wiki_page import get_open_contributions
-from wiki.wiki.doctype.wiki_page.wiki_page import get_open_drafts
 
 
 def get_context(context):

--- a/wiki/www/drafts.py
+++ b/wiki/www/drafts.py
@@ -27,9 +27,9 @@ def get_context(context):
 	for contribution in contributions:
 		route = frappe.db.get_value("Wiki Page", contribution.wiki_page, "route")
 		if contribution.new:
-			contribution.edit_link = f"/{route}/new?wiki_page_patch={contribution.name}"
+			contribution.edit_link = f"/{route}/new-wiki?wiki_page_patch={contribution.name}"
 		else:
-			contribution.edit_link = f"/{route}/edit?wiki_page_patch={contribution.name}"
+			contribution.edit_link = f"/{route}/edit-wiki?wiki_page_patch={contribution.name}"
 		contribution.color = color_map[contribution.status]
 		contribution.creation = frappe.utils.pretty_date(contribution.creation)
 		context.contributions.extend([contribution])
@@ -78,9 +78,9 @@ def get_drafts(limit):
 	for contribution in contributions:
 		route = frappe.db.get_value("Wiki Page", contribution.wiki_page, "route")
 		if contribution.new:
-			contribution.edit_link = f"/{route}/new?wiki_page_patch={contribution.name}"
+			contribution.edit_link = f"/{route}/new-wiki?wiki_page_patch={contribution.name}"
 		else:
-			contribution.edit_link = f"/{route}/edit?wiki_page_patch={contribution.name}"
+			contribution.edit_link = f"/{route}/edit-wiki?wiki_page_patch={contribution.name}"
 		contribution.color = color_map[contribution.status]
 		contribution.creation = frappe.utils.pretty_date(contribution.creation)
 		context.contributions.extend([contribution])

--- a/wiki/www/drafts.py
+++ b/wiki/www/drafts.py
@@ -5,28 +5,6 @@ from wiki.wiki.doctype.wiki_page.wiki_page import get_open_contributions
 from wiki.wiki.doctype.wiki_page.wiki_page import get_open_drafts
 
 
-def get_user_drafts(limit):
-	drafts = []
-	wiki_page_patches = frappe.get_list(
-		"Wiki Page Patch",
-		["message", "status", "name", "wiki_page", "creation", "new"],
-		order_by="modified desc",
-		limit=cint(limit),
-		filters=[["status", "=", "Draft"], ["owner", '=', frappe.session.user]],
-	)
-	for wiki_page_patch in wiki_page_patches:
-		route = frappe.db.get_value("Wiki Page", wiki_page_patch.wiki_page, "route")
-		if wiki_page_patch.new:
-			wiki_page_patch.edit_link = f"/{route}/new-wiki?wiki_page_patch={wiki_page_patch.name}"
-		else:
-			wiki_page_patch.edit_link = f"/{route}/edit-wiki?wiki_page_patch={wiki_page_patch.name}"
-		wiki_page_patch.color = "orange"
-		wiki_page_patch.creation = frappe.utils.pretty_date(wiki_page_patch.creation)
-		drafts.extend([wiki_page_patch])
-
-	return drafts
-
-
 def get_context(context):
 	context.pilled_title = "My Drafts"
 	context.no_cache = 1
@@ -51,3 +29,25 @@ def get_context(context):
 @frappe.whitelist()
 def get_drafts(limit):
 	return {"contributions": get_user_drafts(limit)}
+
+
+def get_user_drafts(limit):
+	drafts = []
+	wiki_page_patches = frappe.get_list(
+		"Wiki Page Patch",
+		["message", "status", "name", "wiki_page", "creation", "new"],
+		order_by="modified desc",
+		limit=cint(limit),
+		filters=[["status", "=", "Draft"], ["owner", '=', frappe.session.user]],
+	)
+	for wiki_page_patch in wiki_page_patches:
+		route = frappe.db.get_value("Wiki Page", wiki_page_patch.wiki_page, "route")
+		if wiki_page_patch.new:
+			wiki_page_patch.edit_link = f"/{route}/new-wiki?wiki_page_patch={wiki_page_patch.name}"
+		else:
+			wiki_page_patch.edit_link = f"/{route}/edit-wiki?wiki_page_patch={wiki_page_patch.name}"
+		wiki_page_patch.color = "orange"
+		wiki_page_patch.creation = frappe.utils.pretty_date(wiki_page_patch.creation)
+		drafts.extend([wiki_page_patch])
+
+	return drafts

--- a/wiki/www/drafts.py
+++ b/wiki/www/drafts.py
@@ -41,10 +41,6 @@ def get_context(context):
 					"label": _("My Contributions ") + get_open_contributions(),
 					"url": "/contributions",
 				},
-				{
-					"label": _("My Drafts ") + get_open_drafts(),
-					"url": "/drafts",
-				},
 			]
 		}
 	)

--- a/wiki/www/drafts.py
+++ b/wiki/www/drafts.py
@@ -28,7 +28,7 @@ def get_user_drafts(limit):
 
 
 def get_context(context):
-	context.pilled_title = "My Drafts  " + get_open_drafts()
+	context.pilled_title = "My Drafts"
 	context.no_cache = 1
 	context.no_sidebar = 1
 	context.contributions = get_user_drafts(10)

--- a/wiki/www/drafts.py
+++ b/wiki/www/drafts.py
@@ -8,14 +8,6 @@ def get_context(context):
 	context.pilled_title = "My Drafts  " + get_open_drafts()
 	context.no_cache = 1
 	context.no_sidebar = 1
-	color_map = {
-		"Changes Requested": "blue",
-		"Under Review": "orange",
-		"Draft": "orange",
-		"Rejected": "red",
-		"Approved": "green",
-	}
-
 	context.contributions = []
 	contributions = frappe.get_list(
 		"Wiki Page Patch",
@@ -30,7 +22,7 @@ def get_context(context):
 			contribution.edit_link = f"/{route}/new-wiki?wiki_page_patch={contribution.name}"
 		else:
 			contribution.edit_link = f"/{route}/edit-wiki?wiki_page_patch={contribution.name}"
-		contribution.color = color_map[contribution.status]
+		contribution.color = "orange"
 		contribution.creation = frappe.utils.pretty_date(contribution.creation)
 		context.contributions.extend([contribution])
 
@@ -57,16 +49,6 @@ def get_context(context):
 @frappe.whitelist()
 def get_drafts(limit):
 	context = frappe._dict()
-	context.no_cache = 1
-	context.no_sidebar = 1
-	color_map = {
-		"Changes Requested": "blue",
-		"Under Review": "orange",
-		"Rejected": "red",
-		"Draft": "orange",
-		"Approved": "green",
-	}
-
 	context.contributions = []
 	contributions = frappe.get_list(
 		"Wiki Page Patch",
@@ -81,7 +63,7 @@ def get_drafts(limit):
 			contribution.edit_link = f"/{route}/new-wiki?wiki_page_patch={contribution.name}"
 		else:
 			contribution.edit_link = f"/{route}/edit-wiki?wiki_page_patch={contribution.name}"
-		contribution.color = color_map[contribution.status]
+		contribution.color = "orange"
 		contribution.creation = frappe.utils.pretty_date(contribution.creation)
 		context.contributions.extend([contribution])
 	return context

--- a/wiki/www/drafts.py
+++ b/wiki/www/drafts.py
@@ -8,7 +8,7 @@ def get_context(context):
 	context.pilled_title = "My Drafts"
 	context.no_cache = 1
 	context.no_sidebar = 1
-	context.contributions = get_user_drafts(10)
+	context.contributions = get_user_drafts(0, 10)
 	context = context.update(
 		{
 			"post_login": [
@@ -26,16 +26,17 @@ def get_context(context):
 
 
 @frappe.whitelist()
-def get_drafts(limit):
-	return {"contributions": get_user_drafts(limit)}
+def get_drafts(start, limit):
+	return {"contributions": get_user_drafts(start, limit)}
 
 
-def get_user_drafts(limit):
+def get_user_drafts(start, limit):
 	drafts = []
 	wiki_page_patches = frappe.get_list(
 		"Wiki Page Patch",
 		["message", "status", "name", "wiki_page", "creation", "new"],
 		order_by="modified desc",
+		start=cint(start),
 		limit=cint(limit),
 		filters=[["status", "=", "Draft"], ["owner", '=', frappe.session.user]],
 	)


### PR DESCRIPTION
1. #93 changed some paths from `/new` / `/edit` to `/new-wiki` / `/edit-wiki`, but some paths were remaining which are causing 404 errors

https://user-images.githubusercontent.com/32034600/184419063-c611c065-519e-4a5a-a8d0-6a8924cf002e.mov

#

2. After https://github.com/frappe/wiki/pull/87, Contributions page (`/contributions`) is **still** erroring out due to "Draft" not being present in the `color_map` - as it only changed the filters in `get_drafts`/`get_contributions` but didn't to change the same in the `get_context` function(s)

Visit: www.frappeframework.com/contributions

#

Other Changes:
- moved out common functionality in `contributions.py` to a separate function
- moved out common functionality in `drafts.py` to a separate function
- removed `color_map` from drafts.py & harcoded the color to orange (as we only fetch draft patches)