### PR TITLE
fix: on mobile screen close menu after navigation

### DIFF
--- a/wiki/public/js/wiki.js
+++ b/wiki/public/js/wiki.js
@@ -168,6 +168,7 @@ window.Wiki = class Wiki {
             },
             100
           );
+          $(".navbar-toggler").click()
         });
     });
   }


### PR DESCRIPTION
Fix a bug where on mobile screens after navigating to a page the menu wouldn't close 