### PR TITLE
 Fix iPad Sidebar Click Issue

### DIFF
--- a/wiki/public/js/render_wiki.js
+++ b/wiki/public/js/render_wiki.js
@@ -11,7 +11,7 @@ function setSortable() {
       pull: ["qux"],
     },
     swapThreshold: 0.7,
-    filter: ".draggable",
+    filter: ".non-draggable",
     onEnd: function (e) {
       frappe.utils.debounce(() => {
         frappe.call({
@@ -46,7 +46,7 @@ function set_search_params(key = "", value = "") {
 }
 
 function toggleSidebarEditor() {
-  $(".sidebar-item, .sidebar-group").toggleClass("draggable");
+  $(".sidebar-item, .sidebar-group").toggleClass("non-draggable");
   $(".drop-icon").toggleClass("hide");
   $(".add-sidebar-page").toggleClass("hide");
   $(".sidebar-edit-mode-btn").toggleClass("hide");
@@ -184,7 +184,7 @@ window.RenderWiki = class RenderWiki extends Wiki {
   }
 
   set_edit_mode() {
-    $(".sidebar-item, .sidebar-group").addClass("draggable");
+    $(".sidebar-item, .sidebar-group").addClass("non-draggable");
 
     $(".web-sidebar ul").each(setSortable);
 

--- a/wiki/public/js/wiki.js
+++ b/wiki/public/js/wiki.js
@@ -147,7 +147,8 @@ window.Wiki = class Wiki {
 
       $($(this))
         .find("a")
-        .on("click", (e) => {
+        // For iPad, touchstart listener is needed to recognize click.
+        .on("click touchstart", (e) => {
           e.preventDefault();
           const href = $(e.currentTarget).attr("href");
           const urlParams = new URLSearchParams(window.location.search);
@@ -180,6 +181,13 @@ window.Wiki = class Wiki {
   set_active_sidebar() {
     $(".doc-sidebar,.web-sidebar").on(
       "click",
+      ".collapsible",
+      this.toggle_sidebar
+    );
+
+    // For iPad, touchstart listener is needed to recognize click.
+    $(".doc-sidebar,.web-sidebar").on(
+      "touchstart",
       ".collapsible",
       this.toggle_sidebar
     );


### PR DESCRIPTION
This PR resolves the issue where clicks on sidebar nav items were not recognised on iPad. The solution involves adding a `touchstart` listener. PFA video.

Changes Made:
- Added a `touchstart` listener at 2 places (sidebar group and sidebar item)
- Minor renaming of class attribute (`draggable` -> `non-draggable`) since those elements were filtered out from Sortable when not in edit mode. 

### Impact of the Issue
This issue significantly affected the usability of all Frappe app wikis, including popular applications like ERPNext, Frappe HR, and others. On iPads, users were unable to interact with the sidebar properly. PFA video. Also, below are raised issues,

- #182 
- #216 

## **Before fix** 

https://github.com/user-attachments/assets/d26b1e80-fd9b-45c6-9e64-c7b26f9eda17

## **After fix**

https://github.com/user-attachments/assets/f5016697-1e88-47eb-9c49-b32b2bd16117

