### PR TITLE
fix: misc fixes

### DIFF
--- a/frontend/src/components/WikiDocumentList.vue
+++ b/frontend/src/components/WikiDocumentList.vue
@@ -298,10 +298,8 @@ async function applyReorder(payload) {
 		payload.newParent,
 		siblingKeys,
 	);
-	for (const sibling of payload.siblings || []) {
-		if (sibling && !sibling._changeType) {
-			sibling._changeType = 'reordered';
-		}
+	if (payload?.item && !payload.item._changeType) {
+		payload.item._changeType = 'reordered';
 	}
 	toast.success(__('Documents reordered'));
 	await loadChanges();

--- a/wiki/frappe_wiki/doctype/wiki_change_request/wiki_change_request.py
+++ b/wiki/frappe_wiki/doctype/wiki_change_request/wiki_change_request.py
@@ -1215,7 +1215,6 @@ def apply_merge_revision(space: Document, revision: Document) -> None:
 			content = frappe.get_value("Wiki Content Blob", content_blob, "content")
 			doc.content = content
 
-		doc.route = None
 		if doc.is_new():
 			doc.insert()
 			key_to_name[doc_key] = doc.name


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Wiki document routes/permalinks remain stable during change request merges and when documents are reordered, preserving existing links.
  * UI reordering correctly recognizes the moved item to ensure consistent reorder behavior.

* **Tests**
  * Added tests verifying route stability across merges and reorder operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->