### PR TITLE
fix: add parseMarkdown for link round-trip support

### DIFF
--- a/frontend/src/components/tiptap-extensions/link-extension.js
+++ b/frontend/src/components/tiptap-extensions/link-extension.js
@@ -17,10 +17,29 @@ export const WikiLink = Mark.create({
 	},
 
 	// TipTap v3 Markdown extension support
+	// Register as handler for 'link' tokens from marked.js
+	markdownTokenName: 'link',
+
+	// Parse markdown link tokens into link marks
+	// Token format: { type: 'link', href: '...', title: '...', tokens: [...] }
+	parseMarkdown(token, helpers) {
+		// Parse the link's child tokens (the link text)
+		const content = helpers.parseInline(token.tokens || []);
+		// Return a mark result that wraps content with the link mark
+		return helpers.applyMark('link', content, {
+			href: token.href || null,
+		});
+	},
+
 	// Renders link marks to markdown format: [text](url)
+	// Guards against empty href to avoid outputting invalid markdown like [text]()
 	renderMarkdown(node, helpers) {
 		const href = node.attrs?.href || '';
 		const content = helpers.renderChildren();
+		// If no href, just return the content without link formatting
+		if (!href) {
+			return content;
+		}
 		return `[${content}](${href})`;
 	},
 


### PR DESCRIPTION
## Summary
- Fixed issue where links were lost on Markdown→editor→Markdown round-trips
- The WikiLink extension was missing `parseMarkdown` and `markdownTokenName`, so when parsing markdown, link tokens from marked.js had no registered handler
- Added empty href guard to prevent outputting invalid markdown like `[text]()`

## Changes
- Added `markdownTokenName: 'link'` to register as handler for link tokens
- Added `parseMarkdown(token, helpers)` to properly parse link tokens and apply the link mark with href attribute  
- Updated `renderMarkdown` to guard against empty href - returns just the content text instead of `[text]()`

## Test plan
- [x] Run `yarn test:e2e e2e/tests/link-persistence.spec.ts` - all tests pass
- [x] Verify links saved as markdown are properly parsed back when loading content

🤖 Generated with [Claude Code](https://claude.ai/code)