### PR TITLE
Frappe Search Integration

### DIFF
--- a/wiki/hooks.py
+++ b/wiki/hooks.py
@@ -167,3 +167,11 @@ frappe_search_doctypes = {
         "extras": ["route"],
     },
 }
+
+frappe_search_doctypes = {
+    "Wiki Page": {
+        "title": "title",
+        "content": ["content"],
+        "fields": ["route"],
+    },
+}

--- a/wiki/hooks.py
+++ b/wiki/hooks.py
@@ -10,9 +10,9 @@ app_license = "MIT"
 page_renderer = "wiki.wiki.doctype.wiki_page.wiki_renderer.WikiPageRenderer"
 
 website_route_rules = [
-	{"from_route": "/<path:wiki_page>/edit-wiki", "to_route": "/edit"},
-	{"from_route": "/<path:wiki_page>/new-wiki", "to_route": "/new"},
-	{"from_route": "/<path:wiki_page>/revisions", "to_route": "/revisions"},
+    {"from_route": "/<path:wiki_page>/edit-wiki", "to_route": "/edit"},
+    {"from_route": "/<path:wiki_page>/new-wiki", "to_route": "/new"},
+    {"from_route": "/<path:wiki_page>/revisions", "to_route": "/revisions"},
 ]
 
 # Includes in <head>
