### PR TITLE
fix: reset editor state when switching between wiki pages

### DIFF
--- a/frontend/src/components/WikiDocumentPanel.vue
+++ b/frontend/src/components/WikiDocumentPanel.vue
@@ -116,6 +116,7 @@ onMounted(async () => {
 
 watch(() => props.pageId, async (newPageId) => {
 	if (newPageId) {
+		currentCrPage.value = null;
 		wikiDoc.name = newPageId;
 		wikiDoc.reload();
 	}
@@ -176,12 +177,7 @@ const isSaving = computed(() => {
 	return updatePageResource.loading;
 });
 
-const editorKey = computed(() => {
-	if (wikiDoc.doc?.name === props.pageId) {
-		return props.pageId;
-	}
-	return null;
-});
+const editorKey = computed(() => props.pageId);
 
 const menuOptions = computed(() => {
 		return [


### PR DESCRIPTION
### Description
This PR resolves issue #489 where the Wiki editor would hold onto "stale" content (unsaved text or draft state) when a user navigated between different pages using the sidebar.

### The Problem
The `WikiDocumentPanel` component was not fully resetting its internal state when the `pageId` changed. Specifically, the `currentCrPage` resource remained populated with the previous page's data, and the `WikiEditor` component was not being re-rendered because its `:key` logic was too restrictive. This caused content from one page to "bleed" into the next.

### Key Changes
- Updated the `watch` on `pageId` to explicitly clear `currentCrPage.value`.
- Simplified the `editorKey` computed property to return `props.pageId` directly. This forces Vue to destroy and recreate the editor component on every page switch, ensuring a clean state.

### Automated Tests
- Verified via manual testing (see attached recordings in the issue) that typing unsaved text on "Page A" and then clicking "Page B" now correctly results in a fresh, empty editor for "Page B" rather than showing "Page A's" text.

Closes #489

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reset draft/state when switching wiki pages to avoid showing stale content.
  * Ensure the editor reloads when changing pages so the correct document is displayed and interactions remain consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->