### PR TITLE
Fix "Open Contribution" button color

### DIFF
--- a/wiki/www/contributions.html
+++ b/wiki/www/contributions.html
@@ -34,7 +34,7 @@
 								j.status }}</span></td>
 						<td>{{ j.message }}</td>
 						<td>{{ j.modified }}</td>
-						<td> <a class="btn btn-default btn-xs center" href="{{ j.edit_link }}">Open Contribution</a>
+						<td> <a class="btn btn-secondary-dark btn-xs center" href="{{ j.edit_link }}">Open Contribution</a>
 						</td>
 					</tr>
 					{% endfor %}


### PR DESCRIPTION
The text of the button was the same as the background. this fix changes the button background color to be the secondary color:
![image](https://github.com/user-attachments/assets/125af07c-db52-4845-95a5-3d1105694cdb)

