### PR TITLE
Fix: align navbar borders well

### DIFF
--- a/wiki/public/scss/navbar.scss
+++ b/wiki/public/scss/navbar.scss
@@ -21,7 +21,6 @@
   position: sticky;
   top: 0;
   z-index: 5;
-  height: 60px;
   position: relative;
 
   @media (max-width: 768px) {


### PR DESCRIPTION
## Before

<img width="1432" height="546" alt="image" src="https://github.com/user-attachments/assets/ae7cd0d8-6fdc-404f-b9ab-0e46128b4940" />


## After 

<img width="1340" height="548" alt="image" src="https://github.com/user-attachments/assets/eccd8a3e-6807-47b5-b08d-528d7d427ed2" />
