### PR TITLE
fix: links not working in UI Editor #481

### DIFF
--- a/frontend/src/components/tiptap-extensions/link-extension.js
+++ b/frontend/src/components/tiptap-extensions/link-extension.js
@@ -45,7 +45,6 @@ export const WikiLink = Mark.create({
 
 	addOptions() {
 		return {
-			openOnClick: true,
 			autolink: true,
 			linkOnPaste: true,
 			HTMLAttributes: {
@@ -201,19 +200,25 @@ export const WikiLink = Mark.create({
 						const linkMark = marks.find((m) => m.type.name === 'link');
 
 						if (linkMark?.attrs.href) {
+							// Helper function for secure programmatic link opening
+							const openSecurely = (url) => {
+								const newWindow = window.open(url, '_blank', 'noopener,noreferrer');
+								if (newWindow) newWindow.opener = null;
+							};
+
 							// If the editor is NOT editable (Read Only/View Mode), let the link work normally
 							if (!view.editable) {
-								window.open(linkMark.attrs.href, '_blank');
+								openSecurely(linkMark.attrs.href);
 								return true;
 							}
 							// If in Edit Mode, only open if Cmd/Ctrl is held down
 							if (event.metaKey || event.ctrlKey) {
-								window.open(linkMark.attrs.href, '_blank');
+								openSecurely(linkMark.attrs.href);
 								return true;
 							}
 						}
 						return false;
-					},
+					}
 				},
 			}),
 		);

--- a/frontend/src/components/tiptap-extensions/link-extension.js
+++ b/frontend/src/components/tiptap-extensions/link-extension.js
@@ -45,7 +45,7 @@ export const WikiLink = Mark.create({
 
 	addOptions() {
 		return {
-			openOnClick: false,
+			openOnClick: true,
 			autolink: true,
 			linkOnPaste: true,
 			HTMLAttributes: {
@@ -91,92 +91,92 @@ export const WikiLink = Mark.create({
 		return {
 			setLink:
 				(attributes) =>
-				({ chain }) => {
-					return chain()
-						.setMark(this.name, attributes)
-						.setMeta('preventAutolink', true)
-						.run();
-				},
+					({ chain }) => {
+						return chain()
+							.setMark(this.name, attributes)
+							.setMeta('preventAutolink', true)
+							.run();
+					},
 
 			toggleLink:
 				(attributes) =>
-				({ chain }) => {
-					return chain()
-						.toggleMark(this.name, attributes, { extendEmptyMarkRange: true })
-						.setMeta('preventAutolink', true)
-						.run();
-				},
+					({ chain }) => {
+						return chain()
+							.toggleMark(this.name, attributes, { extendEmptyMarkRange: true })
+							.setMeta('preventAutolink', true)
+							.run();
+					},
 
 			unsetLink:
 				() =>
-				({ chain }) => {
-					return chain()
-						.unsetMark(this.name, { extendEmptyMarkRange: true })
-						.setMeta('preventAutolink', true)
-						.run();
-				},
+					({ chain }) => {
+						return chain()
+							.unsetMark(this.name, { extendEmptyMarkRange: true })
+							.setMeta('preventAutolink', true)
+							.run();
+					},
 
 			openLinkEditor:
 				() =>
-				({ editor, state }) => {
-					const { from, to, empty } = state.selection;
-					const linkMark = editor.isActive('link');
+					({ editor, state }) => {
+						const { from, to, empty } = state.selection;
+						const linkMark = editor.isActive('link');
 
-					// If no text is selected and not in a link, do nothing
-					if (empty && !linkMark) {
-						return false;
-					}
+						// If no text is selected and not in a link, do nothing
+						if (empty && !linkMark) {
+							return false;
+						}
 
-					// Get the link mark range if cursor is within a link
-					let linkRange = null;
-					let currentHref = '';
+						// Get the link mark range if cursor is within a link
+						let linkRange = null;
+						let currentHref = '';
 
-					if (linkMark) {
-						const $pos = state.doc.resolve(from);
-						const markType = state.schema.marks.link;
-						const range = getMarkRange($pos, markType);
+						if (linkMark) {
+							const $pos = state.doc.resolve(from);
+							const markType = state.schema.marks.link;
+							const range = getMarkRange($pos, markType);
 
-						if (range) {
-							linkRange = range;
-							// Get the current href
-							const marks = $pos.marks();
-							const linkMarkInstance = marks.find(
-								(m) => m.type.name === 'link',
-							);
-							if (linkMarkInstance) {
-								currentHref = linkMarkInstance.attrs.href || '';
+							if (range) {
+								linkRange = range;
+								// Get the current href
+								const marks = $pos.marks();
+								const linkMarkInstance = marks.find(
+									(m) => m.type.name === 'link',
+								);
+								if (linkMarkInstance) {
+									currentHref = linkMarkInstance.attrs.href || '';
+								}
 							}
 						}
-					}
 
-					// Select the link text if we found a range
-					if (linkRange) {
-						editor.chain().setTextSelection(linkRange).run();
-					}
+						// Select the link text if we found a range
+						if (linkRange) {
+							editor.chain().setTextSelection(linkRange).run();
+						}
 
-					// Call the callback to show the popup
-					if (this.options.onOpenLinkEditor) {
-						// Use requestAnimationFrame to ensure selection is complete
-						requestAnimationFrame(() => {
-							const selection = window.getSelection();
-							if (selection && selection.rangeCount > 0) {
-								const range = selection.getRangeAt(0);
-								const rect = range.getBoundingClientRect();
+						// Call the callback to show the popup
+						if (this.options.onOpenLinkEditor) {
+							// Use requestAnimationFrame to ensure selection is complete
+							requestAnimationFrame(() => {
+								const selection = window.getSelection();
+								if (selection && selection.rangeCount > 0) {
+									const range = selection.getRangeAt(0);
+									const rect = range.getBoundingClientRect();
 
-								this.options.onOpenLinkEditor({
-									editor,
-									href: currentHref,
-									isNew: !linkMark,
-									rect,
-									from: linkRange?.from ?? from,
-									to: linkRange?.to ?? to,
-								});
-							}
-						});
-					}
+									this.options.onOpenLinkEditor({
+										editor,
+										href: currentHref,
+										isNew: !linkMark,
+										rect,
+										from: linkRange?.from ?? from,
+										to: linkRange?.to ?? to,
+									});
+								}
+							});
+						}
 
-					return true;
-				},
+						return true;
+					},
 		};
 	},
 
@@ -195,19 +195,23 @@ export const WikiLink = Mark.create({
 				key: new PluginKey('wikiLinkClick'),
 				props: {
 					handleClick: (view, pos, event) => {
-						// Cmd/Ctrl + Click opens link in new tab
-						if (event.metaKey || event.ctrlKey) {
-							const { state } = view;
-							const $pos = state.doc.resolve(pos);
-							const marks = $pos.marks();
-							const linkMark = marks.find((m) => m.type.name === 'link');
+						const { state } = view;
+						const $pos = state.doc.resolve(pos);
+						const marks = $pos.marks();
+						const linkMark = marks.find((m) => m.type.name === 'link');
 
-							if (linkMark?.attrs.href) {
+						if (linkMark?.attrs.href) {
+							// If the editor is NOT editable (Read Only/View Mode), let the link work normally
+							if (!view.editable) {
+								window.open(linkMark.attrs.href, '_blank');
+								return true;
+							}
+							// If in Edit Mode, only open if Cmd/Ctrl is held down
+							if (event.metaKey || event.ctrlKey) {
 								window.open(linkMark.attrs.href, '_blank');
 								return true;
 							}
 						}
-
 						return false;
 					},
 				},

--- a/wiki/public/css/main.css
+++ b/wiki/public/css/main.css
@@ -409,10 +409,11 @@
   font-weight: 600;
 }
 
-/* Ensure links in the Wiki Editor are visible and blue */
+/* Ensure links in the Wiki Editor are recognizable across themes */
 .wiki-editor-content a {
-  color: var(--ink-blue-3);
+  color: inherit;
   text-decoration: underline;
   text-underline-offset: 2px;
   cursor: pointer;
 }
+

--- a/wiki/public/css/main.css
+++ b/wiki/public/css/main.css
@@ -411,7 +411,8 @@
 
 /* Ensure links in the Wiki Editor are visible and blue */
 .wiki-editor-content a {
-  color: #3b82f6 !important;
-  text-decoration: underline !important;
-  cursor: pointer !important;
+  color: var(--ink-blue-3);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
 }

--- a/wiki/public/css/main.css
+++ b/wiki/public/css/main.css
@@ -119,7 +119,7 @@
 }
 
 /* Inline code styling */
-.prose :not(pre) > code {
+.prose :not(pre)>code {
   background-color: var(--surface-gray-2);
   color: var(--ink-gray-9);
   padding: 0.125rem 0.375rem;
@@ -128,8 +128,8 @@
   font-weight: 500;
 }
 
-.prose :not(pre) > code::before,
-.prose :not(pre) > code::after {
+.prose :not(pre)>code::before,
+.prose :not(pre)>code::after {
   content: none;
 }
 
@@ -270,11 +270,11 @@
   color: var(--ink-gray-7);
 }
 
-.callout-content > *:first-child {
+.callout-content>*:first-child {
   margin-top: 0;
 }
 
-.callout-content > *:last-child {
+.callout-content>*:last-child {
   margin-bottom: 0;
 }
 
@@ -383,7 +383,7 @@
   margin-bottom: 0;
 }
 
-.prose img + em {
+.prose img+em {
   display: block;
   margin-top: 0.25rem;
   font-size: 0.875rem;
@@ -409,3 +409,9 @@
   font-weight: 600;
 }
 
+/* Ensure links in the Wiki Editor are visible and blue */
+.wiki-editor-content a {
+  color: #3b82f6 !important;
+  text-decoration: underline !important;
+  cursor: pointer !important;
+}


### PR DESCRIPTION
### Problem
Users reported that links created using the UI Editor toolbar were non-functional in the Wiki Document view. This was caused by the custom Tiptap extension explicitly disabling clicks and failing to distinguish between 'Editor' and 'Viewer' states.

### Changes
- Updated `link-extension.js` to allow standard clicks when the editor is in `read-only` mode (`!view.editable`).
- Modified `WikiLink` configuration to set `openOnClick: true`.
- Added CSS to `main.css` to ensure links inside `.wiki-editor-content` have visible blue coloring and underlining, preventing "invisible" text in dark mode.

### Verification
- [x] Links are clickable in Published/Preview mode.
- [x] Links are visible (blue) even when not highlighted.
- [x] Editor remains functional (Cmd+Click still works to open links while editing).

Fixes #481

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Links clicked in read-only view now open automatically in a new tab.
  * In edit mode, opening links requires holding Cmd/Ctrl.

* **Bug Fixes**
  * Click handling refined for consistent navigation across read-only and edit modes.
  * Link editor flow reorganized for more reliable selection and editor opening.

* **Style**
  * Wiki editor links now inherit color, are underlined with an offset, and show a pointer for improved discoverability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->