### PR TITLE
fix: rebuild index if not found while search

### DIFF
--- a/wiki/hooks.py
+++ b/wiki/hooks.py
@@ -108,10 +108,6 @@ after_migrate = ["wiki.wiki.doctype.wiki_page.search.rebuild_index_in_background
 # Scheduled Tasks
 # ---------------
 
-scheduler_events = {
-	"all": ["wiki.wiki.doctype.wiki_page.search.rebuild_index_if_not_exists"],
-}
-
 # scheduler_events = {
 # 	"all": [
 # 		"wiki.tasks.all"

--- a/wiki/wiki/doctype/wiki_page/search.py
+++ b/wiki/wiki/doctype/wiki_page/search.py
@@ -94,16 +94,6 @@ def rebuild_index_in_background():
 		frappe.enqueue(rebuild_index, queue="long")
 
 
-def rebuild_index_if_not_exists():
-	spaces = frappe.db.get_all("Wiki Space", pluck="route")
-	for space in spaces:
-		try:
-			frappe.cache().ft(space).info()
-		except ResponseError:
-			rebuild_index()
-			break
-
-
 def create_index_for_records(records, space):
 	r = frappe.cache()
 	for i, d in enumerate(records):

--- a/wiki/wiki/doctype/wiki_page/search.py
+++ b/wiki/wiki/doctype/wiki_page/search.py
@@ -24,7 +24,9 @@ def search(query, path, space):
 
 	try:
 		result = r.ft(space).search(query)
-	except ResponseError:
+	except ResponseError as e:
+		if str(e).endswith("no such index"):
+			rebuild_index_in_background()
 		return {"total": 0, "docs": [], "duration": 0}
 
 	names = []


### PR DESCRIPTION
fix #161

The `rebuild_index_if_not_exists` seems to be corrupting whatever indices we had.