### PR TITLE
fix: content out-of-sync while switching between pages

### DIFF
--- a/frontend/src/components/WikiDocumentPanel.vue
+++ b/frontend/src/components/WikiDocumentPanel.vue
@@ -177,7 +177,7 @@ const isSaving = computed(() => {
 });
 
 const editorKey = computed(() => {
-	if (wikiDoc.doc?.name === props.pageId) {
+	if (wikiDoc.doc?.name === props.pageId && !crPageResource.loading) {
 		return props.pageId;
 	}
 	return null;


### PR DESCRIPTION
## Before:
While switching between pages from the sidebar, old content shows up even after switching the page

https://github.com/user-attachments/assets/e0d8f331-18cd-4f0b-97f5-756cfa5d210b

## After:
Happened due to race condition between `editorContent` computed property & fetching current changed page. The property used to return `currentCrPage.value?.content` before the request to fetch currentCrPage completed

https://github.com/user-attachments/assets/a53b498c-f19b-4f72-8822-a5d827236b29


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Wiki editor now initializes only after the change-request page resources are fully loaded, ensuring more reliable editor operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->