### PR TITLE
ci: use name instead of full object in test case

### DIFF
--- a/wiki/wiki/report/wiki_broken_links/test_broken_link_checker.py
+++ b/wiki/wiki/report/wiki_broken_links/test_broken_link_checker.py
@@ -65,7 +65,7 @@ class TestWikiBrokenLinkChecker(FrappeTestCase):
 		self.assertEqual(len(data), 0)
 
 		self.test_wiki_space.append(
-			"wiki_sidebars", {"wiki_page": self.test_wiki_page, "parent_label": "Test Parent Label"}
+			"wiki_sidebars", {"wiki_page": self.test_wiki_page.name, "parent_label": "Test Parent Label"}
 		)
 		self.test_wiki_space.save()
 


### PR DESCRIPTION
Updated the test case to send only the **name** instead of entire **DocType** object.

closes #414 