### PR TITLE
fix: manually set the rotation of the active sidebar-group icon

### DIFF
--- a/wiki/public/js/wiki.js
+++ b/wiki/public/js/wiki.js
@@ -173,6 +173,11 @@ window.Wiki = class Wiki {
     $(".sidebar-item.active")
       .parents(" .web-sidebar .sidebar-group>ul")
       .removeClass("hidden");
+
+    $(".sidebar-item.active")
+      .parents(" .web-sidebar .sidebar-group")
+      .find(".icon")
+      .addClass("rotate")
   }
 
   scrolltotop() {
@@ -288,6 +293,8 @@ function loadWikiPage(url, pageElement, replaceState = false) {
         $(".wiki-content").html(r.message.content);
 
         $(".wiki-title").html(r.message.title);
+        
+        $('title').text(r.message.title);
 
         if (r.message.toc_html) {
           $(".page-toc .list-unstyled").html(r.message.toc_html);


### PR DESCRIPTION
fixes #389 by manually adding the "rotate" class to the active sidebar-group icon on initial load.


https://github.com/user-attachments/assets/a557da4d-f7bc-4d6d-9eae-aedc91a3227a

