### PR TITLE
feat: setup translatable frontend for V2

### DIFF
--- a/wiki/api.py
+++ b/wiki/api.py
@@ -1,0 +1,12 @@
+import frappe
+from frappe.translate import get_all_translations
+
+
+@frappe.whitelist(allow_guest=True)
+def get_translations():
+	if frappe.session.user != "Guest":
+		language = frappe.db.get_value("User", frappe.session.user, "language")
+	else:
+		language = frappe.db.get_single_value("System Settings", "language")
+
+	return get_all_translations(language)

--- a/wiki/api.py
+++ b/wiki/api.py
@@ -3,10 +3,11 @@ from frappe.translate import get_all_translations
 
 
 @frappe.whitelist(allow_guest=True)
-def get_translations():
+def get_translations() -> dict[str, str]:
 	if frappe.session.user != "Guest":
 		language = frappe.db.get_value("User", frappe.session.user, "language")
-	else:
-		language = frappe.db.get_single_value("System Settings", "language")
+
+	if not language:
+		language = frappe.db.get_single_value("System Settings", "language") or "en"
 
 	return get_all_translations(language)

--- a/wiki/install.py
+++ b/wiki/install.py
@@ -3,14 +3,15 @@
 
 
 import frappe
+from frappe import _
 
 
 def after_install():
 	# create the wiki homepage
 	page = frappe.new_doc("Wiki Page")
-	page.title = "Home"
+	page.title = _("Home")
 	page.route = "wiki/home"
-	page.content = "Welcome to the homepage of your wiki!"
+	page.content = _("Welcome to the homepage of your wiki!")
 	page.published = True
 	page.insert()
 

--- a/wiki/install.py
+++ b/wiki/install.py
@@ -23,7 +23,7 @@ def after_install():
 	# create the wiki sidebar
 	sidebar = frappe.new_doc("Wiki Group Item")
 	sidebar.wiki_page = page.name
-	sidebar.parent_label = "Wiki"
+	sidebar.parent_label = _("Wiki")
 	sidebar.parent = space.name
 	sidebar.parenttype = "Wiki Space"
 	sidebar.parentfield = "wiki_sidebars"

--- a/wiki/public/js/editor.js
+++ b/wiki/public/js/editor.js
@@ -2,6 +2,8 @@ import * as Ace from "ace-builds";
 import "ace-builds/src-noconflict/mode-markdown";
 import "ace-builds/src-noconflict/theme-tomorrow_night";
 
+const __ = globalThis.__;
+
 const editorContainer = document.getElementById("wiki-editor");
 const previewContainer = $("#preview-container");
 const previewToggleBtn = $("#toggle-btn");
@@ -19,7 +21,6 @@ let showPreview = false;
 
 let editor = Ace.edit(editorContainer, {
   mode: "ace/mode/markdown",
-  placeholder: "Write your content here...",
   theme: "ace/theme/tomorrow_night",
 });
 
