### PR TITLE
Update contributions.py to include color_map for "Draft" and correct user filter

### DIFF
--- a/wiki/www/contributions.py
+++ b/wiki/www/contributions.py
@@ -8,6 +8,7 @@ color_map = {
 	"Under Review": "orange",
 	"Rejected": "red",
 	"Approved": "green",
+	"Draft": "red"
 }
 
 

--- a/wiki/www/contributions.py
+++ b/wiki/www/contributions.py
@@ -46,7 +46,7 @@ def get_user_contributions(start, limit):
 		order_by="modified desc",
 		start=cint(start),
 		limit=cint(limit),
-		filters=[["status", "!=", "Draft"], ["owner", '=', frappe.session.user]],
+		filters=[["status", "!=", "Draft"], ["raised_by", '=', frappe.session.user]],
 	)
 	for wiki_page_patch in wiki_page_patches:
 		route = frappe.db.get_value("Wiki Page", wiki_page_patch.wiki_page, "route")


### PR DESCRIPTION
color_map in contributions.py did not include a color for "Draft" causing the page to crash if a draft is saved in contributions. This PR adds "Draft" as the color red to color map to fix this issue.