### PR TITLE
feat: Better Media Interactions in Editor

### DIFF
--- a/wiki/public/js/editor.js
+++ b/wiki/public/js/editor.js
@@ -165,6 +165,7 @@ editorContainer.addEventListener("drop", function (e) {
     files,
     folder: "Home/Attachments",
     allow_multiple: false,
+    make_attachments_public: true,
     restrictions: {
       allowed_file_types: ["image/*"],
     },
@@ -216,6 +217,7 @@ function insertMarkdown(type) {
         disable_file_browser: true,
         allow_toggle_private: false,
         allow_multiple: false,
+        make_attachments_public: true,
         restrictions: {
           allowed_file_types: ["image/*"],
         },

--- a/wiki/public/js/editor.js
+++ b/wiki/public/js/editor.js
@@ -147,16 +147,32 @@ editorContainer.addEventListener("drop", function (e) {
   if (!dataTransfer?.files?.length) {
     return;
   }
-  let files = dataTransfer.files;
+  validateAndUploadFiles(dataTransfer.files, "drop");
+});
+
+editorContainer.addEventListener("paste", function (e) {
+  const clipboardData = e.clipboardData;
+  if (!clipboardData?.files?.length) {
+    return;
+  }
+
+  e.preventDefault();
+  e.stopPropagation();
+
+  validateAndUploadFiles(clipboardData.files, "paste");
+});
+
+function validateAndUploadFiles(files, event) {
   const allowedTypes = ["image/", "video/mp4", "video/quicktime"];
   const invalidFiles = Array.from(files).filter(
     (file) => !allowedTypes.some((type) => file.type.includes(type)),
   );
 
   if (invalidFiles.length > 0) {
+    const action = event === "paste" ? "paste" : "insert";
     frappe.show_alert({
       message: __(
-        "You can only insert images, videos and GIFs in Markdown fields. Invalid file(s): " +
+        `You can only ${action} images, videos and GIFs in Markdown fields. Invalid file(s): ` +
           invalidFiles.map((f) => f.name).join(", "),
       ),
       indicator: "orange",
@@ -169,7 +185,7 @@ editorContainer.addEventListener("drop", function (e) {
     "Insert Media in Markdown",
     files,
   );
-});
+}
 
 function insertMarkdown(type) {
   const selection = editor.getSelectedText();

--- a/wiki/public/js/editor.js
+++ b/wiki/public/js/editor.js
@@ -242,7 +242,10 @@ function uploadMedia(fileTypes, dialogTitle, files = null) {
       if (["mp4", "mov"].includes(fileType)) {
         content = `\n<video controls width="100%" height="auto"><source src="${file_url}" type="video/${fileType}"></video>`;
       } else {
-        content = `\n![](${file_url})`;
+        const fileName =
+          file_doc.file_name || file_doc.file_url.split("/").pop();
+        const altText = fileName.split(".").slice(0, -1).join(".");
+        content = `\n![${altText}](${file_url})`;
       }
       editor.session.insert(editor.getCursorPosition(), content);
     },

--- a/wiki/public/js/editor.js
+++ b/wiki/public/js/editor.js
@@ -164,7 +164,7 @@ editorContainer.addEventListener("drop", function (e) {
     frm: this.frm,
     files,
     folder: "Home/Attachments",
-    allow_multiple: false,
+    allow_multiple: true,
     make_attachments_public: true,
     restrictions: {
       allowed_file_types: ["image/*"],
@@ -216,7 +216,7 @@ function insertMarkdown(type) {
         folder: "Home/Attachments",
         disable_file_browser: true,
         allow_toggle_private: false,
-        allow_multiple: false,
+        allow_multiple: true,
         make_attachments_public: true,
         restrictions: {
           allowed_file_types: ["image/*"],

--- a/wiki/public/scss/modal.scss
+++ b/wiki/public/scss/modal.scss
@@ -58,10 +58,8 @@
   .modal-footer {
     border-top: unset;
     justify-content: end;
-
-    .btn {
-      width: 100%;
-    }
+    display: flex;
+    gap: 0.5rem;
   }
 }
 

--- a/wiki/wiki/doctype/wiki_page/templates/editor.html
+++ b/wiki/wiki/doctype/wiki_page/templates/editor.html
@@ -98,6 +98,13 @@
           <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21" />
         </svg>
       </button>
+      <button data-mde-button="video" title="video">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+          stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-video">
+          <path d="m16 13 5.223 3.482a.5.5 0 0 0 .777-.416V7.87a.5.5 0 0 0-.752-.432L16 10.5" />
+          <rect x="2" y="6" width="14" height="12" rx="2" />
+        </svg>
+      </button>
       <button data-mde-button="table" title="Table">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
           stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-table">

--- a/wiki/wiki/doctype/wiki_page/wiki_page.json
+++ b/wiki/wiki/doctype/wiki_page/wiki_page.json
@@ -113,7 +113,8 @@
    "link_fieldname": "wiki_page"
   }
  ],
- "modified": "2024-09-04 17:06:27.584176",
+ "make_attachments_public": 1,
+ "modified": "2025-10-01 12:12:16.380238",
  "modified_by": "Administrator",
  "module": "Wiki",
  "name": "Wiki Page",
@@ -145,6 +146,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "show_title_field_in_link": 1,
  "sort_field": "modified",
  "sort_order": "DESC",


### PR DESCRIPTION
https://github.com/user-attachments/assets/e436d376-b7a4-4b31-9dae-454c97b597c4

Currently, media interactions are very limiting & frustrating. This slows down the workflow of writing docs. 

1. Made wiki page attachments public by default. Had to manually toggle private files to public during every upload
2. Adding multiple images
3. Uploading videos
4. Paste media to upload
5. Set filename as alt property for images