### PR TITLE
feat(wiki): add rate limiting for feedback submissions

### DIFF
--- a/wiki/wiki/doctype/wiki_feedback/wiki_feedback.py
+++ b/wiki/wiki/doctype/wiki_feedback/wiki_feedback.py
@@ -3,6 +3,7 @@
 
 import frappe
 from frappe.model.document import Document
+from frappe.rate_limiter import rate_limit
 from frappe.utils import validate_email_address
 
 
@@ -10,7 +11,13 @@ class WikiFeedback(Document):
 	pass
 
 
+def get_feedback_limit():
+	wiki_settings = frappe.get_single("Wiki Settings")
+	return wiki_settings.feedback_submission_limit or 3
+
+
 @frappe.whitelist(allow_guest=True)
+@rate_limit(limit=get_feedback_limit, seconds=60 * 60)
 def submit_feedback(name, feedback, rating, email=None, feedback_index=None):
 	email = validate_email_address(email)
 	doc = frappe.get_doc(

--- a/wiki/wiki/doctype/wiki_settings/wiki_settings.json
+++ b/wiki/wiki/doctype/wiki_settings/wiki_settings.json
@@ -24,6 +24,7 @@
   "feedback_tab",
   "feedback_section",
   "enable_feedback",
+  "feedback_submission_limit",
   "ask_for_contact_details",
   "section_break_mmtu",
   "javascript"
@@ -140,7 +141,6 @@
   },
   {
    "default": "0",
-   "depends_on": "eval:doc.enable_feedback",
    "fieldname": "ask_for_contact_details",
    "fieldtype": "Check",
    "label": "Ask for contact details"
@@ -149,12 +149,21 @@
    "fieldname": "feedback_tab",
    "fieldtype": "Tab Break",
    "label": "Feedback"
+  },
+  {
+   "default": "3",
+   "depends_on": "enable_feedback",
+   "description": "Hourly rate limit on submitting feedbacks",
+   "fieldname": "feedback_submission_limit",
+   "fieldtype": "Int",
+   "label": "Feedback Submission Limit",
+   "non_negative": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-06-03 16:19:02.137667",
+ "modified": "2024-09-29 14:05:32.587922",
  "modified_by": "Administrator",
  "module": "Wiki",
  "name": "Wiki Settings",


### PR DESCRIPTION
- Implement rate limiting for feedback submissions to prevent spamming
- Hourly limit can be configured via Wiki Settings
<img width="767" alt="Screenshot 2024-09-29 at 2 12 16 PM" src="https://github.com/user-attachments/assets/f664e77f-d229-4ec4-8c96-28f3f07d6017">
