### PR TITLE
feat: save editor drafts to localstorage

### DIFF
--- a/wiki/public/js/editor.js
+++ b/wiki/public/js/editor.js
@@ -116,7 +116,7 @@ editor.session.on("change", function () {
 });
 
 // Also save title changes
-wikiTitleInput.on("change", function () {
+wikiTitleInput.on("input", function () {
   const content = editor.getValue();
   const title = $(this).val()?.trim() || "";
 
@@ -184,10 +184,6 @@ $(".sidebar-items > .list-unstyled").on("click", ".add-sidebar-page", () => {
     url.searchParams.set("newWiki", "1");
     window[`history`]["pushState"]({}, "", url);
   }, 1);
-});
-
-discardEditBtn.on("click", function () {
-  localStorage.removeItem(`wiki_draft_${wikiPageName}`);
 });
 
 editorContainer.addEventListener(

--- a/wiki/public/js/editor.js
+++ b/wiki/public/js/editor.js
@@ -35,12 +35,6 @@ $(document).ready(() => {
     const draft = getLocalDraft();
     if (draft && (draft.title || draft.content)) {
       setLocalDraftinEditor(draft);
-      const draftPreview =
-        draft.title || draft.content?.substring(0, 30) + "...";
-      frappe.show_alert({
-        message: __("Unsaved draft '{0}' restored", [draftPreview.bold()]),
-        indicator: "blue",
-      });
     }
   }
 });
@@ -157,6 +151,11 @@ function setLocalDraftinEditor(draft) {
   if (!draft) return;
   editor.setValue(draft.content || "", 1);
   wikiTitleInput.val(draft.title || "");
+  const draftPreview = draft.title || draft.content?.substring(0, 30) + "...";
+  frappe.show_alert({
+    message: __("Unsaved draft '{0}' restored", [draftPreview.bold()]),
+    indicator: "blue",
+  });
 }
 
 outdatedDraftWarning.hide();

--- a/wiki/public/js/editor.js
+++ b/wiki/public/js/editor.js
@@ -98,8 +98,10 @@ function setEditor() {
   });
 }
 
-// Auto-save to localStorage
-editor.session.on("change", function () {
+editor.session.on("change", () => saveDraftLocally());
+wikiTitleInput.on("input", () => saveDraftLocally());
+
+function saveDraftLocally() {
   const content = editor.getValue();
   const title = wikiTitleInput.val()?.trim() || "";
 
@@ -113,24 +115,7 @@ editor.session.on("change", function () {
       }),
     );
   }
-});
-
-// Also save title changes
-wikiTitleInput.on("input", function () {
-  const content = editor.getValue();
-  const title = $(this).val()?.trim() || "";
-
-  if (content || title) {
-    localStorage.setItem(
-      `wiki_draft_${wikiPageName}`,
-      JSON.stringify({
-        content: content,
-        title: title,
-        timestamp: Date.now(),
-      }),
-    );
-  }
-});
+}
 
 function saveWikiPage(draft = false) {
   const title = wikiTitleInput.val()?.trim();

--- a/wiki/public/js/editor.js
+++ b/wiki/public/js/editor.js
@@ -34,14 +34,13 @@ $(document).ready(() => {
   } else if (urlParams.get("newWiki")) {
     const draft = getLocalDraft();
     if (draft && (draft.title || draft.content)) {
-      frappe.confirm(
-        __(
-          `An unsaved draft titled {0} was found. Do you want to continue editing it?`,
-          [__(draft.title || draft.content?.substring(0, 10) + "...").bold()],
-        ),
-        () => setLocalDraftinEditor(draft),
-        () => localStorage.removeItem(`wiki_draft_${wikiPageName}`),
-      );
+      setLocalDraftinEditor(draft);
+      const draftPreview =
+        draft.title || draft.content?.substring(0, 30) + "...";
+      frappe.show_alert({
+        message: __("Unsaved draft '{0}' restored", [draftPreview.bold()]),
+        indicator: "blue",
+      });
     }
   }
 });

