### PR TITLE
fix: add markdown serialization to link extension for proper persistence

### DIFF
--- a/e2e/tests/link-persistence.spec.ts
+++ b/e2e/tests/link-persistence.spec.ts
@@ -1,0 +1,208 @@
+import { expect, test } from '@playwright/test';
+import { getDoc } from '../helpers/frappe';
+
+interface WikiDocument {
+	name: string;
+	title: string;
+	content: string;
+	route: string;
+}
+
+test.describe('Link Persistence Tests', () => {
+	test('should save links as markdown to the database', async ({
+		page,
+		request,
+	}) => {
+		// Navigate to wiki and click first space
+		await page.goto('/wiki');
+		await page.waitForLoadState('networkidle');
+
+		const spaceLink = page.locator('a[href*="/wiki/spaces/"]').first();
+		await expect(spaceLink).toBeVisible({ timeout: 5000 });
+		await spaceLink.click();
+		await page.waitForLoadState('networkidle');
+
+		// Create a new page
+		const createFirstPage = page.locator(
+			'button:has-text("Create First Page")',
+		);
+		const newPageButton = page.locator('button[title="New Page"]');
+
+		const pageTitle = `Link Save Test ${Date.now()}`;
+
+		if (await createFirstPage.isVisible({ timeout: 2000 }).catch(() => false)) {
+			await createFirstPage.click();
+		} else {
+			await newPageButton.click();
+		}
+
+		await page.getByLabel('Title').fill(pageTitle);
+		await page
+			.getByRole('dialog')
+			.getByRole('button', { name: 'Create' })
+			.click();
+		await page.waitForLoadState('networkidle');
+
+		const editor = page.locator('.ProseMirror, [contenteditable="true"]');
+		await expect(editor).toBeVisible({ timeout: 10000 });
+
+		// Clear and type content
+		await editor.click();
+		await page.keyboard.press('Meta+a');
+		await page.keyboard.type('Visit ');
+		await page.keyboard.type('Example Website');
+
+		// Wait for text to be fully inserted
+		await page.waitForTimeout(500);
+
+		// Select "Example Website" text
+		await page.keyboard.press('End');
+		for (let i = 0; i < 'Example Website'.length; i++) {
+			await page.keyboard.press('Shift+ArrowLeft');
+		}
+		await page.waitForTimeout(300);
+
+		// Use toolbar button to add link
+		await page.click('button[title="Insert Link"]');
+
+		// Wait for link popup input
+		const linkInput = page.getByPlaceholder('https://example.com');
+		await expect(linkInput).toBeVisible({ timeout: 5000 });
+		await linkInput.fill('https://example.com');
+		await page.click('button[title="Submit"]');
+		await page.waitForTimeout(500);
+
+		// Verify link is visible in editor before save
+		const editorLink = editor.locator('a[href="https://example.com"]');
+		await expect(editorLink).toBeVisible({ timeout: 5000 });
+		await expect(editorLink).toHaveText('Example Website');
+
+		// Save the page
+		const saveButton = page.locator('button:has-text("Save")');
+		await saveButton.click();
+		await page.waitForLoadState('networkidle');
+		await page.waitForTimeout(3000); // Wait for DB commit
+
+		// Get the page ID from URL to verify content via API
+		// URL format: /wiki/spaces/{spaceId}/page/{pageId}
+		const url = page.url();
+		const pageIdMatch = url.match(/\/wiki\/spaces\/[^/]+\/page\/([^/?#]+)/);
+		expect(pageIdMatch).toBeTruthy();
+		const pageId = decodeURIComponent(pageIdMatch?.[1] ?? '');
+
+		// Verify content was saved correctly via API - links should be in markdown format
+		const savedDoc = await getDoc<WikiDocument>(
+			request,
+			'Wiki Document',
+			pageId,
+		);
+		expect(savedDoc.content).toContain(
+			'[Example Website](https://example.com)',
+		);
+	});
+
+	test('should display links on published page view', async ({ page }) => {
+		// Navigate to wiki and click first space
+		await page.goto('/wiki');
+		await page.waitForLoadState('networkidle');
+
+		const spaceLink = page.locator('a[href*="/wiki/spaces/"]').first();
+		await expect(spaceLink).toBeVisible({ timeout: 5000 });
+		await spaceLink.click();
+		await page.waitForLoadState('networkidle');
+
+		// Create a new page
+		const createFirstPage = page.locator(
+			'button:has-text("Create First Page")',
+		);
+		const newPageButton = page.locator('button[title="New Page"]');
+
+		const pageTitle = `Publish Links Test ${Date.now()}`;
+
+		if (await createFirstPage.isVisible({ timeout: 2000 }).catch(() => false)) {
+			await createFirstPage.click();
+		} else {
+			await newPageButton.click();
+		}
+
+		await page.getByLabel('Title').fill(pageTitle);
+		await page
+			.getByRole('dialog')
+			.getByRole('button', { name: 'Create' })
+			.click();
+		await page.waitForLoadState('networkidle');
+
+		const editor = page.locator('.ProseMirror, [contenteditable="true"]');
+		await expect(editor).toBeVisible({ timeout: 10000 });
+
+		// Add content with link
+		await editor.click();
+		await page.keyboard.press('Meta+a');
+		await page.keyboard.type('Click here to visit ');
+		await page.keyboard.type('Frappe');
+
+		await page.waitForTimeout(500);
+
+		// Select "Frappe"
+		await page.keyboard.press('End');
+		for (let i = 0; i < 'Frappe'.length; i++) {
+			await page.keyboard.press('Shift+ArrowLeft');
+		}
+		await page.waitForTimeout(300);
+
+		// Add link
+		await page.click('button[title="Insert Link"]');
+		const linkInput = page.getByPlaceholder('https://example.com');
+		await expect(linkInput).toBeVisible({ timeout: 5000 });
+		await linkInput.fill('https://frappe.io');
+		await page.click('button[title="Submit"]');
+		await page.waitForTimeout(500);
+
+		// Verify link was created
+		const editorLink = editor.locator('a[href="https://frappe.io"]');
+		await expect(editorLink).toBeVisible({ timeout: 5000 });
+
+		// Save
+		await page.click('button:has-text("Save")');
+		await page.waitForLoadState('networkidle');
+		await page.waitForTimeout(3000);
+
+		// Publish via dropdown
+		await page
+			.locator(
+				'button:has-text("Save") ~ button, button:has-text("Save") + * button',
+			)
+			.first()
+			.click();
+
+		await page.waitForSelector('[role="menuitem"]', {
+			state: 'visible',
+			timeout: 5000,
+		});
+		await page.getByRole('menuitem', { name: 'Publish' }).click();
+		await page.waitForLoadState('networkidle');
+
+		// Wait for Published badge
+		await expect(page.locator('text=Published').first()).toBeVisible({
+			timeout: 10000,
+		});
+
+		// Open View Page in new tab
+		const viewPageButton = page.locator('button:has-text("View Page")');
+		await expect(viewPageButton).toBeVisible({ timeout: 5000 });
+
+		const [newPage] = await Promise.all([
+			page.context().waitForEvent('page'),
+			viewPageButton.click(),
+		]);
+
+		await newPage.waitForLoadState('networkidle');
+
+		// Verify link is visible on public page - this was the user's reported issue
+		const publicLink = newPage.locator('a[href="https://frappe.io"]');
+		await expect(publicLink).toBeVisible({ timeout: 10000 });
+		await expect(publicLink).toHaveText('Frappe');
+
+		await newPage.close();
+	});
+});

--- a/frontend/src/components/tiptap-extensions/link-extension.js
+++ b/frontend/src/components/tiptap-extensions/link-extension.js
@@ -16,6 +16,14 @@ export const WikiLink = Mark.create({
 		return this.options.autolink;
 	},
 
+	// TipTap v3 Markdown extension support
+	// Renders link marks to markdown format: [text](url)
+	renderMarkdown(node, helpers) {
+		const href = node.attrs?.href || '';
+		const content = helpers.renderChildren();
+		return `[${content}](${href})`;
+	},
+
 	addOptions() {
 		return {
 			openOnClick: false,


### PR DESCRIPTION
## Summary
- Fixed issue where links added in the editor were not appearing on the published page view
- The WikiLink extension was missing the `renderMarkdown` method required by TipTap v3's Markdown extension, causing links to be silently dropped during markdown serialization
- Added E2E tests to verify link persistence in saved content and published page view

## Test plan
- [x] Run `yarn test:e2e e2e/tests/link-persistence.spec.ts` - all tests pass
- [x] Verify links are saved as markdown format `[text](url)` in the database
- [x] Verify links appear correctly on published page view

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Link rendering improved so wiki links are exported/represented in Markdown format ([text](url)).

* **Tests**
  * Added end-to-end tests for link persistence, verifying links are saved as Markdown and displayed correctly in both editor and published page views.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->