### PR TITLE
feat: support custom favicons for each wiki space

### DIFF
--- a/wiki/wiki/doctype/wiki_page/wiki_page.py
+++ b/wiki/wiki/doctype/wiki_page/wiki_page.py
@@ -330,6 +330,7 @@ class WikiPage(WebsiteGenerator):
 						"url": "/drafts",
 					},
 				],
+				"favicon": wiki_space.favicon,
 			}
 		)
 

--- a/wiki/wiki/doctype/wiki_space/wiki_space.json
+++ b/wiki/wiki/doctype/wiki_space/wiki_space.json
@@ -12,6 +12,7 @@
   "space_name",
   "route",
   "app_switcher_logo",
+  "favicon",
   "wiki_sidebars",
   "navbar_tab",
   "logo_section",
@@ -80,11 +81,16 @@
    "fieldtype": "Attach Image",
    "label": "App Switcher Logo",
    "make_attachment_public": 1
+  },
+  {
+   "fieldname": "favicon",
+   "fieldtype": "Attach Image",
+   "label": "Favicon"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-02-20 12:08:19.790688",
+ "modified": "2025-07-29 22:11:36.434232",
  "modified_by": "Administrator",
  "module": "Wiki",
  "name": "Wiki Space",
@@ -116,6 +122,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],


### PR DESCRIPTION
Previously, the favicon remained the same when switching between different Wiki Spaces, which caused confusion and inconsistency in branding across spaces.

This PR fixes that by adding a favicon field to the Wiki Space DocType, allowing each space to have its own unique favicon.

Now, when you switch between Wiki Spaces, the favicon updates accordingly — improving clarity and user experience.

Before  - 

<img width="946" height="228" alt="Screenshot from 2025-07-29 19-57-11" src="https://github.com/user-attachments/assets/f0220dd2-d068-4da7-a260-e2ac311a2573" />


After - 



https://github.com/user-attachments/assets/c5905d23-682a-4ca0-ba07-2adff261afcd

