### PR TITLE
feat: add meta tags for Wiki Page

### DIFF
--- a/wiki/wiki/doctype/wiki_page/wiki_page.json
+++ b/wiki/wiki/doctype/wiki_page/wiki_page.json
@@ -16,7 +16,11 @@
   "published",
   "allow_guest",
   "section_break_4",
-  "content"
+  "content",
+  "meta_tags_section",
+  "meta_description",
+  "meta_image",
+  "meta_keywords"
  ],
  "fields": [
   {
@@ -70,6 +74,28 @@
    "fieldname": "allow_guest",
    "fieldtype": "Check",
    "label": "Allow Guest"
+  },
+  {
+   "fieldname": "meta_tags_section",
+   "fieldtype": "Section Break",
+   "label": "Meta Tags"
+  },
+  {
+   "fieldname": "meta_description",
+   "fieldtype": "Small Text",
+   "label": "Description"
+  },
+  {
+   "description": "Ideally should be 1200 x 630 pixels.",
+   "fieldname": "meta_image",
+   "fieldtype": "Attach Image",
+   "label": "Image"
+  },
+  {
+   "description": "Should be a comma separated list",
+   "fieldname": "meta_keywords",
+   "fieldtype": "Small Text",
+   "label": "Keywords"
   }
  ],
  "has_web_view": 1,
@@ -87,7 +113,7 @@
    "link_fieldname": "wiki_page"
   }
  ],
- "modified": "2021-12-12 16:50:44.703450",
+ "modified": "2022-09-24 15:09:35.710833",
  "modified_by": "Administrator",
  "module": "Wiki",
  "name": "Wiki Page",
@@ -122,6 +148,7 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "title_field": "title",
  "track_changes": 1,
  "website_search_field": "content"

--- a/wiki/wiki/doctype/wiki_page/wiki_page.py
+++ b/wiki/wiki/doctype/wiki_page/wiki_page.py
@@ -151,7 +151,14 @@ class WikiPage(WebsiteGenerator):
 		context.banner_image = wiki_settings.logo
 		context.script = wiki_settings.javascript
 		context.docs_search_scope = self.get_docs_search_scope()
-		context.metatags = {"title": self.title}
+		context.metatags = {
+			"title": self.title, 
+			"description": self.meta_description,
+			"keywords": self.meta_keywords,
+			"image": self.meta_image,
+			"og:image:width": "1200",
+			"og:image:height": "630",
+			}
 		context.last_revision = self.get_last_revision()
 		context.number_of_revisions = frappe.db.count(
 			"Wiki Page Revision Item", {"wiki_page": self.name}


### PR DESCRIPTION
This PR adds the following meta tags in every Wiki page:

1. Description
2. Keywords
3. Image
4. Image width and height defaults to 1200 by 630px - this is needed for Facebook Open Graph

Hopefully doing this will now allow us to find documentation from Google by improving page rankings. 

I wasn't able to figure out how to add these fields in the web page editor. Maybe someone can help me with that.

#97 should be partially done with this.