### PR TITLE
feat: delete wiki page

### DIFF
--- a/wiki/wiki/doctype/wiki_page/templates/show.html
+++ b/wiki/wiki/doctype/wiki_page/templates/show.html
@@ -17,6 +17,7 @@
 			{%- endif -%}
 			{%- endif -%}
 			<li><a href="/{{ path }}/edit-wiki">Edit Page</a>&nbsp;</li>
+			<li><a href="javascript:;" onclick="handleDelete()">Delete Page</a>&nbsp;</li>
 			<li><a href="/{{ path }}/new-wiki">New Page</a>&nbsp;</li>
 		</ul>
 	</div>
@@ -33,7 +34,18 @@
 
 <script>
 	new RenderWiki();
-
+	function handleDelete() {
+		frappe.call({
+			method: "wiki.wiki.doctype.wiki_page.wiki_page.delete_wiki_page",
+			args: {
+				wiki_page_route: new URL(window.location.href).pathname
+			},
+			callback: (r) => {
+				if (r.message)
+					window.location.assign("/home")
+			}
+		})
+	}
 </script>
 
 {%- if script -%}

--- a/wiki/wiki/doctype/wiki_page/templates/show.html
+++ b/wiki/wiki/doctype/wiki_page/templates/show.html
@@ -42,7 +42,7 @@
 			},
 			callback: (r) => {
 				if (r.message)
-					window.location.assign("/home")
+					window.location.assign("/wiki")
 			}
 		})
 	}

--- a/wiki/wiki/doctype/wiki_page/templates/show.html
+++ b/wiki/wiki/doctype/wiki_page/templates/show.html
@@ -35,15 +35,18 @@
 <script>
 	new RenderWiki();
 	function handleDelete() {
-		frappe.call({
-			method: "wiki.wiki.doctype.wiki_page.wiki_page.delete_wiki_page",
-			args: {
-				wiki_page_route: new URL(window.location.href).pathname
-			},
-			callback: (r) => {
-				if (r.message)
-					window.location.assign("/wiki")
-			}
+		frappe.confirm('Are you sure you want to delete the Wiki Page?',
+			() => {
+				frappe.call({
+				method: "wiki.wiki.doctype.wiki_page.wiki_page.delete_wiki_page",
+				args: {
+					wiki_page_route: new URL(window.location.href).pathname
+				},
+				callback: (r) => {
+					if (r.message)
+						window.location.assign("/wiki")
+				}
+			})
 		})
 	}
 </script>

--- a/wiki/wiki/doctype/wiki_page/wiki_page.py
+++ b/wiki/wiki/doctype/wiki_page/wiki_page.py
@@ -462,6 +462,11 @@ def approve(wiki_page_patch):
 
 @frappe.whitelist()
 def delete_wiki_page(wiki_page_route):
+	if not frappe.has_permission(doctype="Wiki Page", ptype="delete", throw=False):
+		frappe.throw(
+			_("You are not permitted to delete a Wiki Page"),
+			frappe.PermissionError,
+		)
 	wiki_page_name = frappe.get_value("Wiki Page", {"route": wiki_page_route[1:]})
 	if wiki_page_name:
 		frappe.delete_doc("Wiki Page", wiki_page_name)

--- a/wiki/wiki/doctype/wiki_page/wiki_page.py
+++ b/wiki/wiki/doctype/wiki_page/wiki_page.py
@@ -85,6 +85,8 @@ class WikiPage(WebsiteGenerator):
 		):
 			frappe.delete_doc("Wiki Sidebar Item", name)
 
+		self.clear_sidebar_cache()
+
 	def set_route(self):
 		if not self.route:
 			self.route = "wiki/" + cleanup_page_name(self.title)
@@ -456,3 +458,13 @@ def approve(wiki_page_patch):
 	patch.approved_by = frappe.session.user
 	patch.status = "Approved"
 	patch.submit()
+
+
+@frappe.whitelist()
+def delete_wiki_page(wiki_page_route):
+	wiki_page_name = frappe.get_value("Wiki Page", {"route": wiki_page_route[1:]})
+	if wiki_page_name:
+		frappe.delete_doc("Wiki Page", wiki_page_name)
+		return True
+
+	frappe.throw(_("The Wiki Page you are trying to delete doesn't exist"))


### PR DESCRIPTION
closes #41 

We now have a Delete Page option along with Edit Page and New Page
<img width="460" alt="Screenshot 2022-12-26 at 3 05 30 PM" src="https://user-images.githubusercontent.com/63963181/209532840-e0411724-8235-4912-9ac2-08f6e28984f8.png">


- [x] Add tests
- [x] Set permission for deleting wiki
- [x] Add dialog box for confirmation before deleting a wiki page

