### PR TITLE
fix: fileUploader breaking because of vue3

### DIFF
--- a/wiki/public/js/edit_asset.js
+++ b/wiki/public/js/edit_asset.js
@@ -58,14 +58,14 @@ window.EditAsset = class EditAsset {
 
 	get_attachment_controls_html() {
 		return `
-			<div class='attachment-controls '>
-				<div class='show-attachments' tabindex="-1" data-trigger="focus">
+			<div class="attachment-controls">
+				<div class="show-attachments" tabindex="-1" data-trigger="focus">
 					${this.get_show_uploads_svg()}
-						<span class='number'>0</span>&nbsp;attachments
-				</div>&nbsp;&nbsp;
-				<div class='add-attachment-wiki'>
-					<span class='btn'>
-					${this.get_upload_image_svg()}
+					<span class="number">0</span> attachments
+				</div>
+				<div class="add-attachment-wiki">
+					<span class="btn">
+						${this.get_upload_image_svg()}
 						Upload Attachment
 					</span>
 				</div>
@@ -541,7 +541,8 @@ window.EditAsset = class EditAsset {
 
 	render_sidebar_diff() {
 		const lis = $(".sidebar-diff");
-		const sidebar_items = JSON.parse($('[name="new_sidebar_items"]').val());
+		let $new_sidebar_items = $('[name="new_sidebar_items"]').val();
+		const sidebar_items = $new_sidebar_items && JSON.parse($new_sidebar_items);
 		lis.empty();
 		for (let sidebar in sidebar_items) {
 			for (let item in sidebar_items[sidebar]) {

--- a/wiki/wiki/doctype/wiki_page/templates/edit.html
+++ b/wiki/wiki/doctype/wiki_page/templates/edit.html
@@ -127,19 +127,22 @@
 <script type="text/javascript"
 	src="/assets/frappe/node_modules/moment-timezone/builds/moment-timezone-with-data.min.js"></script>
 {{ include_script('desk.bundle.js') }}
+{{ include_script('file_uploader.bundle.js') }}
 {{ include_script('wiki.bundle.js') }}
-
-
-<script type="text/javascript" src="/assets/frappe/node_modules/vue/dist/vue.js"></script>
 
 <script>
 
-	Vue.prototype.__ = window.__;
-	Vue.prototype.frappe = window.frappe;
+	let frappe_version = "{{ frappe_version }}";
+	if (parseInt(frappe_version.split(".")[0]) <= 14 && !frappe_version.endsWith("-dev")) {
+		Vue.prototype.__ = window.__;
+		Vue.prototype.frappe = window.frappe;
+	}
+
+	frappe.boot = {{ boot }};
+
 	new EditWiki();
 
 	var edit = new EditAsset();
-	frappe.boot = {{ boot }};
 
 </script>
 

--- a/wiki/www/edit.py
+++ b/wiki/www/edit.py
@@ -30,6 +30,7 @@ def get_context(context):
 	boot_json = re.sub(r"</script\>", "", boot_json)
 
 	context.boot = boot_json
+	context.frappe_version = frappe.__version__
 	wiki_settings = frappe.get_single("Wiki Settings")
 	context.banner_image = wiki_settings.logo
 	context.script = wiki_settings.javascript


### PR DESCRIPTION
Wiki uses file uploader and file uploader is written in vue2 up to frappe version 14 and in version 15(develop) it is re-written in vue 3. This PR allows support for both the vue2 & vue 3 versions.