### PR TITLE
fix: add new pages to sidebar after patch approval

### DIFF
--- a/wiki/wiki/doctype/wiki_page_patch/wiki_page_patch.py
+++ b/wiki/wiki/doctype/wiki_page_patch/wiki_page_patch.py
@@ -61,7 +61,20 @@ class WikiPagePatch(Document):
 
 	def update_sidebars(self):
 		if not hasattr(self, "new_sidebar_items") or not self.new_sidebar_items:
-			self.new_sidebar_items = "{}"
+			wiki_space_name = frappe.get_value(
+				"Wiki Space", {"route": self.wiki_page_doc.get_space_route()}
+			)
+
+			wiki_space = frappe.get_doc("Wiki Space", wiki_space_name)
+			wiki_space.append(
+				"wiki_sidebars",
+				{
+					"wiki_page": self.new_wiki_page.name,
+					"parent_label": self.new_sidebar_group,
+				},
+			)
+			wiki_space.save()
+			return
 
 		sidebars = json.loads(self.new_sidebar_items)
 

--- a/wiki/wiki/doctype/wiki_page_patch/wiki_page_patch.py
+++ b/wiki/wiki/doctype/wiki_page_patch/wiki_page_patch.py
@@ -61,19 +61,7 @@ class WikiPagePatch(Document):
 
 	def update_sidebars(self):
 		if not hasattr(self, "new_sidebar_items") or not self.new_sidebar_items:
-			wiki_space_name = frappe.get_value(
-				"Wiki Space", {"route": self.wiki_page_doc.get_space_route()}
-			)
-
-			wiki_space = frappe.get_doc("Wiki Space", wiki_space_name)
-			wiki_space.append(
-				"wiki_sidebars",
-				{
-					"wiki_page": self.new_wiki_page.name,
-					"parent_label": self.new_sidebar_group,
-				},
-			)
-			wiki_space.save()
+			self.insert_on_sidebar(self.new_sidebar_group, self.new_wiki_page.name)
 			return
 
 		sidebars = json.loads(self.new_sidebar_items)
@@ -86,23 +74,24 @@ class WikiPagePatch(Document):
 					idx += 1
 					if item["name"] == "new-wiki-page":
 						item["name"] = self.new_wiki_page.name
-						wiki_space_name = frappe.get_value(
-							"Wiki Space", {"route": self.wiki_page_doc.get_space_route()}
-						)
-
-						wiki_space = frappe.get_doc("Wiki Space", wiki_space_name)
-						wiki_space.append(
-							"wiki_sidebars",
-							{
-								"wiki_page": self.new_wiki_page.name,
-								"parent_label": list(sidebars)[-1],
-							},
-						)
-						wiki_space.save()
+						self.insert_on_sidebar(list(sidebars)[-1], self.new_wiki_page.name)
 
 					frappe.db.set_value(
 						"Wiki Group Item", {"wiki_page": str(item["name"])}, {"parent_label": sidebar, "idx": idx}
 					)
+
+	def insert_on_sidebar(self, parent_label: str, wiki_page: str):
+		wiki_space_name = frappe.get_value("Wiki Space", {"route": self.wiki_page_doc.get_space_route()})
+
+		wiki_space = frappe.get_doc("Wiki Space", wiki_space_name)
+		wiki_space.append(
+			"wiki_sidebars",
+			{
+				"wiki_page": wiki_page,
+				"parent_label": parent_label,
+			},
+		)
+		wiki_space.save()
 
 
 @frappe.whitelist()


### PR DESCRIPTION
This PR addresses issue #244 (refer to the full description there).

### Problem
New Wiki Pages can be published in two distinct ways: (i) immediately, if the creator holds the `Wiki Approver` role; or (ii) pending manual approval of the associated `Wiki Page Patch` if the creator lacks the `Wiki Approver` role.

The logic for this is embedded in the whitelisted `update` function within the `wiki/doctype/wiki_report/wiki_report.py` file. This function checks if the user possesses the `submit` perm for that doctype to determine whether to submit it immediately or not. There is an issue within this function: it expects to receive the `new_sidebar_items` argument from the API call, and subsequently stores it (at runtime) in the `Wiki Page Patch` object. However, this doctype lacks a corresponding field, thus the information is not persisted in the database. Consequently, when the doctype is not immediately submitted, this information is lost, preventing its later use in updating the sidebar.

### Solution
In my opinion, there is a design flaw in how sidebar updates are currently managed. Nevertheless, I have chosen not to alter the existing mechanism within this PR (such a refactor could be pursued in a following PR). My solution leverages the `new_sidebar_group` property (an existing property of the doctype) to compute the position in the sidebar and to update it when the  `new_sidebar_items`  property is not present (preserving the original behavior).