### PR TITLE
fix: improvements to sqlite based search

### DIFF
--- a/wiki/search.py
+++ b/wiki/search.py
@@ -7,9 +7,13 @@ import json
 import frappe
 from frappe.utils import cstr
 from redis.commands.search.field import TagField, TextField
-from redis.commands.search.indexDefinition import IndexDefinition
 from redis.commands.search.query import Query
 from redis.exceptions import ResponseError
+
+try:
+	from redis.commands.search.indexDefinition import IndexDefinition
+except ImportError:
+	IndexDefinition = None
 
 
 class Search:
@@ -22,6 +26,9 @@ class Search:
 			self.schema.append(frappe._dict(field))
 
 	def create_index(self):
+		if not IndexDefinition:
+			return
+
 		index_def = IndexDefinition(
 			prefix=[f"{self.redis.make_key(self.prefix).decode()}:"],
 		)

--- a/wiki/wiki/doctype/wiki_settings/wiki_settings.json
+++ b/wiki/wiki/doctype/wiki_settings/wiki_settings.json
@@ -176,7 +176,7 @@
    "label": "Disable guest access"
   },
   {
-   "default": "0",
+   "default": "1",
    "description": "Uses SQLite FTS for  searching. This takes precedence over Redis search if enabled.\n<br>\nSQLite based search is experimental.",
    "fieldname": "use_sqlite_for_search",
    "fieldtype": "Check",
@@ -191,7 +191,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-05-21 09:32:30.142174",
+ "modified": "2025-06-16 13:13:21.868523",
  "modified_by": "Administrator",
  "module": "Wiki",
  "name": "Wiki Settings",


### PR DESCRIPTION
Improves SQLite FTS based search and sets it as default.

1. Uses sensible heuristics for exact match ranking
2. Allows boolean operators for more control [`AND`, `OR`, `NOT`]: `hello NOT world` matches `"hello"` but not `"hello world"`
3. Allows explicit prefixing search: `hell* worl*` matches `"hello world"`
4. Allows exact searches: `"hello world"` matches only `"hello world"`
5. Defaults to final word prefixed search: `hello wor` matches `"hello world"`

Fixes throw on redis search `IndexDefinition` import ∵ newer versions of redis don't have it.
