### PR TITLE
feat: role based access in wiki space

### DIFF
--- a/wiki/hooks.py
+++ b/wiki/hooks.py
@@ -87,9 +87,10 @@ after_migrate = ["wiki.wiki.doctype.wiki_page.search.build_index_in_background"]
 # -----------
 # Permissions evaluated in scripted ways
 
-# permission_query_conditions = {
-# 	"Event": "frappe.desk.doctype.event.event.get_permission_query_conditions",
-# }
+permission_query_conditions = {
+    "Wiki Space": "wiki.wiki.doctype.wiki_space.wiki_space.get_permission_query_conditions",
+	# "Event": "frappe.desk.doctype.event.event.get_permission_query_conditions",
+}
 #
 # has_permission = {
 # 	"Event": "frappe.desk.doctype.event.event.has_permission",

--- a/wiki/wiki/doctype/wiki_page/wiki_page.py
+++ b/wiki/wiki/doctype/wiki_page/wiki_page.py
@@ -166,6 +166,10 @@ class WikiPage(WebsiteGenerator):
 			frappe.local.response["type"] = "redirect"
 			frappe.local.response["location"] = "/login?" + urlencode({"redirect-to": frappe.request.url})
 			raise frappe.Redirect
+		
+		space = frappe.get_doc("Wiki Space", {"route": self.get_space_route()})
+		if not space.user_has_access():
+			raise frappe.PermissionError(_('User does not have access'))
 
 	def set_breadcrumbs(self, context):
 		context.add_breadcrumbs = True

--- a/wiki/wiki/doctype/wiki_space/wiki_space.json
+++ b/wiki/wiki/doctype/wiki_space/wiki_space.json
@@ -11,9 +11,12 @@
   "general_tab",
   "space_name",
   "route",
-  "column_break_bynr",
-  "app_switcher_logo",
+  "section_break_sche",
   "favicon",
+  "app_switcher_logo",
+  "column_break_pffe",
+  "restricted_to_roles",
+  "allowed_roles",
   "section_break_z5nn",
   "wiki_sidebars",
   "navbar_tab",
@@ -90,17 +93,34 @@
    "label": "Favicon"
   },
   {
-   "fieldname": "column_break_bynr",
-   "fieldtype": "Column Break"
-  },
-  {
    "fieldname": "section_break_z5nn",
    "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "section_break_sche",
+   "fieldtype": "Section Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "restricted_to_roles",
+   "fieldtype": "Check",
+   "label": "Restricted to Roles"
+  },
+  {
+   "depends_on": "eval: doc.restricted_to_roles",
+   "fieldname": "allowed_roles",
+   "fieldtype": "Table MultiSelect",
+   "label": "Allowed Roles",
+   "options": "Has Role"
+  },
+  {
+   "fieldname": "column_break_pffe",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-07-30 00:06:22.631960",
+ "modified": "2025-08-09 06:03:44.708391",
  "modified_by": "Administrator",
  "module": "Wiki",
  "name": "Wiki Space",
@@ -133,8 +153,9 @@
   }
  ],
  "row_format": "Dynamic",
+ "show_title_field_in_link": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],
- "title_field": "route"
+ "title_field": "space_name"
 }


### PR DESCRIPTION
Added role-based access control to the Wiki app, allowing organizations to restrict access to specific wiki spaces based on user roles.

- Only users with allowed roles can access a wiki space.

- Admin can access regardless of role restrictions.

- Enables using the wiki for internal documentation.


https://github.com/user-attachments/assets/21c10b3e-9381-415e-b3b3-b510e39c26cb

