### PR TITLE
fix: table of content is scrollable

### DIFF
--- a/wiki/public/scss/wiki.scss
+++ b/wiki/public/scss/wiki.scss
@@ -332,6 +332,8 @@ textarea.wiki-content {
 		ul {
 			padding-bottom: 0;
 			margin-bottom: 0;
+			overflow-y: scroll;
+			height: calc(100vh - 300px);
 		}
 
 		.h5 {


### PR DESCRIPTION
The Table of Contents on the right side wasn't scrollable - hence defeating the purpose if there were too many sections on a page.

**Before**
The right sidebar wasn't scrollable.

![ezgif com-gif-maker-2](https://user-images.githubusercontent.com/19825455/192139953-3e718505-2568-401d-adee-162ee48629f8.gif)



**After**
The right sidebar is scrollable. 

![ezgif com-gif-maker-3](https://user-images.githubusercontent.com/19825455/192140079-54c23722-cb0a-474e-bb92-73c3200e0be0.gif)


The height of the `ul` is set to `100vh - 300px` - I just based it off on browser dimensions. No need to make this responsive since it's hidden on tablets/mobile anyway.