### PR TITLE
feat(wiki): change Wiki Page content from rich text to markdown

### DIFF
--- a/wiki/patches.txt
+++ b/wiki/patches.txt
@@ -7,3 +7,4 @@ wiki.wiki.doctype.wiki_feedback.patches.delete_wiki_feedback_item
 [post_model_sync]
 wiki.wiki.doctype.wiki_space.patches.wiki_sidebar_migration
 wiki.wiki.doctype.wiki_settings.patches.wiki_navbar_item_migration
+wiki.wiki.doctype.wiki_page.patches.update_content_field_value

--- a/wiki/wiki/doctype/wiki_page/patches/update_content_field_value.py
+++ b/wiki/wiki/doctype/wiki_page/patches/update_content_field_value.py
@@ -1,0 +1,8 @@
+import frappe
+from markdownify import markdownify as md
+
+def execute():
+    wiki_pages = frappe.db.get_all("Wiki Page", fields=["name", "content"])
+    for page in wiki_pages:
+        markdown_content = md(page['content'])
+        frappe.db.set_value('Wiki Page', page['name'], 'content', markdown_content)

--- a/wiki/wiki/doctype/wiki_page/wiki_page.json
+++ b/wiki/wiki/doctype/wiki_page/wiki_page.json
@@ -28,7 +28,7 @@
    "default": "No Content",
    "description": "It is recommended that you start your first heading with h2, as the title will be the h1.",
    "fieldname": "content",
-   "fieldtype": "HTML Editor",
+   "fieldtype": "Markdown Editor",
    "ignore_xss_filter": 1,
    "in_preview": 1,
    "label": "Content",
@@ -113,7 +113,7 @@
    "link_fieldname": "wiki_page"
   }
  ],
- "modified": "2023-09-16 09:44:36.699353",
+ "modified": "2024-08-24 17:32:29.161020",
  "modified_by": "Administrator",
  "module": "Wiki",
  "name": "Wiki Page",


### PR DESCRIPTION
This PR addresses issue #245
- Added a patch to convert 'content' field's value in existing Wiki Page records from Rich Text (HTML) to Markdown.
- Updated the 'content' field's type in the Wiki Page Doctype to 'Markdown Editor'.