### PR TITLE
style: Make whole sidebar link clickable

### DIFF
--- a/wiki/public/scss/wiki.scss
+++ b/wiki/public/scss/wiki.scss
@@ -238,7 +238,6 @@ body.dark {
   display: flex;
   align-items: center;
   height: 26px;
-  padding: 5px 8px;
   border-radius: 8px;
 }
 .sidebar-item-active {
@@ -343,7 +342,7 @@ body.dark {
     margin: 0;
     font-weight: 420;
     width: 100%;
-    padding: 0;
+    padding: 5px 8px;
 
     &:hover {
       color: unset;


### PR DESCRIPTION
Currently, the padding on the `<li>` element makes some of the highlighted area not a link that redirects you to a page. By transferring the padding to the `<a>` element, the whole highlighted area is a clickable link.

Perhaps it would even be better to transfer the `:hover` styles from the `.sidebar-group-item` to the `.sidebar-item a` to avoid confusion.