### PR TITLE
feature: Make sidebar items' links full-width

### DIFF
--- a/wiki/public/scss/wiki.scss
+++ b/wiki/public/scss/wiki.scss
@@ -309,6 +309,7 @@ body.dark {
 	}
 
 	:first-child {
+		width: 100%;
 		margin-right: auto;
 	}
 }

--- a/wiki/public/scss/wiki.scss
+++ b/wiki/public/scss/wiki.scss
@@ -310,7 +310,6 @@ body.dark {
 
 	:first-child {
 		width: 100%;
-		margin-right: auto;
 	}
 }
 


### PR DESCRIPTION
In the hopes of fixing #196

I only added `width: 100%` to CSS selector `.sidebar-item :first-child` to expand the child `<a>` element.

This make the sidebar links consistent with the sidebar groups which are full-width as well as making it easier to navigate through the pages without having to think how long the title is.

I left the `margin-right: auto`, but by making the `width: 100%`, it removes the margin. There may be a situation where it is needed, but it seems very unlikely.