### PR TITLE
fix: update page title in the DOM when loading wiki content using sidebar

### DIFF
--- a/wiki/public/js/wiki.js
+++ b/wiki/public/js/wiki.js
@@ -288,6 +288,8 @@ function loadWikiPage(url, pageElement, replaceState = false) {
         $(".wiki-content").html(r.message.content);
 
         $(".wiki-title").html(r.message.title);
+        
+        $('title').text(r.message.title);
 
         if (r.message.toc_html) {
           $(".page-toc .list-unstyled").html(r.message.toc_html);


### PR DESCRIPTION
fixes #387

the sidebar, instead of performing a full refresh of the page, swaps the main content, and thus leaving the title (the <title> tag) of the document unchanged, this is fixed by manually updating the title.


https://github.com/user-attachments/assets/cf26ba53-8a47-4d42-920d-b33dce18f918