@@ -42,7 +43,7 @@ $(document).ready(() => {
 previewContainer.hide();
 previewToggleBtn.on("click", function () {
   showPreview = !showPreview;
-  previewToggleBtn.text(showPreview ? "Edit" : "Preview");
+  previewToggleBtn.text(showPreview ? __("Edit") : __("Preview"));
   if (showPreview) {
     previewContainer.show();
     $(".wiki-editor-container").hide();
@@ -70,6 +71,7 @@ function setEditor() {
     wrap: true,
     showPrintMargin: true,
     theme: "ace/theme/tomorrow_night",
+    placeholder: __("Write your content here..."),
   });
   editor.renderer.lineHeight = 20;
 
@@ -193,7 +195,7 @@ function saveWikiPage(draft = false) {
     method: "wiki.wiki.doctype.wiki_page.wiki_page.update",
     args: {
       name: $('[name="wiki-page-name"]').val(),
-      message: `${isEmptyEditor ? "Created" : "Edited"} ${title}`,
+      message: `${isEmptyEditor ? __("Created") : __("Edited")} ${title}`,
       content,
       new: isEmptyEditor,
       new_sidebar_items: isEmptyEditor ? getSidebarItems() : "",
@@ -276,11 +278,11 @@ function validateAndUploadFiles(files, event) {
   );
 
   if (invalidFiles.length > 0) {
-    const action = event === "paste" ? "paste" : "insert";
+    const action = event === "paste" ? __("paste") : __("insert");
     frappe.show_alert({
       message: __(
         `You can only {0} images, videos and GIFs in Markdown fields. Invalid file(s): {1}`,
-        [__(action), invalidFiles.map((f) => f.name).join(", ")],
+        [action, invalidFiles.map((f) => f.name).join(", ")],
       ),
       indicator: "orange",
     });
@@ -289,7 +291,7 @@ function validateAndUploadFiles(files, event) {
 
   uploadMedia(
     ["image/*", "video/mp4", "video/quicktime"],
-    "Insert Media in Markdown",
+    __("Insert Media in Markdown"),
     files,
   );
 }
@@ -300,39 +302,42 @@ function insertMarkdown(type) {
 
   switch (type) {
     case "bold":
-      insertion = `**${selection || "bold text"}**`;
+      insertion = `**${selection || __("bold text")}**`;
       break;
     case "italic":
-      insertion = `*${selection || "italic text"}*`;
+      insertion = `*${selection || __("italic text")}*`;
       break;
     case "heading":
-      insertion = `\n# ${selection || "Heading"}`;
+      insertion = `\n# ${selection || __("Heading")}`;
       break;
     case "quote":
-      insertion = `\n> ${selection || "Quote"}`;
+      insertion = `\n> ${selection || __("Quote")}`;
       break;
     case "olist":
-      insertion = `\n1. ${selection || "List item"}`;
+      insertion = `\n1. ${selection || __("List item")}`;
       break;
     case "ulist":
-      insertion = `\n* ${selection || "List item"}`;
+      insertion = `\n* ${selection || __("List item")}`;
       break;
     case "link":
-      insertion = `[${selection || "link text"}](url)`;
+      insertion = `[${selection || __("link text")}](url)`;
       break;
     case "image":
-      uploadMedia(["image/*"], "Insert Image in Markdown");
+      uploadMedia(["image/*"], __("Insert Image in Markdown"));
       break;
     case "video":
-      uploadMedia(["video/mp4", "video/quicktime"], "Insert Video in Markdown");
+      uploadMedia(
+        ["video/mp4", "video/quicktime"],
+        __("Insert Video in Markdown"),
+      );
       break;
     case "table":
-      insertion = `${selection}\n| Header 1 | Header 2 |\n| -------- | -------- |\n| Row 1 | Row 1 |\n| Row 2 | Row 2 |`;
+      insertion = `${selection}\n| ${__("Header 1")} | ${__("Header 2")} |\n| -------- | -------- |\n| ${__("Row 1")} | ${__("Row 1")} |\n| ${__("Row 2")} | ${__("Row 2")} |`;
       break;
     case "disclosure":
       insertion = `\n<details>\n<summary>${
-        selection || "Title"
-      }</summary>\nContent\n</details>`;
+        selection || __("Title")
+      }</summary>\n${__("Content")}\n</details>`;
       break;
   }
 

--- a/wiki/public/js/render_wiki.js
+++ b/wiki/public/js/render_wiki.js
@@ -1,4 +1,5 @@
 import HtmlDiff from "htmldiff-js";
+const __ = globalThis.__;
 
 function setSortable() {
   if (window.innerWidth < 768) {
@@ -153,7 +154,7 @@ window.RenderWiki = class RenderWiki extends Wiki {
   }
 
   set_nav_buttons() {
-    var current_index = -1;
+    let current_index = -1;
     const sidebar_items = $(".sidebar-column").find("a").not(".navbar-brand");
 
     sidebar_items.each(function (index) {
@@ -236,7 +237,7 @@ window.RenderWiki = class RenderWiki extends Wiki {
         indicator: "red",
         message: __(`Are you sure you want to <b>discard</b> the changes?`),
         primary_action: {
-          label: "Yes",
+          label: __("Yes"),
           action() {
             // clear draft from localstorage
             const urlParams = new URLSearchParams(window.location.search);
@@ -274,7 +275,7 @@ window.RenderWiki = class RenderWiki extends Wiki {
         const newSidebarItem = $(`
         <li class="sidebar-item sidebar-group-item active" data-type="Wiki Page" data-name="new-wiki-page" data-group-name="${groupName}">
           <div>
-            <a href="#">New Wiki Page</a>
+            <a href="#">${__("New Wiki Page")}</a>
           </div>
         </li>
       `);
@@ -321,7 +322,10 @@ window.RenderWiki = class RenderWiki extends Wiki {
   add_trash_icon() {
     const trashIcon = `<div class="text-muted hide remove-sidebar-item small">
       <span class="trash-icon">
-        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-trash"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path></svg>
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-trash">
+          <polyline points="3 6 5 6 21 6"></polyline>
+          <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+        </svg>
       </span>
     </div>`;
 
@@ -346,7 +350,7 @@ window.RenderWiki = class RenderWiki extends Wiki {
             `Are you sure you want to <b>delete</b> the Wiki Page <b>${title}</b>?`,
           ),
           primary_action: {
-            label: "Yes",
+            label: __("Yes"),
             action() {
               frappe.call({
                 method:
@@ -359,7 +363,7 @@ window.RenderWiki = class RenderWiki extends Wiki {
                     sidebar_item.remove();
 
                     frappe.show_alert({
-                      message: `Wiki Page <b>${title}</b> deleted`,
+                      message: __(`Wiki Page <b>${title}</b> deleted`),
                       indicator: "green",
                     });
                     dialog.hide();
@@ -377,9 +381,10 @@ window.RenderWiki = class RenderWiki extends Wiki {
     const initial_content = $(".revision-content").html().trim();
     let revisions = [];
     let currentRevisionIndex = 1;
+    let message = __("No Revisions");
 
     // set initial revision
-    if (initial_content !== "<h3>No Revisions</h3>") {
+    if (initial_content !== `<h3>${message}</h3>`) {
       $(".revision-content")[0].innerHTML = HtmlDiff.execute(
         $(".revision-content").html(),
         $(".from-markdown .wiki-content")
@@ -389,7 +394,7 @@ window.RenderWiki = class RenderWiki extends Wiki {
       $(".previous-revision").removeClass("hide");
     } else {
       $(".revision-content")[0].innerHTML =
-        `<div class="no-revision">No Revisions</div>`;
+        `<div class="no-revision">${message}</div>`;
       $(".revision-time").hide();
       $(".revisions-modal .modal-header").hide();
     }
@@ -494,7 +499,9 @@ window.RenderWiki = class RenderWiki extends Wiki {
 				<div class="collapsible">
 					<span class="text-sm">${title}</span>
           <span class='add-sidebar-page'>
-            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-plus"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-plus">
+              <line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line>
+            </svg>
           </span>
           <span class='drop-icon hide'>
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -584,7 +591,7 @@ window.RenderWiki = class RenderWiki extends Wiki {
           })
           .then((res) => {
             let results = res.message.docs || [];
-            let dropdown_html = `<div style="margin: 0.8rem;text-align: center;">No results found</div>`;
+            let dropdown_html = `<div style="margin: 0.8rem;text-align: center;">${__("No results found")}</div>`;
             if (results.length > 0) {
               dropdown_html = results
                 .map((r) => {

--- a/wiki/public/js/render_wiki.js
+++ b/wiki/public/js/render_wiki.js
@@ -347,7 +347,8 @@ window.RenderWiki = class RenderWiki extends Wiki {
           title: __("Delete Wiki Page"),
           indicator: "red",
           message: __(
-            `Are you sure you want to <b>delete</b> the Wiki Page <b>${title}</b>?`,
+            `Are you sure you want to <b>delete</b> the Wiki Page <b>{0}</b>?`,
+            [title],
           ),
           primary_action: {
             label: __("Yes"),
@@ -363,7 +364,7 @@ window.RenderWiki = class RenderWiki extends Wiki {
                     sidebar_item.remove();
 
                     frappe.show_alert({
-                      message: __(`Wiki Page <b>${title}</b> deleted`),
+                      message: __("Wiki Page <b>{0}</b> deleted", [title]),
                       indicator: "green",
                     });
                     dialog.hide();
@@ -378,13 +379,13 @@ window.RenderWiki = class RenderWiki extends Wiki {
   }
 
   set_revisions() {
-    const initial_content = $(".revision-content").html().trim();
+    const isEmpty = $(".revision-content").data("empty");
     let revisions = [];
     let currentRevisionIndex = 1;
     let message = __("No Revisions");
 
     // set initial revision
-    if (initial_content !== `<h3>${message}</h3>`) {
+    if (!isEmpty) {
       $(".revision-content")[0].innerHTML = HtmlDiff.execute(
         $(".revision-content").html(),
         $(".from-markdown .wiki-content")

--- a/wiki/public/js/translation.js
+++ b/wiki/public/js/translation.js
@@ -1,0 +1,40 @@
+export { translate as __ };
+if (!globalThis.translatedMessages) fetchTranslations();
+globalThis.__ = translate;
+
+function format(message, replace) {
+  return message.replace(/{(\d+)}/g, (match, number) =>
+    replace[number] === undefined ? match : replace[number],
+  );
+}
+
+function translate(message, replace, context = null) {
+  const translatedMessages = globalThis.translatedMessages || {};
+  let translatedMessage = "";
+
+  if (context) {
+    const key = `${message}:${context}`;
+    if (translatedMessages[key]) {
+      translatedMessage = translatedMessages[key];
+    }
+  }
+
+  if (!translatedMessage) {
+    translatedMessage = translatedMessages[message] || message;
+  }
+
+  const hasPlaceholders = /{\d+}/.test(message);
+  if (!hasPlaceholders) {
+    return translatedMessage;
+  }
+
+  return format(translatedMessage, replace);
+}
+
+function fetchTranslations() {
+  fetch("/api/method/wiki.api.get_translations")
+    .then((response) => response.json())
+    .then((data) => {
+      globalThis.translatedMessages = data.message;
+    });
+}

--- a/wiki/public/js/translation.js
+++ b/wiki/public/js/translation.js
@@ -1,40 +1,60 @@
 export { translate as __ };
-if (!globalThis.translatedMessages) fetchTranslations();
+
+globalThis.translatedMessages = globalThis.translatedMessages || null;
+
+let translationsPromise = null;
+
 globalThis.__ = translate;
 
-function format(message, replace) {
-  return message.replace(/{(\d+)}/g, (match, number) =>
-    replace[number] === undefined ? match : replace[number],
-  );
+ensureTranslationsLoaded();
+
+function ensureTranslationsLoaded() {
+  if (!translationsPromise) {
+    translationsPromise = fetchTranslations();
+  }
+  return translationsPromise;
 }
 
-function translate(message, replace, context = null) {
-  const translatedMessages = globalThis.translatedMessages || {};
+function translate(message, replace = [], context = null) {
+  const messages = globalThis.translatedMessages;
+
+  if (!messages) {
+    return format(message, replace);
+  }
+
   let translatedMessage = "";
 
   if (context) {
-    const key = `${message}:${context}`;
-    if (translatedMessages[key]) {
-      translatedMessage = translatedMessages[key];
-    }
+    const contextualKey = `${message}:${context}`;
+    translatedMessage = messages[contextualKey] || "";
   }
 
   if (!translatedMessage) {
-    translatedMessage = translatedMessages[message] || message;
+    translatedMessage = messages[message] || message;
   }
 
-  const hasPlaceholders = /{\d+}/.test(message);
-  if (!hasPlaceholders) {
-    return translatedMessage;
-  }
-
-  return format(translatedMessage, replace);
+  return hasPlaceholders(translatedMessage)
+    ? format(translatedMessage, replace)
+    : translatedMessage;
 }
 
-function fetchTranslations() {
-  fetch("/api/method/wiki.api.get_translations")
-    .then((response) => response.json())
-    .then((data) => {
-      globalThis.translatedMessages = data.message;
-    });
+function format(message, replace) {
+  if (!replace?.length) return message;
+
+  return message.replace(/{(\d+)}/g, (match, index) => replace[index] ?? match);
+}
+
+function hasPlaceholders(message) {
+  return /{\d+}/.test(message);
+}
+
+async function fetchTranslations() {
+  try {
+    const response = await fetch("/api/method/wiki.api.get_translations");
+    const data = await response.json();
+    globalThis.translatedMessages = data.message || {};
+  } catch (error) {
+    console.error("Failed to load translations", error);
+    globalThis.translatedMessages = {};
+  }
 }

--- a/wiki/public/js/wiki.bundle.js
+++ b/wiki/public/js/wiki.bundle.js
@@ -1,3 +1,4 @@
+import "./translation.js";
 import "./wiki";
 import "./render_wiki";
 import "./editor";

--- a/wiki/public/js/wiki.js
+++ b/wiki/public/js/wiki.js
@@ -1,3 +1,5 @@
+const __ = globalThis.__;
+
 function add_link_to_headings() {
   $(".from-markdown")
     .not(".revision-content")
@@ -215,7 +217,7 @@ window.Wiki = class Wiki {
     const lastUpdatedDate = frappe.datetime.prettyDate(
       $(".user-contributions").data("date"),
     );
-    $(".user-contributions").append(`last updated ${lastUpdatedDate}`);
+    $(".user-contributions").append(`${__("last updated")} ${lastUpdatedDate}`);
   }
 
   set_darkmode_button() {

--- a/wiki/search.py
+++ b/wiki/search.py
@@ -5,6 +5,7 @@
 import json
 
 import frappe
+from frappe import _
 from frappe.utils import cstr
 from redis.commands.search.field import TagField, TextField
 from redis.commands.search.query import Query
@@ -87,9 +88,9 @@ class Search:
 
 		out = frappe._dict(docs=[], total=result.total, duration=result.duration)
 		for doc in result.docs:
-			id = doc.id.split(":", 1)[1]
+			doc_id = doc.id.split(":", 1)[1]
 			_doc = frappe._dict(doc.__dict__)
-			_doc.id = id
+			_doc.id = doc_id
 			_doc.payload = json.loads(doc.payload) if doc.payload else None
 			out.docs.append(_doc)
 		return out
@@ -99,7 +100,7 @@ class Search:
 
 	def drop_index(self):
 		if self.index_exists():
-			print(f"Dropping index {self.index_name}")
+			print(_("Dropping index {0}").format(self.index_name))
 			self.redis.ft(self.index_name).dropindex(delete_documents=True)
 
 	def index_exists(self):

--- a/wiki/wiki/doctype/wiki_page/search.py
+++ b/wiki/wiki/doctype/wiki_page/search.py
@@ -3,6 +3,7 @@
 
 
 import frappe
+from frappe import _
 from frappe.utils import strip_html_tags, update_progress_bar
 from frappe.utils.redis_wrapper import RedisWrapper
 
@@ -122,7 +123,7 @@ def create_index_for_records(records, space):
 	r = frappe.cache()
 	for i, d in enumerate(records):
 		if not hasattr(frappe.local, "request") and len(records) > 10:
-			update_progress_bar(f"Indexing Wiki Pages - {space}", i, len(records), absolute=True)
+			update_progress_bar(_("Indexing Wiki Pages - {0}").format(space), i, len(records), absolute=True)
 
 		key = r.make_key(f"{PREFIX}{space}:{d.name}").decode()
 		mapping = {
@@ -188,7 +189,7 @@ def build_index_in_background():
 	if frappe.cache().get_value(INDEX_BUILD_FLAG):
 		return
 
-	print(f"Queued rebuilding of search index for {frappe.local.site}")
+	print(_("Queued rebuilding of search index for {0}").format(frappe.local.site))
 	frappe.enqueue(build_index, queue="long")
 
 

--- a/wiki/wiki/doctype/wiki_page/templates/comment.html
+++ b/wiki/wiki/doctype/wiki_page/templates/comment.html
@@ -6,7 +6,7 @@
 		<div class="timeline-item activity-toggle">
 			<div class="timeline-dot"></div>
 			<div class="timeline-content flex align-center">
-				<h4>Activity</h4>
+				<h4>{{ _("Activity") }}</h4>
 			</div>
 		</div>
 		<div class="timeline-items">

--- a/wiki/wiki/doctype/wiki_page/templates/editor.html
+++ b/wiki/wiki/doctype/wiki_page/templates/editor.html
@@ -1,21 +1,21 @@
 <div class="wiki-edit-control-btn">
   <button id="toggle-btn" class="btn btn-secondary btn-sm text-sm">
-    Preview
+    {{ _("Preview") }}
   </button>
   <div class="wiki-edit-control-btn flex">
     <div class="btn btn-secondary discard-edit-btn btn-sm" data-new="false">
-      Discard
+      {{ _("Discard") }}
     </div>
     <div class="btn-group">
       <div type="button" class="btn btn-group btn-primary save-wiki-page-btn btn-sm" data-wiki-button="saveWikiPage">
-        Save
+        {{ _("Save") }}
       </div>
       <div type="button" class="btn btn-primary btn-sm dropdown-toggle dropdown-toggle-split" data-toggle="dropdown"
         aria-haspopup="true" aria-expanded="false">
-        <span class="sr-only">Toggle Dropdown</span>
+        <span class="sr-only">{{ _("Toggle Dropdown") }}</span>
       </div>
       <div class="dropdown-menu" aria-labelledby="saveDropdownMenuButton">
-        <a href="#" class="dropdown-item text-sm" data-wiki-button="draftWikiPage">Draft</a>
+        <a href="#" class="dropdown-item text-sm" data-wiki-button="draftWikiPage">{{ _("Draft") }}</a>
       </div>
     </div>
   </div>
@@ -23,24 +23,24 @@
 
 <div id="preview-container" class="markdown-preview"></div>
 <div id="outdated-draft-warning" class="alert alert-warning text-sm mb-5">
-    This page has been updated since your last edit. Your draft may contain outdated content.
-    <span role="button" tabindex="0" class="load-latest-version-btn ml-1 text-sm font-weight-bold">Load Latest Version</span>
+    {{ _("This page has been updated since your last edit. Your draft may contain outdated content.") }}
+    <span role="button" tabindex="0" class="load-latest-version-btn ml-1 text-sm font-weight-bold">{{ _("Load Latest Version") }}</span>
 </div>
 <div class="wiki-editor-container">
   <div class="wiki-title-container">
-    <label class="text-sm">Title</label>
-    <input type="text" class="form-control wiki-title-input" value="" placeholder="What's the Wiki Title?" />
+    <label class="text-sm">{{ _("Title") }}</label>
+    <input type="text" class="form-control wiki-title-input" value="" placeholder="{{ _('What is the Wiki Title?') }}" />
   </div>
-  <label class="text-sm">Content</label>
+  <label class="text-sm">{{ _("Content") }}</label>
   <div class="editor-container">
     <div class="toolbar">
-      <button data-mde-button="bold" title="Bold">
+      <button data-mde-button="bold" title="{{ _('Bold') }}">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
           stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-bold">
           <path d="M6 12h9a4 4 0 0 1 0 8H7a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1h7a4 4 0 0 1 0 8" />
         </svg>
       </button>
-      <button data-mde-button="italic" title="Italic">
+      <button data-mde-button="italic" title="{{ _('Italic') }}">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
           stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-italic">
           <line x1="19" x2="10" y1="4" y2="4" />
@@ -48,7 +48,7 @@
           <line x1="15" x2="9" y1="4" y2="20" />
         </svg>
       </button>
-      <button data-mde-button="heading" title="Heading">
+      <button data-mde-button="heading" title="{{ _('Heading') }}">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
           stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-heading">
           <path d="M6 12h12" />
@@ -56,7 +56,7 @@
           <path d="M18 20V4" />
         </svg>
       </button>
-      <button data-mde-button="quote" title="Quote">
+      <button data-mde-button="quote" title="{{ _('Quote') }}">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
           stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-quote">
           <path
@@ -65,7 +65,7 @@
             d="M5 3a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2 1 1 0 0 1 1 1v1a2 2 0 0 1-2 2 1 1 0 0 0-1 1v2a1 1 0 0 0 1 1 6 6 0 0 0 6-6V5a2 2 0 0 0-2-2z" />
         </svg>
       </button>
-      <button data-mde-button="olist" title="Ordered List">
+      <button data-mde-button="olist" title="{{ _('Ordered List') }}">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
           stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-ordered">
           <path d="M10 12h11" />
@@ -76,7 +76,7 @@
           <path d="M6 18H4c0-1 2-2 2-3s-1-1.5-2-1" />
         </svg>
       </button>
-      <button data-mde-button="ulist" title="Unordered List">
+      <button data-mde-button="ulist" title="{{ _('Unordered List') }}">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
           stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list">
           <path d="M3 12h.01" />
@@ -87,14 +87,14 @@
           <path d="M8 6h13" />
         </svg>
       </button>
-      <button data-mde-button="link" title="Link">
+      <button data-mde-button="link" title="{{ _('Link') }}">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
           stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-link">
           <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
           <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
         </svg>
       </button>
-      <button data-mde-button="image" title="Image">
+      <button data-mde-button="image" title="{{ _('Image') }}">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
           stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-image">
           <rect width="18" height="18" x="3" y="3" rx="2" ry="2" />
@@ -102,14 +102,14 @@
           <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21" />
         </svg>
       </button>
-      <button data-mde-button="video" title="video">
+      <button data-mde-button="video" title="{{ _('video') }}">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
           stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-video">
           <path d="m16 13 5.223 3.482a.5.5 0 0 0 .777-.416V7.87a.5.5 0 0 0-.752-.432L16 10.5" />
           <rect x="2" y="6" width="14" height="12" rx="2" />
         </svg>
       </button>
-      <button data-mde-button="table" title="Table">
+      <button data-mde-button="table" title="{{ _('Table') }}">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
           stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-table">
           <path d="M12 3v18" />
@@ -118,7 +118,7 @@
           <path d="M3 15h18" />
         </svg>
       </button>
-      <button data-mde-button="disclosure" title="Disclosure">
+      <button data-mde-button="disclosure" title="{{ _('Disclosure') }}">
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
           stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
           class="lucide lucide-list-collapse">

--- a/wiki/wiki/doctype/wiki_page/templates/editor.html
+++ b/wiki/wiki/doctype/wiki_page/templates/editor.html
@@ -102,7 +102,7 @@
           <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21" />
         </svg>
       </button>
-      <button data-mde-button="video" title="{{ _('video') }}">
+      <button data-mde-button="video" title="{{ _('Video') }}">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
           stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-video">
           <path d="m16 13 5.223 3.482a.5.5 0 0 0 .777-.416V7.87a.5.5 0 0 0-.752-.432L16 10.5" />

--- a/wiki/wiki/doctype/wiki_page/templates/feedback.html
+++ b/wiki/wiki/doctype/wiki_page/templates/feedback.html
@@ -2,13 +2,13 @@
     <div class="modal-dialog feedback-modal modal-dialog-centered" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="feedbackRating">Feedback</h5>
+                <h5 class="modal-title" id="feedbackRating">{{ _("Feedback") }}</h5>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close" style="outline: none;">
                     <span aria-hidden="true">&times;</span>
                 </button>
             </div>
             <div class="modal-body">
-                <label for="rating-options" class="text-muted text-xs">How would you rate this page?</label>
+                <label for="rating-options" class="text-muted text-xs">{{ _("How would you rate this page?") }}</label>
                 <div id="rating-options" class="rating-options mb-2">
                     <div class="rating-options-buttons" style="grid-template-columns: repeat(5, minmax(0px, 1fr));">
                         <button class="ratings-number question-2-rating-1 auto-text-color" type="submit" value="0.2">
@@ -28,17 +28,18 @@
                         </button>
                     </div>
                 </div>
-                <label for="long-feedback" class="text-muted text-xs">How can we make it better?</label>
+                <label for="long-feedback" class="text-muted text-xs">{{ _("How can we make it better?") }}</label>
                 <textarea id="long-feedback" class="long-feedback form-control mb-2"></textarea>
                 {%- if ask_for_contact_details -%}
-                <label for="email" class="text-muted text-xs">Enter your email if you would like to contribute to the
-                    docs</label>
+                <label for="email" class="text-muted text-xs">
+                    {{ _("Enter your email if you would like to contribute to the docs") }}
+                </label>
                 <input class="feedback-email" type="email" id="email" name="email">
                 {%- endif -%}
             </div>
             <div class="modal-footer">
                 <button class="submit-feedback-btn disabled btn btn-primary btn-sm" type="button" data-dismiss="modal">
-                    Submit
+                    {{ _("Submit") }}
                 </button>
             </div>
         </div>

--- a/wiki/wiki/doctype/wiki_page/templates/navbar_search.html
+++ b/wiki/wiki/doctype/wiki_page/templates/navbar_search.html
@@ -10,7 +10,7 @@
           <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
         </svg>
       </div>
-      <span class="text-muted">Search</span>
+      <span class="text-muted">{{ _("Search") }}</span>
       <kbd>/</kbd>
     </button>
   </div>

--- a/wiki/wiki/doctype/wiki_page/templates/page_settings.html
+++ b/wiki/wiki/doctype/wiki_page/templates/page_settings.html
@@ -3,7 +3,7 @@
     <div class="modal-dialog modal-dialog-centered" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title page-settings-title">Page Settings</h5>
+                <h5 class="modal-title page-settings-title">{{ _("Page Settings") }}</h5>
                 <button type="button" class="d-block d-sm-none close" data-dismiss="modal" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                 </button>
@@ -11,9 +11,9 @@
             <div class="modal-body">
                 <div class="form-group">
                     <div>
-                        <label class="text-muted text-xs" for="pageRoute">Route</label>
+                        <label class="text-muted text-xs" for="pageRoute">{{ _("Route") }}</label>
                         <div class="flex align-items-center">
-                            <div class="text-sm wiki-space-route-block" title="Wiki Space route (can't be modified)">
+                            <div class="text-sm wiki-space-route-block" title="{{ _("Wiki Space route (can't be modified)") }}">
                                 {{ route.split('/')[0] }}/
                             </div>
                             <input value="{{ '/'.join(route.split('/')[1:]) }}" type="text" id="pageRoute"
@@ -25,7 +25,7 @@
                         <input type="checkbox" id="pageHideOnSidebar" {{ 'checked' if bool(hide_on_sidebar) else '' }}
                             name="pageHideOnSidebar">
                         <label class="text-muted text-xs" for="pageHideOnSidebar" class="mt-2">
-                            Hide on Sidebar
+                            {{ _("Hide on Sidebar") }}
                         </label>
                     </div>
                 </div>
@@ -33,7 +33,7 @@
             <div class="modal-footer">
                 <button type="button" data-modal-button="update"
                     class="btn btn-primary btn-sm update-page-settings-button">
-                    Update
+                    {{ _("Update") }}
                 </button>
             </div>
         </div>

--- a/wiki/wiki/doctype/wiki_page/templates/revisions.html
+++ b/wiki/wiki/doctype/wiki_page/templates/revisions.html
@@ -3,11 +3,11 @@
     <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <div class="d-flex flex-column">
+                <div class="d-flex flex-column flex-grow-1">
                     <h5 class="modal-title revision-title" id="revisionsModalTitle">{{ title }}</h5>
                     <span class="small text-muted revision-time">{{ current_revision.raised_by_username or
                         current_revision.raised_by or
-                        current_revision.owner }} edited {{
+                        current_revision.owner }} {{ _("edited") }} {{
                         frappe.utils.pretty_date(current_revision.creation) }}</span>
                 </div>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
@@ -21,9 +21,9 @@
             </div>
             <div class="modal-footer d-flex justify-content-between">
                 <button type="button" data-modal-button="previous"
-                    class="previous-revision btn btn-secondary btn-sm hide">Previous</button>
+                    class="previous-revision btn btn-secondary btn-sm hide">{{ _("Previous") }}</button>
                 <button type="button" data-modal-button="next"
-                    class="next-revision btn btn-secondary btn-sm hide">Next</button>
+                    class="next-revision btn btn-secondary btn-sm hide">{{ _("Next") }}</button>
             </div>
         </div>
     </div>

--- a/wiki/wiki/doctype/wiki_page/templates/show.html
+++ b/wiki/wiki/doctype/wiki_page/templates/show.html
@@ -2,11 +2,11 @@
 	<div class="alert alert-warning admin-banner {% if not (is_admin and pending_patches_count)%}hide{% endif %}"
 		role="alert">
 		<div class="d-flex justify-content-between align-items-center">
-			<div>This space has
-				<strong id="pending-patches-count">{{ pending_patches_count }}</strong> change(s) pending for
-				review.
+			<div>{{ _("This space has") }}
+				<strong id="pending-patches-count">{{ pending_patches_count }}</strong>
+				{{ _("change(s) pending for review.") }}
 			</div>
-			<button class="btn btn-sm btn-warning review-changes-btn">Review changes</button>
+			<button class="btn btn-sm btn-warning review-changes-btn">{{ _("Review changes") }}</button>
 		</div>
 	</div>
 	<div class="d-flex justify-content-between align-items-center">
@@ -27,14 +27,14 @@
 	<div class="modal-dialog modal-dialog-centered" role="document">
 		<div class="modal-content">
 			<div class="modal-header">
-				<h5 class="modal-title" id="addGroupModalTitle">Title</h5>
+				<h5 class="modal-title" id="addGroupModalTitle">{{ _("Title") }}</h5>
 			</div>
 			<div class="modal-body">
-				<span class="text-muted text-xs">Enter title for the new Wiki Group</span>
+				<span class="text-muted text-xs">{{ _("Enter title for the new Wiki Group") }}</span>
 				<input type="text" id="title" name="title">
 			</div>
 			<div class="modal-footer">
-				<button class="add-group-btn btn btn-primary btn-sm" type="button" data-dismiss="modal">Submit</button>
+				<button class="add-group-btn btn btn-primary btn-sm" type="button" data-dismiss="modal">{{ _("Submit") }}</button>
 			</div>
 		</div>
 	</div>
@@ -43,8 +43,8 @@
 <div class="flex my-4 wiki-page-meta d-print-none">
 	{%- if show_feedback -%}
 	<div class="flex">
-		<span class="text-sm d-none d-sm-block">Was this article helpful?</span>
-		<span class="text-sm ml-2 feedback-btn" data-toggle="modal" data-target="#feedbackModal">Give Feedback</span>
+		<span class="text-sm d-none d-sm-block">{{ _("Was this article helpful?") }}</span>
+		<span class="text-sm ml-2 feedback-btn" data-toggle="modal" data-target="#feedbackModal">{{ _("Give Feedback") }}</span>
 	</div>
 	{% include "wiki/doctype/wiki_page/templates/feedback.html" %}
 	{%- endif -%}
@@ -66,13 +66,13 @@
 			</svg>
 		</div>
 		<div class="dropdown-menu d-print-none" aria-labelledby="wikiOptionsButton">
-			<a class="dropdown-item edit-wiki-btn" href="#">Edit Page</a>
-			<a class="dropdown-item add-wiki-btn" href="#">New Page</a>
+			<a class="dropdown-item edit-wiki-btn" href="#">{{ _("Edit Page") }}</a>
+			<a class="dropdown-item add-wiki-btn" href="#">{{ _("New Page") }}</a>
 			<a class="dropdown-item show-revisions" href="#" data-toggle="modal" data-target="#revisionsModal">
-				Revisions
+				{{ _("Revisions") }}
 			</a>
 			<a class="dropdown-item show-page-settings" href="#" data-toggle="modal" data-target="#pageSettingsModal">
-				Page Settings
+				{{ _("Page Settings") }}
 			</a>
 		</div>
 	</div>
@@ -81,12 +81,12 @@
 <div class="wiki-footer d-print-none">
 	<div class="forward-back">
 		<a href="#" class="btn left footer-prev-page-link">
-			<p>Previous Page</p>
-			<p class="footer-prev-page">Left</p>
+			<p> {{ _("Previous Page") }} </p>
+			<p class="footer-prev-page">{{ _("Left") }}</p>
 		</a>
 		<a href="#" class="btn pull-right right footer-next-page-link">
-			<p>Next Page</p>
-			<p class="footer-next-page">Right</p>
+			<p>{{ _("Next Page") }}</p>
+			<p class="footer-next-page">{{ _("Right") }}</p>
 		</a>
 		</a>
 	</div>

--- a/wiki/wiki/doctype/wiki_page/templates/web_sidebar.html
+++ b/wiki/wiki/doctype/wiki_page/templates/web_sidebar.html
@@ -22,7 +22,7 @@ sidebar_items | len > 0 -%}
       </svg>
       <span class="sidebar-group-title">{{ sidebar_group }}</span>
       <span class="add-sidebar-page hide" data-group-name="{{ sidebar_group }}" data-toggle="tooltip"
-        data-placement="top" title="{{ __('New Wiki Page in the group') }} {{ sidebar_group }}">
+        data-placement="top" title="{{ _('New Wiki Page in the group') }} {{ sidebar_group }}">
         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="20" viewBox="0 0 24 24" fill="none"
           stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
           class="feather feather-plus">
@@ -40,7 +40,7 @@ sidebar_items | len > 0 -%}
 </ul>
 <div class="d-none d-lg-block sidebar-options">
   <div class="sidebar-edit-mode-btn text-muted" data-toggle="tooltip" data-placement="top"
-    title="{{ __('Changes to sidebar will be automatically saved') }}">
+    title="{{ _('Changes to sidebar will be automatically saved') }}">
     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
       stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-edit-3">
       <path d="M12 20h9"></path>

--- a/wiki/wiki/doctype/wiki_page/templates/web_sidebar.html
+++ b/wiki/wiki/doctype/wiki_page/templates/web_sidebar.html
@@ -22,7 +22,7 @@ sidebar_items | len > 0 -%}
       </svg>
       <span class="sidebar-group-title">{{ sidebar_group }}</span>
       <span class="add-sidebar-page hide" data-group-name="{{ sidebar_group }}" data-toggle="tooltip"
-        data-placement="top" title="__('New Wiki Page in the group') {{ sidebar_group }}">
+        data-placement="top" title="{{ __('New Wiki Page in the group') }} {{ sidebar_group }}">
         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="20" viewBox="0 0 24 24" fill="none"
           stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
           class="feather feather-plus">
@@ -40,7 +40,7 @@ sidebar_items | len > 0 -%}
 </ul>
 <div class="d-none d-lg-block sidebar-options">
   <div class="sidebar-edit-mode-btn text-muted" data-toggle="tooltip" data-placement="top"
-    title="__('Changes to sidebar will be automatically saved')">
+    title="{{ __('Changes to sidebar will be automatically saved') }}">
     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
       stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-edit-3">
       <path d="M12 20h9"></path>

--- a/wiki/wiki/doctype/wiki_page/templates/web_sidebar.html
+++ b/wiki/wiki/doctype/wiki_page/templates/web_sidebar.html
@@ -22,7 +22,7 @@ sidebar_items | len > 0 -%}
       </svg>
       <span class="sidebar-group-title">{{ sidebar_group }}</span>
       <span class="add-sidebar-page hide" data-group-name="{{ sidebar_group }}" data-toggle="tooltip"
-        data-placement="top" title="New Wiki Page in the group {{ sidebar_group }}">
+        data-placement="top" title="__('New Wiki Page in the group') {{ sidebar_group }}">
         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="20" viewBox="0 0 24 24" fill="none"
           stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
           class="feather feather-plus">
@@ -40,13 +40,13 @@ sidebar_items | len > 0 -%}
 </ul>
 <div class="d-none d-lg-block sidebar-options">
   <div class="sidebar-edit-mode-btn text-muted" data-toggle="tooltip" data-placement="top"
-    title="Changes to sidebar will be automatically saved">
+    title="__('Changes to sidebar will be automatically saved')">
     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
       stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-edit-3">
       <path d="M12 20h9"></path>
       <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"></path>
     </svg>
-    <span class="small">Edit Sidebar</span>
+    <span class="small">{{ _("Edit Sidebar") }}</span>
   </div>
   <div class="add-sidebar-group text-muted hide">
     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
@@ -54,7 +54,7 @@ sidebar_items | len > 0 -%}
       <line x1="12" y1="5" x2="12" y2="19"></line>
       <line x1="5" y1="12" x2="19" y2="12"></line>
     </svg>
-    <span class="small">Add Group</span>
+    <span class="small">{{ _("Add Group") }}</span>
   </div>
   <div class="sidebar-view-mode-btn text-muted hide">
     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
@@ -62,7 +62,7 @@ sidebar_items | len > 0 -%}
       <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
       <line x1="9" y1="3" x2="9" y2="21"></line>
     </svg>
-    <span class="small">View Sidebar</span>
+    <span class="small">{{ _("View Sidebar") }}</span>
   </div>
 </div>
 {%- endif -%} {% endmacro %} {% macro my_account() %}

--- a/wiki/wiki/doctype/wiki_page/templates/wiki_doc.html
+++ b/wiki/wiki/doctype/wiki_page/templates/wiki_doc.html
@@ -24,7 +24,7 @@ id="page-{{ name or route | e }}" data-path="{{ pathname | e }}"
 		<div class="modal-content review-patch-modal">
 			<div class="modal-header">
 				<div class="d-flex flex-column">
-					<h5 class="modal-title" id="patchDiffModalTitle">Review Changes</h5>
+					<h5 class="modal-title" id="patchDiffModalTitle">{{ _("Review Changes") }}</h5>
 					<span class="small text-muted patch-info"></span>
 				</div>
 				<div>
@@ -33,8 +33,8 @@ id="page-{{ name or route | e }}" data-path="{{ pathname | e }}"
 					</button>
 					<div class="view-toggle-buttons-wrapper">
 						<div class="view-toggle-buttons">
-							<button type="button" class="btn btn-sm view-raw active">View Raw</button>
-							<button type="button" class="btn btn-sm view-preview">View Preview</button>
+							<button type="button" class="btn btn-sm view-raw active">{{ _("View Raw") }}</button>
+							<button type="button" class="btn btn-sm view-preview">{{ _("View Preview") }}</button>
 						</div>
 					</div>
 				</div>
@@ -44,8 +44,8 @@ id="page-{{ name or route | e }}" data-path="{{ pathname | e }}"
 				<div class="preview-content markdown"></div>
 			</div>
 			<div class="modal-footer review-modal-footer">
-				<button type="button" class="btn approve-patch">Approve</button>
-				<button type="button" class="btn reject-patch">Reject</button>
+				<button type="button" class="btn approve-patch">{{ _("Approve") }}</button>
+				<button type="button" class="btn reject-patch">{{ _("Reject") }}</button>
 			</div>
 		</div>
 	</div>
@@ -74,7 +74,7 @@ id="page-{{ name or route | e }}" data-path="{{ pathname | e }}"
 	{% if page_toc_html %}
 	<div class="page-toc d-none d-xl-block">
 		{% if page_toc_html %}
-		<p class="page-toc-title">On this page</p>
+		<p class="page-toc-title">{{ _("On this page") }}</p>
 		<div class='list-unstyled'>
 			<ul>
 				{{ page_toc_html }}
@@ -87,8 +87,8 @@ id="page-{{ name or route | e }}" data-path="{{ pathname | e }}"
 
 	<div class="contributions-view d-none">
 		<div class="d-flex justify-content-between align-items-center mb-4">
-			<span class="page-title">Review Changes</span>
-			<a class="back-to-content">← Back to Content</a>
+			<span class="page-title">{{ _("Review Changes") }}</span>
+			<a class="back-to-content">{{ _("← Back to Content") }}</a>
 		</div>
 		<input class="d-none" type="text" autocomplete="off" name="limit" value="0">
 		<div class="frappe-card">
@@ -97,11 +97,11 @@ id="page-{{ name or route | e }}" data-path="{{ pathname | e }}"
 					<table class="table">
 						<thead class="white">
 							<tr>
-								<td class="message-col">{{ _("Message") }}</td>
-								<td class="status-col">{{ _("Status") }}</td>
-								<td class="space-col">{{ _("Space") }}</td>
-								<td class="raised-by-col">{{ _("Raised By") }}</td>
-								<td class="date-col">{{ _("Last update on") }}</td>
+								<th class="message-col">{{ _("Message") }}</th>
+								<th class="status-col">{{ _("Status") }}</th>
+								<th class="space-col">{{ _("Space") }}</th>
+								<th class="raised-by-col">{{ _("Raised By") }}</th>
+								<th class="date-col">{{ _("Last update on") }}</th>
 							</tr>
 						</thead>
 						<tbody></tbody>
@@ -110,7 +110,7 @@ id="page-{{ name or route | e }}" data-path="{{ pathname | e }}"
 			</div>
 		</div>
 		<div class="pagination-container">
-			<button class="btn pull-right get_patches d-none">Load More</button>
+			<button class="btn pull-right get_patches d-none">{{ _("Load More") }}</button>
 		</div>
 		<br>
 		<br>
@@ -144,7 +144,7 @@ id="page-{{ name or route | e }}" data-path="{{ pathname | e }}"
 							$('#patchDiffModal').modal('show');
 							$('.diff-content').html(r.message.diff);
 							$('.preview-content').html(r.message.merged_html);
-							$('.patch-info').html(`<b>${r.message.raised_by}</b> submitted changes <b>${r.message.raised_on}</b>`);
+							$('.patch-info').html(`<b>${r.message.raised_by}</b> {{ _("submitted changes") }} <b>${r.message.raised_on}</b>`);
 						}
 					}
 				});
@@ -294,7 +294,7 @@ id="page-{{ name or route | e }}" data-path="{{ pathname | e }}"
 							$('#patchDiffModal').modal('show');
 							$('.diff-content').html(r.message.diff);
 							$('.preview-content').html(r.message.merged_html);
-							$('.patch-info').html(`<b>${r.message.raised_by}</b> submitted changes <b>${r.message.raised_on}</b>`);
+							$('.patch-info').html(`<b>${r.message.raised_by}</b> {{ _("submitted changes") }} <b>${r.message.raised_on}</b>`);
 						}
 					}
 				});

--- a/wiki/wiki/doctype/wiki_page/templates/wiki_navbar.html
+++ b/wiki/wiki/doctype/wiki_page/templates/wiki_navbar.html
@@ -1,6 +1,6 @@
 <nav class="wiki-navbar navbar navbar-light navbar-expand-lg sticky-top pr-4">
   <div class="navbar-brand-container">
-    <a class="navbar-brand" alt="Go to home page" data-prefix="{{ url_prefix }}"
+    <a class="navbar-brand" alt="__('Go to home page')" data-prefix="{{ url_prefix }}"
       href="{{ url_prefix or "" }}{{ home_page or " /" }}">
       {%- if light_mode_logo -%}
       <img alt="Logo" data-alt-src="{{ dark_mode_logo }}" src='{{ light_mode_logo }}'>
@@ -72,7 +72,7 @@
             <path d="m21 21-4.3-4.3"></path>
           </svg>
         </div>
-        <input id="searchInput" type="search" class="form-control" placeholder="Search" />
+        <input id="searchInput" type="search" class="form-control" placeholder="{{ _('Search') }}" />
       </div>
       <div class="modal-body">
         <div class="overflow-hidden search-dropdown-menu w-100" aria-labelledby="dropdownMenuSearch"></div>

--- a/wiki/wiki/doctype/wiki_page/templates/wiki_navbar.html
+++ b/wiki/wiki/doctype/wiki_page/templates/wiki_navbar.html
@@ -1,11 +1,11 @@
 <nav class="wiki-navbar navbar navbar-light navbar-expand-lg sticky-top pr-4">
   <div class="navbar-brand-container">
-    <a class="navbar-brand" alt="__('Go to home page')" data-prefix="{{ url_prefix }}"
+    <a class="navbar-brand" alt="{{ _('Go to home page') }}" data-prefix="{{ url_prefix }}"
       href="{{ url_prefix or "" }}{{ home_page or " /" }}">
       {%- if light_mode_logo -%}
-      <img alt="Logo" data-alt-src="{{ dark_mode_logo }}" src='{{ light_mode_logo }}'>
+      <img alt="{{ _('Logo') }}" data-alt-src="{{ dark_mode_logo }}" src='{{ light_mode_logo }}'>
       {%- elif dark_mode_logo -%}
-      <img alt="Logo" data-alt-src="{{ light_mode_logo }}" src='{{ dark_mode_logo }}'>
+      <img alt="{{ _('Logo') }}" data-alt-src="{{ light_mode_logo }}" src='{{ dark_mode_logo }}'>
       {%- elif brand_html -%}
       {{ brand_html }}
       {%- else -%}

--- a/wiki/wiki/doctype/wiki_page/wiki_page.py
+++ b/wiki/wiki/doctype/wiki_page/wiki_page.py
@@ -41,7 +41,7 @@ class WikiPage(WebsiteGenerator):
 		revision = frappe.new_doc("Wiki Page Revision")
 		revision.append("wiki_pages", {"wiki_page": self.name})
 		revision.content = self.content
-		revision.message = "Create Wiki Page"
+		revision.message = _("Create Wiki Page")
 		revision.raised_by = frappe.session.user
 		revision.insert()
 
@@ -189,7 +189,9 @@ class WikiPage(WebsiteGenerator):
 		if space := frappe.get_value("Wiki Group Item", {"wiki_page": self.name}, "parent"):
 			return frappe.get_value("Wiki Space", space, "route")
 		else:
-			frappe.throw("Wiki Page doesn't have a Wiki Space associated with it. Please add them via Desk.")
+			frappe.throw(
+				_("Wiki Page doesn't have a Wiki Space associated with it. Please add them via Desk.")
+			)
 
 	def calculate_toc_html(self, html):
 		from bs4 import BeautifulSoup
@@ -306,7 +308,7 @@ class WikiPage(WebsiteGenerator):
 		if len(revisions) > 1:
 			context.previous_revision = revisions[1]
 		else:
-			context.previous_revision = {"content": "<h3>No Revisions</h3>", "name": ""}
+			context.previous_revision = {"content": f"<h3>{_('No Revisions')}</h3>", "name": ""}
 
 		context.show_sidebar = True
 		context.hide_login = True
@@ -324,11 +326,11 @@ class WikiPage(WebsiteGenerator):
 					{"label": _("My Account"), "url": "/me"},
 					{"label": _("Logout"), "url": "/?cmd=web_logout"},
 					{
-						"label": _("Contributions ") + get_open_contributions(),
+						"label": _("Contributions") + get_open_contributions(),
 						"url": "/contributions",
 					},
 					{
-						"label": _("My Drafts ") + get_open_drafts(),
+						"label": _("My Drafts") + get_open_drafts(),
 						"url": "/drafts",
 					},
 				],

--- a/wiki/wiki/doctype/wiki_settings/wiki_settings.js
+++ b/wiki/wiki/doctype/wiki_settings/wiki_settings.js
@@ -5,13 +5,13 @@ frappe.ui.form.on("Wiki Settings", {
   refresh: function (frm) {
     frm.add_web_link("/wiki", __("See on website"));
 
-    frm.add_custom_button("Clear Wiki Page Cache", () => {
+    frm.add_custom_button(__("Clear Wiki Page Cache"), () => {
       frm.call({
         method: "clear_wiki_page_cache",
         callback: (r) => {
           if (r.message) {
             frappe.show_alert({
-              message: "Wiki Page Cache Cleared",
+              message: __("Wiki Page Cache Cleared"),
               indicator: "blue",
             });
           }

--- a/wiki/wiki/doctype/wiki_space/wiki_space.js
+++ b/wiki/wiki/doctype/wiki_space/wiki_space.js
@@ -5,8 +5,8 @@ frappe.ui.form.on("Wiki Space", {
   refresh(frm) {
     frm.add_web_link(`/${frm.doc.route}`, __("See on website"));
 
-    frm.add_custom_button("Clone Wiki Space", () => {
-      frappe.prompt("Enter new Wiki Space's route", ({ value }) => {
+    frm.add_custom_button(__("Clone Wiki Space"), () => {
+      frappe.prompt(__("Enter new Wiki Space's route"), ({ value }) => {
         frm.call("clone_wiki_space_in_background", { new_space_route: value });
       });
     });

--- a/wiki/wiki/doctype/wiki_space/wiki_space.py
+++ b/wiki/wiki/doctype/wiki_space/wiki_space.py
@@ -4,6 +4,7 @@ import json
 
 import frappe
 import pymysql
+from frappe import _
 from frappe.model.document import Document
 
 from wiki.wiki.doctype.wiki_page.search import build_index_in_background, drop_index
@@ -16,10 +17,10 @@ class WikiSpace(Document):
 			wiki_page = frappe.get_doc(
 				{
 					"doctype": "Wiki Page",
-					"title": "New Wiki Page",
+					"title": _("New Wiki Page"),
 					"route": f"{self.route}/new-wiki-page",
 					"published": 1,
-					"content": f"Welcome to Wiki Space {self.route}",
+					"content": _("Welcome to Wiki Space {0}").format(self.route),
 				}
 			)
 			wiki_page.insert()
@@ -47,7 +48,7 @@ class WikiSpace(Document):
 
 			frappe.publish_progress(
 				percent=i * 100 / len(self.wiki_sidebars),
-				title=f"Updating Wiki Page routes - <b>{self.route}</b>",
+				title=_("Updating Wiki Page routes - <b>{0}</b>").format(self.route),
 				description=f"{i}/{len(self.wiki_sidebars)}",
 			)
 
@@ -61,7 +62,7 @@ class WikiSpace(Document):
 					)
 			except Exception as e:
 				if isinstance(e, pymysql.err.IntegrityError):
-					frappe.throw(f"Wiki Page with route <b>{wiki_page.route}</b> already exists.")
+					frappe.throw(_("Wiki Page with route <b>{0}</b> already exists.").format(wiki_page.route))
 				else:
 					raise e
 
@@ -91,7 +92,7 @@ class WikiSpace(Document):
 
 def clone_wiki_space(name, route, new_space_route):
 	if frappe.db.exists("Wiki Space", new_space_route):
-		frappe.throw(f"Wiki Space <b>{new_space_route}</b> already exists.")
+		frappe.throw(_("Wiki Space <b>{0}</b> already exists.").format(new_space_route))
 
 	items = frappe.get_all(
 		"Wiki Group Item",
@@ -106,7 +107,7 @@ def clone_wiki_space(name, route, new_space_route):
 	for idx, item in enumerate(items, 1):
 		frappe.publish_progress(
 			idx * 100 / len(items),
-			title=f"Cloning into new Wiki Space <b>{new_space_route}</b>",
+			title=_("Cloning into new Wiki Space <b>{0}</b>").format(new_space_route),
 			description=f"{idx}/{len(items)}",
 		)
 		cloned_doc = frappe.get_doc("Wiki Page", item.wiki_page).clone(route, new_space_route)

--- a/wiki/wiki/doctype/wiki_space/wiki_space.py
+++ b/wiki/wiki/doctype/wiki_space/wiki_space.py
@@ -29,7 +29,7 @@ class WikiSpace(Document):
 				"wiki_sidebars",
 				{
 					"wiki_page": wiki_page.name,
-					"parent_label": "New Group",
+					"parent_label": _("New Group"),
 				},
 			)
 

--- a/wiki/wiki_search.py
+++ b/wiki/wiki_search.py
@@ -4,6 +4,7 @@
 import re
 
 import frappe
+from frappe import _
 from frappe.utils import cstr, strip_html_tags, update_progress_bar
 from frappe.utils.redis_wrapper import RedisWrapper
 
@@ -39,7 +40,7 @@ class WikiSearch(Search):
 		for i, doc in enumerate(records):
 			self.index_doc(doc)
 			if not hasattr(frappe.local, "request"):
-				update_progress_bar("Indexing Wiki Pages", i, total)
+				update_progress_bar(_("Indexing Wiki Pages"), i, total)
 		if not hasattr(frappe.local, "request"):
 			print()
 

--- a/wiki/wiki_search.py
+++ b/wiki/wiki_search.py
@@ -45,7 +45,6 @@ class WikiSearch(Search):
 			print()
 
 	def index_doc(self, doc):
-		doc_id = f"Wiki Page:{doc.name}"
 		fields = {
 			"title": doc.title,
 			"content": strip_html_tags(doc.content),
@@ -59,12 +58,11 @@ class WikiSearch(Search):
 			"published": doc.published,
 			"allow_guest": doc.allow_guest,
 		}
-		self.add_document(doc_id, fields, payload=payload)
+		self.add_document(f"Wiki Page:{doc.name}", fields, payload=payload)
 
 	def remove_doc(self, doc):
 		if doc.doctype == "Wiki Page":
-			doc_id = f"Wiki Page:{doc.name}"
-			self.remove_document(doc_id)
+			self.remove_document(f"Wiki Page:{doc.name}")
 
 	def clean_query(self, query):
 		query = query.strip().replace("-*", "*")

--- a/wiki/wiki_search.py
+++ b/wiki/wiki_search.py
@@ -44,7 +44,7 @@ class WikiSearch(Search):
 			print()
 
 	def index_doc(self, doc):
-		id = f"Wiki Page:{doc.name}"
+		doc_id = f"Wiki Page:{doc.name}"
 		fields = {
 			"title": doc.title,
 			"content": strip_html_tags(doc.content),
@@ -58,12 +58,12 @@ class WikiSearch(Search):
 			"published": doc.published,
 			"allow_guest": doc.allow_guest,
 		}
-		self.add_document(id, fields, payload=payload)
+		self.add_document(doc_id, fields, payload=payload)
 
 	def remove_doc(self, doc):
 		if doc.doctype == "Wiki Page":
-			id = f"Wiki Page:{doc.name}"
-			self.remove_document(id)
+			doc_id = f"Wiki Page:{doc.name}"
+			self.remove_document(doc_id)
 
 	def clean_query(self, query):
 		query = query.strip().replace("-*", "*")

--- a/wiki/www/contributions.html
+++ b/wiki/www/contributions.html
@@ -42,7 +42,7 @@
 			</table>
 			{% else %}
 			<div class="no-background-jobs">
-				<img src="/assets/frappe/images/ui-states/list-empty-state.svg" alt="Empty State">
+				<img src="/assets/frappe/images/ui-states/list-empty-state.svg" alt="{{ _('Empty State') }}">
 				<p class="text-muted">{{ _("No Contributions Made") }}</p>
 			</div>
 			{% endif %}

--- a/wiki/www/contributions.html
+++ b/wiki/www/contributions.html
@@ -21,20 +21,20 @@
 			<table class="table">
 				<thead class="white">
 					<tr>
-						<td style="width: 20%">{{ _("Status") }}</th>
-						<td style="width: 30%">{{ _("Message") }}</th>
-						<td style="width: 30%">{{ _("Last update on") }}</th>
-						<td style="width: 20%">{{ _("Link") }}</th>
+						<th style="width: 20%">{{ _("Status") }}</th>
+						<th style="width: 30%">{{ _("Message") }}</th>
+						<th style="width: 30%">{{ _("Last update on") }}</th>
+						<th style="width: 20%">{{ _("Link") }}</th>
 					</tr>
 				</thead>
 				<tbody>
 					{% for j in contributions %}
 					<tr>
 						<td class="worker-name"><span class="indicator-pill no-margin {{j.color}}">&nbsp;&nbsp;{{
-								j.status }}</span></td>
+								j.status_label }}</span></td>
 						<td>{{ j.message }}</td>
 						<td>{{ j.modified }}</td>
-						<td> <a class="btn btn-secondary-dark btn-xs center" href="{{ j.edit_link }}">Open Contribution</a>
+						<td><a class="btn btn-default btn-xs center" href="{{ j.edit_link }}">{{ _("Open Contribution") }}</a>
 						</td>
 					</tr>
 					{% endfor %}
@@ -52,7 +52,7 @@
 </div>
 {% if contributions %}
 <br>
-<div> <button class='btn pull-right get_contributions'>More</button></div>
+<div> <button class='btn pull-right get_contributions'>{{ _("More") }}</button></div>
 <br>
 <br>
 
@@ -80,10 +80,10 @@
 					for (contribution of response.message.contributions) {
 						$('.list-jobs tbody').append($(`	<tr>
 						<td class="worker-name"><span class="indicator-pill no-margin ${contribution.color}">&nbsp;&nbsp;
-							${contribution.status}</span></td>
+							${contribution.status_label}</span></td>
 						<td>${contribution.message}</td>
 						<td>${contribution.modified}</td>
-						<td> <a class="btn btn-default btn-xs center" href="${contribution.edit_link}">Open Contribution</a>
+						<td> <a class="btn btn-default btn-xs center" href="${contribution.edit_link}">{{ _("Open Contribution") }}</a>
 						</td>
 					</tr>
 				`))

--- a/wiki/www/contributions.py
+++ b/wiki/www/contributions.py
@@ -4,20 +4,6 @@ from frappe.utils.data import cint
 
 from wiki.wiki.doctype.wiki_page.wiki_page import get_open_drafts
 
-color_map = {
-	"Changes Requested": "blue",
-	"Under Review": "orange",
-	"Rejected": "red",
-	"Approved": "green",
-}
-
-status_label_map = {
-	"Changes Requested": _("Changes Requested"),
-	"Under Review": _("Under Review"),
-	"Rejected": _("Rejected"),
-	"Approved": _("Approved"),
-}
-
 
 def get_context(context) -> dict:
 	context.pilled_title = _("My Contributions")
@@ -46,6 +32,20 @@ def get_contributions(start, limit) -> dict:
 
 
 def get_user_contributions(start, limit) -> list:
+	color_map = {
+		"Changes Requested": "blue",
+		"Under Review": "orange",
+		"Rejected": "red",
+		"Approved": "green",
+	}
+
+	status_label_map = {
+		"Changes Requested": _("Changes Requested"),
+		"Under Review": _("Under Review"),
+		"Rejected": _("Rejected"),
+		"Approved": _("Approved"),
+	}
+
 	contributions = []
 	wiki_page_patches = frappe.get_list(
 		"Wiki Page Patch",

--- a/wiki/www/contributions.py
+++ b/wiki/www/contributions.py
@@ -11,9 +11,16 @@ color_map = {
 	"Approved": "green",
 }
 
+status_label_map = {
+	"Changes Requested": _("Changes Requested"),
+	"Under Review": _("Under Review"),
+	"Rejected": _("Rejected"),
+	"Approved": _("Approved"),
+}
 
-def get_context(context):
-	context.pilled_title = "My Contributions"
+
+def get_context(context) -> dict:
+	context.pilled_title = _("My Contributions")
 	context.no_cache = 1
 	context.no_sidebar = 1
 	context.contributions = get_user_contributions(0, 10)
@@ -34,11 +41,11 @@ def get_context(context):
 
 
 @frappe.whitelist()
-def get_contributions(start, limit):
+def get_contributions(start, limit) -> dict:
 	return {"contributions": get_user_contributions(start, limit)}
 
 
-def get_user_contributions(start, limit):
+def get_user_contributions(start, limit) -> list:
 	contributions = []
 	wiki_page_patches = frappe.get_list(
 		"Wiki Page Patch",
@@ -52,6 +59,7 @@ def get_user_contributions(start, limit):
 		route = frappe.db.get_value("Wiki Page", wiki_page_patch.wiki_page, "route")
 		wiki_page_patch.edit_link = f"/{route}?editWiki=1&wikiPagePatch={wiki_page_patch.name}"
 		wiki_page_patch.color = color_map[wiki_page_patch.status]
+		wiki_page_patch.status_label = status_label_map.get(wiki_page_patch.status, wiki_page_patch.status)
 		wiki_page_patch.modified = frappe.utils.pretty_date(wiki_page_patch.modified)
 		contributions.extend([wiki_page_patch])
 

--- a/wiki/www/contributions.py
+++ b/wiki/www/contributions.py
@@ -10,7 +10,7 @@ def get_context(context) -> dict:
 	context.no_cache = 1
 	context.no_sidebar = 1
 	context.contributions = get_user_contributions(0, 10)
-	context = context.update(
+	context.update(
 		{
 			"post_login": [
 				{"label": _("My Account"), "url": "/me"},

--- a/wiki/www/drafts.html
+++ b/wiki/www/drafts.html
@@ -22,10 +22,10 @@
 				<table class="table">
 					<thead class="">
 						<tr>
-							<td style="width: 20%">{{ _("Status") }}</th>
-							<td style="width: 30%">{{ _("Message") }}</th>
-							<td style="width: 30%">{{ _("Last update on") }}</th>
-							<td style="width: 20%">{{ _("Link") }}</th>
+							<th style="width: 20%">{{ _("Status") }}</th>
+							<th style="width: 30%">{{ _("Message") }}</th>
+							<th style="width: 30%">{{ _("Last update on") }}</th>
+							<th style="width: 20%">{{ _("Link") }}</th>
 						</tr>
 					</thead>
 					<tbody>
@@ -35,7 +35,7 @@
 									j.status }}</span></td>
 							<td>{{ j.message }}</td>
 							<td>{{ j.modified }}</td>
-							<td> <a class="btn btn-default btn-xs center" href="{{ j.edit_link }}">Open Draft</a>
+							<td> <a class="btn btn-default btn-xs center" href="{{ j.edit_link }}">{{ _("Open Draft") }}</a>
 							</td>
 						</tr>
 						{% endfor %}
@@ -53,7 +53,7 @@
 	</div>
 	{% if contributions %}
 	<br>
-	<div> <button class='btn pull-right get_contributions'>More</button></div>
+	<div> <button class='btn pull-right get_contributions'>{{ _("More") }}</button></div>
 	<br>
 	<br>
 </div>
@@ -85,7 +85,7 @@
 								${contribution.status}</span></td>
 							<td>${contribution.message}</td>
 							<td>${contribution.modified}</td>
-							<td> <a class="btn btn-default btn-xs center" href="${contribution.edit_link}">Open Draft</a>
+							<td> <a class="btn btn-default btn-xs center" href="${contribution.edit_link}">${__("Open Draft")}</a>
 							</td>
 						</tr>
 

--- a/wiki/www/drafts.html
+++ b/wiki/www/drafts.html
@@ -32,7 +32,7 @@
 						{% for j in contributions %}
 						<tr>
 							<td><span class="indicator-pill no-margin {{j.color}}">&nbsp;&nbsp;{{
-									j.status }}</span></td>
+									j.status_label }}</span></td>
 							<td>{{ j.message }}</td>
 							<td>{{ j.modified }}</td>
 							<td> <a class="btn btn-default btn-xs center" href="{{ j.edit_link }}">{{ _("Open Draft") }}</a>
@@ -43,7 +43,7 @@
 				</table>
 				{% else %}
 				<div class="no-background-jobs">
-					<img src="/assets/frappe/images/ui-states/list-empty-state.svg" alt="Empty State">
+					<img src="/assets/frappe/images/ui-states/list-empty-state.svg" alt="{{ _('Empty State') }}">
 					<p class="text-muted">{{ _("No Drafts Made") }}</p>
 				</div>
 				{% endif %}

--- a/wiki/www/drafts.py
+++ b/wiki/www/drafts.py
@@ -50,6 +50,7 @@ def get_user_drafts(start, limit):
 		else:
 			wiki_page_patch.edit_link = f"/{route}?editWiki=1&wikiPagePatch={wiki_page_patch.name}"
 		wiki_page_patch.color = "orange"
+		wiki_page_patch.status_label = _("Draft")
 		wiki_page_patch.modified = frappe.utils.pretty_date(wiki_page_patch.modified)
 		drafts.extend([wiki_page_patch])
 

--- a/wiki/www/drafts.py
+++ b/wiki/www/drafts.py
@@ -6,7 +6,7 @@ from wiki.wiki.doctype.wiki_page.wiki_page import get_open_contributions
 
 
 def get_context(context):
-	context.pilled_title = "My Drafts"
+	context.pilled_title = _("My Drafts")
 	context.no_cache = 1
 	context.no_sidebar = 1
 	context.contributions = get_user_drafts(0, 10)
@@ -16,7 +16,7 @@ def get_context(context):
 				{"label": _("My Account"), "url": "/me"},
 				{"label": _("Logout"), "url": "/?cmd=web_logout"},
 				{
-					"label": _("My Contributions ") + get_open_contributions(),
+					"label": _("My Contributions") + get_open_contributions(),
 					"url": "/contributions",
 				},
 			]


### PR DESCRIPTION
This PR sets up the necessary logic to make the Wiki frontend translatable. Since Version 3 is still in development, these changes ensure that UI strings are properly wrapped and prepared for localization.

I have integrated some work previously done by @NagariaHussain in [this commit](https://github.com/frappe/wiki/pull/431/changes/8539bcfff6cd52b82d7acd23eeba2fba90abb477)

Quick demo using pt-BR .po file:

https://github.com/user-attachments/assets/80a46cf5-58c6-498e-81d5-d68aaa71c920



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime translation loader, a translations API, and per-visitor language detection with sensible fallbacks.

* **Style**
  * Extensive localization of UI labels, placeholders, prompts, messages and templates across the wiki.
  * Improved semantic table markup and refined button and empty‑state labels.

* **Refactor**
  * Minor backend and content-flow adjustments to support translations and improve contribution/draft label handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->