@@ -109,7 +109,7 @@ after_migrate = ["wiki.wiki.doctype.wiki_page.search.rebuild_index_in_background
 # ---------------
 
 scheduler_events = {
-	"cron": {"*/15 * * * *": ["wiki.wiki.doctype.wiki_page.search.rebuild_index_in_background"]}
+    "cron": {"*/15 * * * *": ["wiki.wiki.doctype.wiki_page.search.rebuild_index_in_background"]}
 }
 
 # scheduler_events = {
@@ -159,3 +159,11 @@ scheduler_events = {
 # exempt linked doctypes from being automatically cancelled
 #
 # auto_cancel_exempted_doctypes = ["Auto Repeat"]
+
+frappe_search_doctypes = {
+    "Wiki Page": {
+        "title": "title",
+        "content": ["content"],
+        "extras": ["route"],
+    },
+}

--- a/wiki/public/js/render_wiki.js
+++ b/wiki/public/js/render_wiki.js
@@ -599,7 +599,7 @@ window.RenderWiki = class RenderWiki extends Wiki {
 
         frappe
           .call({
-            method: "frappe_search.core.search",
+            method: "frappe_search.api.search",
             args: {
               query: searchInput.val(),
               path: window.location.pathname,
@@ -612,10 +612,9 @@ window.RenderWiki = class RenderWiki extends Wiki {
             if (results.length === 0) {
               dropdown_html = `<div style="margin: 1.5rem 9rem;">No results found</div>`;
             } else {
-              console.log(results);
               dropdown_html = results
                 .map((r) => {
-                  return `<a class="dropdown-item" href="/${r.extras.route}">
+                  return `<a class="dropdown-item" href="/${r.fields.route}">
               <h6>${r.highlighted_title || r.title}</h6>
               <div>${
                 res.message.search_engine === "frappe_web_search"

--- a/wiki/public/js/render_wiki.js
+++ b/wiki/public/js/render_wiki.js
@@ -126,8 +126,8 @@ window.RenderWiki = class RenderWiki extends Wiki {
       if (
         !$(
           `.doc-sidebar .sidebar-group[data-title="${urlParams.get(
-            "newWiki",
-          )}"] .add-sidebar-page`,
+            "newWiki"
+          )}"] .add-sidebar-page`
         ).length
       ) {
         this.add_wiki_sidebar(urlParams.get("newWiki"));
@@ -135,17 +135,17 @@ window.RenderWiki = class RenderWiki extends Wiki {
         $(
           $(
             `.sidebar-items > .list-unstyled .h6:contains(${urlParams.get(
-              "newWiki",
-            )}) + .add-sidebar-page`,
-          )[0],
+              "newWiki"
+            )}) + .add-sidebar-page`
+          )[0]
         ).trigger("click");
       } else
         $(
           $(
             `.sidebar-items > .list-unstyled .h6:contains(${urlParams.get(
-              "newWiki",
-            )}) + .add-sidebar-page`,
-          )[1],
+              "newWiki"
+            )}) + .add-sidebar-page`
+          )[1]
         ).trigger("click");
     }
     $(".wiki-footer, .wiki-page-meta").toggleClass("hide");
@@ -168,7 +168,7 @@ window.RenderWiki = class RenderWiki extends Wiki {
           {
             scrollTop: offset,
           },
-          500,
+          500
         );
       });
     });
@@ -257,7 +257,7 @@ window.RenderWiki = class RenderWiki extends Wiki {
     $(".edit-wiki-btn, .sidebar-edit-mode-btn").on("click", function () {
       if (frappe.session.user === "Guest")
         window.location.assign(
-          `/login?redirect-to=${window.location.pathname}`,
+          `/login?redirect-to=${window.location.pathname}`
         );
       else {
         const urlParams = new URLSearchParams(window.location.search);
@@ -283,7 +283,7 @@ window.RenderWiki = class RenderWiki extends Wiki {
       const groupName = $(".sidebar-item.active").data("group-name");
       $(".edit-wiki-btn").trigger("click");
       $(
-        `.doc-sidebar .add-sidebar-page[data-group-name="${groupName}"]`,
+        `.doc-sidebar .add-sidebar-page[data-group-name="${groupName}"]`
       ).trigger("click");
     });
 
@@ -308,7 +308,7 @@ window.RenderWiki = class RenderWiki extends Wiki {
           if (newWikiPage.data("group-name") !== groupName) {
             // when new item is created in a different group as earlier
             newSidebarItem.appendTo(
-              $(this).parent().parent().children(".list-unstyled"),
+              $(this).parent().parent().children(".list-unstyled")
             );
             if (urlParams.get("newWiki") !== groupName)
               set_search_params("newWiki", groupName);
@@ -325,11 +325,11 @@ window.RenderWiki = class RenderWiki extends Wiki {
         } else {
           // fresh new item
           active_items = $(
-            ".sidebar-item.active, .sidebar-item.active .active",
+            ".sidebar-item.active, .sidebar-item.active .active"
           ).removeClass("active");
 
           newSidebarItem.appendTo(
-            $(this).parent().parent().children(".list-unstyled"),
+            $(this).parent().parent().children(".list-unstyled")
           );
           if (!$(".wiki-editor").is(":visible")) toggleEditor();
           if (urlParams.get("newWiki") !== groupName)
@@ -338,7 +338,7 @@ window.RenderWiki = class RenderWiki extends Wiki {
 
         $(this).parent().parent().each(setSortable);
         e.stopPropagation();
-      },
+      }
     );
   }
 
@@ -367,7 +367,7 @@ window.RenderWiki = class RenderWiki extends Wiki {
           title: __("Delete Wiki Page"),
           indicator: "red",
           message: __(
-            `Are you sure you want to <b>delete</b> the Wiki Page <b>${title}</b>?`,
+            `Are you sure you want to <b>delete</b> the Wiki Page <b>${title}</b>?`
           ),
           primary_action: {
             label: "Yes",
@@ -393,7 +393,7 @@ window.RenderWiki = class RenderWiki extends Wiki {
             },
           },
         });
-      },
+      }
     );
   }
 
@@ -408,7 +408,7 @@ window.RenderWiki = class RenderWiki extends Wiki {
         $(".revision-content").html(),
         $(".from-markdown .wiki-content")
           .html()
-          .replaceAll(/<br class="ProseMirror-trailingBreak">/g, ""),
+          .replaceAll(/<br class="ProseMirror-trailingBreak">/g, "")
       );
       $(".previous-revision").removeClass("hide");
     } else {
@@ -450,11 +450,11 @@ window.RenderWiki = class RenderWiki extends Wiki {
       if (previousRevision.content)
         $(".revision-content")[0].innerHTML = HtmlDiff.execute(
           previousRevision.content,
-          currentRevision.content,
+          currentRevision.content
         );
       else $(".revision-content")[0].innerHTML = currentRevision.content;
       $(
-        ".revision-time",
+        ".revision-time"
       )[0].innerHTML = `${currentRevision.author} edited ${currentRevision.revision_time}`;
       currentRevisionIndex++;
       addHljsClass();
@@ -472,10 +472,10 @@ window.RenderWiki = class RenderWiki extends Wiki {
       $(".previous-revision").removeClass("hide");
       $(".revision-content")[0].innerHTML = HtmlDiff.execute(
         nextRevision.content,
-        currentRevision.content,
+        currentRevision.content
       );
       $(
-        ".revision-time",
+        ".revision-time"
       )[0].innerHTML = `${currentRevision.author} edited ${currentRevision.revision_time}`;
       currentRevisionIndex--;
       addHljsClass();
@@ -505,7 +505,7 @@ window.RenderWiki = class RenderWiki extends Wiki {
       $(".doc-sidebar .sidebar-items")
         .children(".list-unstyled")
         .not(".hidden")
-        .first(),
+        .first()
     );
 
     $(".web-sidebar ul").each(setSortable);
@@ -537,7 +537,7 @@ window.RenderWiki = class RenderWiki extends Wiki {
         $(this)
           .parent()
           .append(
-            $(`<ul class="list-unstyled" style="min-height:20px;"> </ul`),
+            $(`<ul class="list-unstyled" style="min-height:20px;"> </ul`)
           );
       }
     });
@@ -568,7 +568,7 @@ window.RenderWiki = class RenderWiki extends Wiki {
       // fixes html tags when they are sliced
       return new DOMParser().parseFromString(
         content.slice(start, end),
-        "text/html",
+        "text/html"
       ).body.innerHTML;
     }
 
@@ -599,7 +599,7 @@ window.RenderWiki = class RenderWiki extends Wiki {
 
         frappe
           .call({
-            method: "wiki.wiki.doctype.wiki_page.search.search",
+            method: "frappe_search.core.search",
             args: {
               query: searchInput.val(),
               path: window.location.pathname,
@@ -607,19 +607,20 @@ window.RenderWiki = class RenderWiki extends Wiki {
             },
           })
           .then((res) => {
-            let results = res.message.docs || [];
+            let results = res.message.results || [];
             let dropdown_html;
             if (results.length === 0) {
               dropdown_html = `<div style="margin: 1.5rem 9rem;">No results found</div>`;
             } else {
+              console.log(results);
               dropdown_html = results
                 .map((r) => {
-                  return `<a class="dropdown-item" href="/${r.route}">
-              <h6>${r.title}</h6>
+                  return `<a class="dropdown-item" href="/${r.extras.route}">
+              <h6>${r.highlighted_title || r.title}</h6>
               <div>${
                 res.message.search_engine === "frappe_web_search"
                   ? r.content
-                  : trimContent(r.content)
+                  : trimContent(r.highlighted_content || r.content)
               }</div>
               </a>
               <div class='dropdown-border'></div>`;
@@ -630,7 +631,7 @@ window.RenderWiki = class RenderWiki extends Wiki {
             $dropdown_menu.addClass("show");
             dropdownItems = $dropdown_menu.find(".dropdown-item");
           });
-      }, 500),
+      }, 500)
     );
 
     $("#dropdownMenuSearch, .mobile-search-icon").on("click", () => {


### PR DESCRIPTION
This integrates [Frappe Search](https://github.com/safwansamsudeen/frappe_search) into Wiki.

The previous implementation also [used website search](https://github.com/frappe/wiki/blob/3899e787aa094b8774738479e60167fb6ba82a72/wiki/wiki/doctype/wiki_page/search.py#L23). Is this necessary? If so, how will we implement it here?

(Will revert the formatting soon).