### PR TITLE
fix: navbar flickering on sidebar link clicks

### DIFF
--- a/wiki/public/js/wiki.js
+++ b/wiki/public/js/wiki.js
@@ -168,7 +168,10 @@ window.Wiki = class Wiki {
             },
             100,
           );
-          $(".navbar-toggler").click();
+
+          const navbar_toggler = $(".navbar-toggler");
+          if (navbar_toggler.attr("aria-expanded") == "true")
+            navbar_toggler.click();
         });
     });
   }


### PR DESCRIPTION
The navbar toggler button gets autoclicked every time the user clicks on any link of the sidebar.  As a result there's a weird animation on the navbar items



https://github.com/user-attachments/assets/800d5401-22ab-4a83-a181-3ed42ca6369e