### PR TITLE
fix: Navbar menu jitter , wiki-options overflow on small devices and  Hide wiki-options dropdown for guest users

### DIFF
--- a/wiki/public/scss/markdown.scss
+++ b/wiki/public/scss/markdown.scss
@@ -292,6 +292,7 @@
   @include media-breakpoint-down(md) {
     width: auto;
     margin: unset;
+    overflow-x: hidden;
   }
 }
 

--- a/wiki/public/scss/navbar.scss
+++ b/wiki/public/scss/navbar.scss
@@ -132,7 +132,6 @@
 
   .wiki-navbar-container {
     padding-right: 1rem;
-    height: 60px;
     align-items: center;
     background-color: var(--background-color);
 

--- a/wiki/wiki/doctype/wiki_page/templates/show.html
+++ b/wiki/wiki/doctype/wiki_page/templates/show.html
@@ -53,6 +53,7 @@
 	<div class="user-contributions" data-date="{{ last_revision.modified }}">
 	</div>
 	{%- endif -%}
+	{%- if show_dropdown -%}
 	<div class="dropdown">
 		<div class="dropdown-toggle wiki-options menu" type="button" role="button" id="wikiOptionsButton"
 			data-toggle="dropdown" aria-label="Wiki Option Button" aria-expanded="false">
@@ -75,6 +76,7 @@
 			</a>
 		</div>
 	</div>
+	{%- endif -%}
 </div>
 <div class="wiki-footer d-print-none">
 	<div class="forward-back">

--- a/wiki/wiki/doctype/wiki_page/wiki_page.py
+++ b/wiki/wiki/doctype/wiki_page/wiki_page.py
@@ -285,6 +285,7 @@ class WikiPage(WebsiteGenerator):
 		context.edit_wiki_page = frappe.form_dict.get("editWiki")
 		context.new_wiki_page = frappe.form_dict.get("newWiki")
 		context.last_revision = self.get_last_revision()
+		context.show_dropdown = frappe.session.user != "Guest"
 		context.number_of_revisions = frappe.db.count("Wiki Page Revision Item", {"wiki_page": self.name})
 		# TODO: group all context values
 		context.hide_on_sidebar = frappe.get_value(


### PR DESCRIPTION
## Summary

This PR addresses multiple UI issues related to the navbar and wiki dropdown on smaller devices:
- Fixes menu jittering on mobile devices caused by explicit `height` CSS property which also hides the main content in its vicinity.
- Resolves dropdown overflow: Ensures that the `wiki-options` dropdown no longer causes horizontal overflow or layout breaking on smaller viewports.
- Hides wiki-options for guest users: Since guest users do not have permissions to edit or manage pages, the options are now conditionally hidden from them to reduce clutter and prevent confusion.

## Changes Introduced
- For menu jittering
   - Remove explicit height causing menu jitter on collapse
- For wiki-options dropdown overflow
   - Add `overflow-x` to wiki-navbar-container to ensure dropdown adjusts within screen boundaries
- Add check to conditional render wiki-options dropdown
  - Add `show_dropdown` in the context

## Screenshot/Screencast

Menu Jitter demo:
Before:

https://github.com/user-attachments/assets/14362fb5-ad67-43b5-81ba-915c112f0e2f



After:

https://github.com/user-attachments/assets/ad25b5b8-0de1-452c-b2fe-854ccd6ce5b3

wiki-options overflow demo:
Before:

https://github.com/user-attachments/assets/45dbf9a5-9ba3-4f85-a777-fec499f3043d




After:

https://github.com/user-attachments/assets/480d2f63-3101-4472-a351-ab141e79c3e8




Wiki-options dropdown permissions:

https://github.com/user-attachments/assets/30f6075c-cf76-44da-aec6-b3d373a48f57




## How to Test
- To test for menu jittering
   - Open any wiki page in smaller devices
   - Check for menu toggle, it should smoothly open and collapse without any jitter
- To test for  `wiki-options` dropdown overflow
  - Open any wiki page in smaller devices ( Log in as user other than guest)
  - Click on `wiki options` button, it should not overflow the screen
- To test for  `wiki-options` dropdown permissions
  - Open any wiki page in smaller devices as a guest user
  - The `wiki options` button should be hidden
  
## Related issues
Fixes: https://github.com/frappe/wiki/issues/282 

@BreadGenie 