--- a/wiki/public/js/editor.js
+++ b/wiki/public/js/editor.js
@@ -121,7 +121,7 @@ function saveDraftLocally() {
 
   if (content || title) {
     localStorage.setItem(
-      `wiki_draft_${wikiPageName}`,
+      getDraftKey(),
       JSON.stringify({
         content: content,
         title: title,
@@ -131,8 +131,17 @@ function saveDraftLocally() {
   }
 }
 
+function getDraftKey() {
+  const urlParams = new URLSearchParams(window.location.search);
+  const patchId = urlParams.get("wikiPagePatch");
+  if (patchId) {
+    return `wiki_page_patch_draft_${patchId}`;
+  }
+  return `wiki_page_draft_${wikiPageName}`;
+}
+
 function getLocalDraft() {
-  const draftKey = `wiki_draft_${wikiPageName}`;
+  const draftKey = getDraftKey();
   const draft = localStorage.getItem(draftKey);
   if (draft) {
     try {
@@ -165,7 +174,7 @@ function showOutdatedDraftWarning(wikiPage) {
           editor.setValue(wikiPage.content || "", 1);
           wikiTitleInput.val(wikiPage.title || "");
           isSettingEditor = false;
-          localStorage.removeItem(`wiki_draft_${wikiPageName}`);
+          localStorage.removeItem(getDraftKey());
           outdatedDraftWarning.hide();
           frappe.show_alert({
             message: __("Updated with latest changes"),
@@ -196,7 +205,7 @@ function saveWikiPage(draft = false) {
     },
     callback: (r) => {
       // Clear draft from localStorage after successful save
-      localStorage.removeItem(`wiki_draft_${wikiPageName}`);
+      localStorage.removeItem(getDraftKey());
       // route back to the main page
       window.location.href = "/" + r.message.route;
     },

--- a/wiki/public/js/editor.js
+++ b/wiki/public/js/editor.js
@@ -36,7 +36,7 @@ $(document).ready(() => {
       frappe.confirm(
         __(
           `An unsaved draft titled {0} was found. Do you want to continue editing it?`,
-          [draft.title.bold()],
+          [__(draft.title || draft.content?.substring(0, 10) + "...").bold()],
         ),
         () => setLocalDraftinEditor(draft),
         () => localStorage.removeItem(`wiki_draft_${wikiPageName}`),
@@ -232,8 +232,8 @@ function validateAndUploadFiles(files, event) {
     const action = event === "paste" ? "paste" : "insert";
     frappe.show_alert({
       message: __(
-        `You can only ${action} images, videos and GIFs in Markdown fields. Invalid file(s): ` +
-          invalidFiles.map((f) => f.name).join(", "),
+        `You can only {0} images, videos and GIFs in Markdown fields. Invalid file(s): {1}`,
+        [__(action), invalidFiles.map((f) => f.name).join(", ")],
       ),
       indicator: "orange",
     });

--- a/wiki/public/js/editor.js
+++ b/wiki/public/js/editor.js
@@ -67,6 +67,7 @@ previewToggleBtn.on("click", function () {
   }
 });
 
+let isLoadingDraft = false;
 function setEditor() {
   const urlParams = new URLSearchParams(window.location.search);
   const currentUrl = new URL(window.location.href);
@@ -103,6 +104,7 @@ editor.session.on("change", () => saveDraftLocally());
 wikiTitleInput.on("input", () => saveDraftLocally());
 
 function saveDraftLocally() {
+  if (isLoadingDraft) return;
   const content = editor.getValue();
   const title = wikiTitleInput.val()?.trim() || "";
 
@@ -133,8 +135,12 @@ function getLocalDraft() {
 
 function setLocalDraftinEditor(draft) {
   if (!draft) return;
+  isLoadingDraft = true;
   editor.setValue(draft.content || "", 1);
   wikiTitleInput.val(draft.title || "");
+  setTimeout(() => {
+	isLoadingDraft = false;
+  }, 100)
 }
 
 function saveWikiPage(draft = false) {

--- a/wiki/public/js/render_wiki.js
+++ b/wiki/public/js/render_wiki.js
@@ -238,10 +238,17 @@ window.RenderWiki = class RenderWiki extends Wiki {
         primary_action: {
           label: "Yes",
           action() {
+            // clear draft from localstorage
+            const urlParams = new URLSearchParams(window.location.search);
+            const patchId = urlParams.get("wikiPagePatch");
+            const draftKey = patchId
+              ? `wiki_page_patch_draft_${patchId}`
+              : `wiki_page_draft_${wikiPageName}`;
+            localStorage.removeItem(draftKey);
+
             toggleEditor();
             $('.sidebar-item[data-name="new-wiki-page"]').remove();
             set_search_params();
-            localStorage.removeItem(`wiki_draft_${wikiPageName}`);
             discardDialog.hide();
           },
         },

--- a/wiki/public/js/render_wiki.js
+++ b/wiki/public/js/render_wiki.js
@@ -241,6 +241,7 @@ window.RenderWiki = class RenderWiki extends Wiki {
             toggleEditor();
             $('.sidebar-item[data-name="new-wiki-page"]').remove();
             set_search_params();
+            localStorage.removeItem(`wiki_draft_${wikiPageName}`);
             discardDialog.hide();
           },
         },

--- a/wiki/wiki/doctype/wiki_page/templates/editor.html
+++ b/wiki/wiki/doctype/wiki_page/templates/editor.html
@@ -22,6 +22,10 @@
 </div>
 
 <div id="preview-container" class="markdown-preview"></div>
+<div id="outdated-draft-warning" class="alert alert-warning text-sm mb-5">
+    This page has been updated since your last edit. Your draft may contain outdated content.
+    <span role="button" tabindex="0" class="load-latest-version-btn ml-1 text-sm font-weight-bold">Load Latest Version</span>
+</div>
 <div class="wiki-editor-container">
   <div class="wiki-title-container">
     <label class="text-sm">Title</label>

--- a/wiki/wiki/doctype/wiki_page/wiki_page.py
+++ b/wiki/wiki/doctype/wiki_page/wiki_page.py
@@ -673,9 +673,11 @@ def update_page_settings(name, settings):
 @frappe.whitelist()
 def get_markdown_content(wikiPageName, wikiPagePatch):
 	if wikiPagePatch:
-		new_code, new_title = frappe.db.get_value("Wiki Page Patch", wikiPagePatch, ["new_code", "new_title"])
-		return {"content": new_code, "title": new_title}
-	return frappe.db.get_value("Wiki Page", wikiPageName, ["content", "title"], as_dict=True)
+		new_code, new_title, modified = frappe.db.get_value(
+			"Wiki Page Patch", wikiPagePatch, ["new_code", "new_title", "modified"]
+		)
+		return {"content": new_code, "title": new_title, "modified": modified}
+	return frappe.db.get_value("Wiki Page", wikiPageName, ["content", "title", "modified"], as_dict=True)
 
 
 @frappe.whitelist(allow_guest=True)


### PR DESCRIPTION
If I accidentally close my tab or switch a page from the sidebar, I lose my edits. Now editor drafts will be stored in local storage:
 
https://github.com/user-attachments/assets/e17157e8-b612-42a2-abb0-2a7b23cfa2a0

## Features:

- A new wiki page is stored locally even if no draft is created.
- If you have multiple wiki page drafts, edits for them are maintained separately.
- After opening edit mode for page/page draft, if a local draft is present, it will be loaded & the user is informed about this, else the document from the backend is shown
- Checks for outdated content if the Wiki Page is modified after the last local draft was saved

https://github.com/user-attachments/assets/aac39029-fd37-4573-bce8-53c66380b915

<hr>

**Why not continuously write to the Wiki Page Patch document instead of storing locally?**

A Wiki Page Patch will generally be approved by someone, so writing incomplete changes to the backend would not be correct. For now, changes will be stored locally, and then you need to explicitly save the draft to update the Wiki Page Patch doctype. 

A better design change might be to continuously write to the backend and then mark the Draft as "Ready for Review".

