### PR TITLE
fix: clone wiki space for v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,18 @@ on:
     branches:
       - develop
       - main
-      - wiki-v3
+      - version-3
+    paths-ignore:
+      - '**.js'
+      - '**.vue'
+      - '**.css'
+      - '**.ts'
   pull_request:
+    paths-ignore:
+      - '**.js'
+      - '**.vue'
+      - '**.css'
+      - '**.ts'
 
 concurrency:
   group: develop-wiki-${{ github.event.number }}

--- a/frontend/src/components/WikiEditor.vue
+++ b/frontend/src/components/WikiEditor.vue
@@ -22,42 +22,50 @@
 </template>
 
 <script setup>
-import { ref, onMounted, onUnmounted, createApp, h } from 'vue';
-import { onKeyStroke } from '@vueuse/core';
-import { Editor, EditorContent } from '@tiptap/vue-3';
-import { StarterKit } from '@tiptap/starter-kit';
-import { Markdown } from '@tiptap/markdown';
-import { Table, TableRow, TableCell, TableHeader } from '@tiptap/extension-table';
-import { TaskList, TaskItem } from '@tiptap/extension-list';
-import { Placeholder } from '@tiptap/extensions';
 import { CodeBlockLowlight } from '@tiptap/extension-code-block-lowlight';
+import { TaskItem, TaskList } from '@tiptap/extension-list';
+import {
+	Table,
+	TableCell,
+	TableHeader,
+	TableRow,
+} from '@tiptap/extension-table';
+import { Placeholder } from '@tiptap/extensions';
+import { Markdown } from '@tiptap/markdown';
+import { StarterKit } from '@tiptap/starter-kit';
+import { Editor, EditorContent } from '@tiptap/vue-3';
+import { onKeyStroke } from '@vueuse/core';
+import { toast, useFileUpload } from 'frappe-ui';
 import { common, createLowlight } from 'lowlight';
-import { useFileUpload, toast } from 'frappe-ui';
+import { createApp, h, onMounted, onUnmounted, ref } from 'vue';
 
-// Import custom extensions
-import { CalloutBlock } from './tiptap-extensions/callout-block.js';
-import { VideoBlock } from './tiptap-extensions/video-block.js';
-import { WikiLink } from './tiptap-extensions/link-extension.js';
-import { WikiImage } from './tiptap-extensions/image-extension.js';
-import { SlashCommands, filterCommands } from './tiptap-extensions/slash-commands.js';
+import LinkPopup from './tiptap-extensions/LinkPopup.vue';
 import SlashCommandsList from './tiptap-extensions/SlashCommandsList.vue';
 import WikiBubbleMenu from './tiptap-extensions/WikiBubbleMenu.vue';
 import WikiToolbar from './tiptap-extensions/WikiToolbar.vue';
-import LinkPopup from './tiptap-extensions/LinkPopup.vue';
+// Import custom extensions
+import { CalloutBlock } from './tiptap-extensions/callout-block.js';
+import { WikiImage } from './tiptap-extensions/image-extension.js';
+import { WikiLink } from './tiptap-extensions/link-extension.js';
+import {
+	SlashCommands,
+	filterCommands,
+} from './tiptap-extensions/slash-commands.js';
+import { VideoBlock } from './tiptap-extensions/video-block.js';
 
 // Import tippy for slash command popup
 import tippy from 'tippy.js';
 import 'tippy.js/dist/tippy.css';
 
 const props = defineProps({
-    content: {
-        type: String,
-        default: '',
-    },
-    saving: {
-        type: Boolean,
-        default: false,
-    },
+	content: {
+		type: String,
+		default: '',
+	},
+	saving: {
+		type: Boolean,
+		default: false,
+	},
 });
 
 const emit = defineEmits(['save']);
@@ -85,458 +93,471 @@ let linkPopupApp = null;
  * Upload file to Frappe and return the file URL
  */
 async function uploadFile(file) {
-    try {
-        const isImage = file.type.includes('image');
-        const result = await fileUploader.upload(file, {
-            private: false,
-            optimize: isImage,
-        });
+	try {
+		const isImage = file.type.includes('image');
+		const result = await fileUploader.upload(file, {
+			private: false,
+			optimize: isImage,
+		});
 
-        toast.success(`${isImage ? 'Image' : 'File'} uploaded successfully`);
-        return result.file_url;
-    } catch (error) {
-        toast.error('Failed to upload file');
-        throw error;
-    }
+		toast.success(`${isImage ? 'Image' : 'File'} uploaded successfully`);
+		return result.file_url;
+	} catch (error) {
+		toast.error('Failed to upload file');
+		throw error;
+	}
 }
 
 /**
  * Handle paste events to upload images
  */
 function handlePaste(_view, event) {
-    const items = event.clipboardData?.items;
-    if (!items) return false;
+	const items = event.clipboardData?.items;
+	if (!items) return false;
 
-    for (const item of items) {
-        if (item.type.indexOf('image') === 0) {
-            event.preventDefault();
-            const file = item.getAsFile();
-            if (file) {
-                uploadFile(file).then((url) => {
-                    if (editor.value) {
-                        editor.value.chain().focus().setImage({ src: url }).run();
-                    }
-                });
-            }
-            return true;
-        }
-    }
-    return false;
+	for (const item of items) {
+		if (item.type.indexOf('image') === 0) {
+			event.preventDefault();
+			const file = item.getAsFile();
+			if (file) {
+				uploadFile(file).then((url) => {
+					if (editor.value) {
+						editor.value.chain().focus().setImage({ src: url }).run();
+					}
+				});
+			}
+			return true;
+		}
+	}
+	return false;
 }
 
 /**
  * Handle drop events to upload files
  */
 function handleDrop(_view, event) {
-    const files = event.dataTransfer?.files;
-    if (!files || files.length === 0) return false;
+	const files = event.dataTransfer?.files;
+	if (!files || files.length === 0) return false;
 
-    event.preventDefault();
+	event.preventDefault();
 
-    for (const file of files) {
-        const isImage = file.type.includes('image');
-        const isVideo = file.type.includes('video');
+	for (const file of files) {
+		const isImage = file.type.includes('image');
+		const isVideo = file.type.includes('video');
 
-        if (isImage || isVideo) {
-            uploadFile(file).then((url) => {
-                if (editor.value) {
-                    if (isVideo) {
-                        editor.value.chain().focus().setVideo({ src: url }).run();
-                    } else {
-                        editor.value.chain().focus().setImage({ src: url }).run();
-                    }
-                }
-            });
-        }
-    }
+		if (isImage) {
+			uploadFile(file).then((url) => {
+				if (editor.value) {
+					editor.value.chain().focus().setImage({ src: url }).run();
+				}
+			});
+		} else if (isVideo && editor.value) {
+			editor.value.commands.uploadVideo(file);
+		}
+	}
 
-    return true;
+	return true;
 }
 
 /**
  * Handle image upload from toolbar
  */
 async function handleImageUpload(file) {
-    try {
-        const url = await uploadFile(file);
-        if (editor.value) {
-            editor.value.chain().focus().setImage({ src: url }).run();
-        }
-    } catch (error) {
-        console.error('Failed to upload image:', error);
-    }
+	try {
+		const url = await uploadFile(file);
+		if (editor.value) {
+			editor.value.chain().focus().setImage({ src: url }).run();
+		}
+	} catch (error) {
+		console.error('Failed to upload image:', error);
+	}
 }
 
 /**
  * Handle image upload from slash command
  */
 function handleSlashImageSelect(event) {
-    const file = event.target.files?.[0];
-    if (file) {
-        handleImageUpload(file);
-    }
-    // Reset input so same file can be selected again
-    event.target.value = '';
+	const file = event.target.files?.[0];
+	if (file) {
+		handleImageUpload(file);
+	}
+	// Reset input so same file can be selected again
+	event.target.value = '';
 }
 
 /**
  * Handle slash command image upload event
  */
 function handleSlashImageUploadEvent() {
-    slashImageInput.value?.click();
+	slashImageInput.value?.click();
 }
 
 /**
  * Show link popup at the given position
  */
 function showLinkPopup({ editor: editorInstance, href, isNew, rect }) {
-    // Destroy existing popup if any
-    hideLinkPopup();
+	// Destroy existing popup if any
+	hideLinkPopup();
 
-    // Create container for the popup
-    const container = document.createElement('div');
+	// Create container for the popup
+	const container = document.createElement('div');
 
-    // Create Vue app for LinkPopup
-    linkPopupApp = createApp({
-        render() {
-            return h(LinkPopup, {
-                href: href || '',
-                isNew,
-                onSave: (newHref) => {
-                    editorInstance.chain().focus().setLink({ href: newHref }).run();
-                    hideLinkPopup();
-                },
-                onRemove: () => {
-                    editorInstance.chain().focus().unsetLink().run();
-                    hideLinkPopup();
-                },
-                onCancel: () => {
-                    hideLinkPopup();
-                },
-            });
-        },
-    });
-    linkPopupApp.mount(container);
+	// Create Vue app for LinkPopup
+	linkPopupApp = createApp({
+		render() {
+			return h(LinkPopup, {
+				href: href || '',
+				isNew,
+				onSave: (newHref) => {
+					editorInstance.chain().focus().setLink({ href: newHref }).run();
+					hideLinkPopup();
+				},
+				onRemove: () => {
+					editorInstance.chain().focus().unsetLink().run();
+					hideLinkPopup();
+				},
+				onCancel: () => {
+					hideLinkPopup();
+				},
+			});
+		},
+	});
+	linkPopupApp.mount(container);
 
-    // Create tippy popup
-    linkPopupInstance = tippy(document.body, {
-        getReferenceClientRect: () => rect,
-        appendTo: () => document.body,
-        content: container,
-        showOnCreate: true,
-        interactive: true,
-        trigger: 'manual',
-        placement: 'bottom-start',
-        maxWidth: 'none',
-        theme: 'none',
-        arrow: false,
-        offset: [0, 8],
-        onHide: () => {
-            // Cleanup when tippy hides
-            if (linkPopupApp) {
-                linkPopupApp.unmount();
-                linkPopupApp = null;
-            }
-        },
-    })[0];
+	// Create tippy popup
+	linkPopupInstance = tippy(document.body, {
+		getReferenceClientRect: () => rect,
+		appendTo: () => document.body,
+		content: container,
+		showOnCreate: true,
+		interactive: true,
+		trigger: 'manual',
+		placement: 'bottom-start',
+		maxWidth: 'none',
+		theme: 'none',
+		arrow: false,
+		offset: [0, 8],
+		onHide: () => {
+			// Cleanup when tippy hides
+			if (linkPopupApp) {
+				linkPopupApp.unmount();
+				linkPopupApp = null;
+			}
+		},
+	})[0];
 }
 
 /**
  * Hide link popup
  */
 function hideLinkPopup() {
-    if (linkPopupInstance && !linkPopupInstance.state.isDestroyed) {
-        linkPopupInstance.destroy();
-    }
-    linkPopupInstance = null;
+	if (linkPopupInstance && !linkPopupInstance.state.isDestroyed) {
+		linkPopupInstance.destroy();
+	}
+	linkPopupInstance = null;
 
-    if (linkPopupApp) {
-        linkPopupApp.unmount();
-        linkPopupApp = null;
-    }
+	if (linkPopupApp) {
+		linkPopupApp.unmount();
+		linkPopupApp = null;
+	}
 }
 
 /**
  * Create suggestion configuration for slash commands
  */
 function createSlashCommandsSuggestion() {
-    return {
-        items: ({ query }) => filterCommands(query),
-        render: () => {
-            let component;
-            let popup;
-            let isDestroyed = false;
+	return {
+		items: ({ query }) => filterCommands(query),
+		render: () => {
+			let component;
+			let popup;
+			let isDestroyed = false;
 
-            return {
-                onStart: (props) => {
-                    isDestroyed = false;
-                    // Create a container for the Vue component
-                    const container = document.createElement('div');
+			return {
+				onStart: (props) => {
+					isDestroyed = false;
+					// Create a container for the Vue component
+					const container = document.createElement('div');
 
-                    // Create the Vue component instance
-                    component = {
-                        element: container,
-                        props,
-                        vm: null,
-                        app: null,
-                    };
+					// Create the Vue component instance
+					component = {
+						element: container,
+						props,
+						vm: null,
+						app: null,
+					};
 
-                    // Mount the SlashCommandsList component directly
-                    import('vue').then(({ createApp }) => {
-                        if (isDestroyed) return;
-                        const app = createApp(SlashCommandsList, {
-                            items: props.items,
-                            command: props.command,
-                        });
-                        component.app = app;
-                        component.vm = app.mount(container);
-                    });
+					// Mount the SlashCommandsList component directly
+					import('vue').then(({ createApp }) => {
+						if (isDestroyed) return;
+						const app = createApp(SlashCommandsList, {
+							items: props.items,
+							command: props.command,
+						});
+						component.app = app;
+						component.vm = app.mount(container);
+					});
 
-                    // Create tippy popup with no default styling
-                    popup = tippy('body', {
-                        getReferenceClientRect: props.clientRect,
-                        appendTo: () => document.body,
-                        content: container,
-                        showOnCreate: true,
-                        interactive: true,
-                        trigger: 'manual',
-                        placement: 'bottom-start',
-                        maxWidth: 'none',
-                        theme: 'none',
-                        arrow: false,
-                        offset: [0, 4],
-                    })[0];
-                },
+					// Create tippy popup with no default styling
+					popup = tippy('body', {
+						getReferenceClientRect: props.clientRect,
+						appendTo: () => document.body,
+						content: container,
+						showOnCreate: true,
+						interactive: true,
+						trigger: 'manual',
+						placement: 'bottom-start',
+						maxWidth: 'none',
+						theme: 'none',
+						arrow: false,
+						offset: [0, 4],
+					})[0];
+				},
 
-                onUpdate: (props) => {
-                    if (isDestroyed) return;
+				onUpdate: (props) => {
+					if (isDestroyed) return;
 
-                    // Re-render with new items
-                    if (component?.app) {
-                        import('vue').then(({ createApp }) => {
-                            if (isDestroyed) return;
-                            // Unmount old app
-                            component.app.unmount();
-                            const container = component.element;
-                            // Create new app with updated props
-                            const app = createApp(SlashCommandsList, {
-                                items: props.items,
-                                command: props.command,
-                            });
-                            component.app = app;
-                            component.vm = app.mount(container);
-                        });
-                    }
+					// Re-render with new items
+					if (component?.app) {
+						import('vue').then(({ createApp }) => {
+							if (isDestroyed) return;
+							// Unmount old app
+							component.app.unmount();
+							const container = component.element;
+							// Create new app with updated props
+							const app = createApp(SlashCommandsList, {
+								items: props.items,
+								command: props.command,
+							});
+							component.app = app;
+							component.vm = app.mount(container);
+						});
+					}
 
-                    if (popup) {
-                        popup.setProps({
-                            getReferenceClientRect: props.clientRect,
-                        });
-                    }
-                },
+					if (popup) {
+						popup.setProps({
+							getReferenceClientRect: props.clientRect,
+						});
+					}
+				},
 
-                onKeyDown: (props) => {
-                    if (props.event.key === 'Escape') {
-                        popup?.hide();
-                        return true;
-                    }
+				onKeyDown: (props) => {
+					if (props.event.key === 'Escape') {
+						popup?.hide();
+						return true;
+					}
 
-                    // Let the component handle arrow keys and enter
-                    if (component?.vm?.onKeyDown) {
-                        return component.vm.onKeyDown(props.event);
-                    }
+					// Let the component handle arrow keys and enter
+					if (component?.vm?.onKeyDown) {
+						return component.vm.onKeyDown(props.event);
+					}
 
-                    return false;
-                },
+					return false;
+				},
 
-                onExit: () => {
-                    if (isDestroyed) return;
-                    isDestroyed = true;
+				onExit: () => {
+					if (isDestroyed) return;
+					isDestroyed = true;
 
-                    // Properly unmount Vue app
-                    if (component?.app) {
-                        component.app.unmount();
-                    }
+					// Properly unmount Vue app
+					if (component?.app) {
+						component.app.unmount();
+					}
 
-                    // Destroy tippy only if it exists and hasn't been destroyed
-                    if (popup && !popup.state.isDestroyed) {
-                        popup.destroy();
-                    }
+					// Destroy tippy only if it exists and hasn't been destroyed
+					if (popup && !popup.state.isDestroyed) {
+						popup.destroy();
+					}
 
-                    popup = null;
-                    component = null;
-                },
-            };
-        },
-    };
+					popup = null;
+					component = null;
+				},
+			};
+		},
+	};
 }
 
 /**
  * Initialize the editor
  */
 function initEditor() {
-    editor.value = new Editor({
-        extensions: [
-            StarterKit.configure({
-                codeBlock: false, // We use CodeBlockLowlight instead
-                // Disable StarterKit's link - we use our custom WikiLink
-                link: false,
-            }),
-            // Custom link extension with Cmd+K support
-            WikiLink.configure({
-                openOnClick: false,
-                HTMLAttributes: {
-                    rel: 'noopener noreferrer',
-                },
-                onOpenLinkEditor: showLinkPopup,
-            }),
-            Markdown,
-            // Custom image extension with caption support
-            WikiImage.configure({
-                inline: false,
-                allowBase64: true,
-            }),
-            Table.configure({
-                resizable: true,
-            }),
-            TableRow,
-            TableCell,
-            TableHeader,
-            TaskList,
-            TaskItem.configure({
-                nested: true,
-            }),
-            Placeholder.configure({
-                placeholder: 'Type "/" for commands, or start writing...',
-            }),
-            CodeBlockLowlight.configure({
-                lowlight,
-            }),
-            // Custom extensions
-            CalloutBlock,
-            VideoBlock,
-            // Slash commands
-            SlashCommands.configure({
-                suggestion: createSlashCommandsSuggestion(),
-            }),
-        ],
-        content: props.content || '',
-        contentType: 'markdown',
-        editorProps: {
-            handlePaste,
-            handleDrop,
-            attributes: {
-                class: 'prose prose-sm max-w-none prose-code:before:content-none prose-code:after:content-none prose-code:bg-transparent prose-code:p-0 prose-code:font-normal prose-table:table-fixed prose-td:p-2 prose-th:p-2 prose-td:border prose-th:border prose-td:border-outline-gray-2 prose-th:border-outline-gray-2 prose-td:relative prose-th:relative prose-th:bg-surface-gray-2 wiki-editor-content',
-            },
-        },
-        onUpdate: () => {
-            handleContentChange();
-        },
-    });
+	editor.value = new Editor({
+		extensions: [
+			StarterKit.configure({
+				codeBlock: false, // We use CodeBlockLowlight instead
+				// Disable StarterKit's link - we use our custom WikiLink
+				link: false,
+			}),
+			// Custom link extension with Cmd+K support
+			WikiLink.configure({
+				openOnClick: false,
+				HTMLAttributes: {
+					rel: 'noopener noreferrer',
+				},
+				onOpenLinkEditor: showLinkPopup,
+			}),
+			Markdown,
+			// Custom image extension with caption support
+			WikiImage.configure({
+				inline: false,
+				allowBase64: true,
+			}),
+			Table.configure({
+				resizable: true,
+			}),
+			TableRow,
+			TableCell,
+			TableHeader,
+			TaskList,
+			TaskItem.configure({
+				nested: true,
+			}),
+			Placeholder.configure({
+				placeholder: 'Type "/" for commands, or start writing...',
+			}),
+			CodeBlockLowlight.configure({
+				lowlight,
+			}),
+			// Custom extensions
+			CalloutBlock,
+			VideoBlock.configure({
+				uploadFunction: uploadFile,
+			}),
+			// Slash commands
+			SlashCommands.configure({
+				suggestion: createSlashCommandsSuggestion(),
+			}),
+		],
+		content: props.content || '',
+		contentType: 'markdown',
+		editorProps: {
+			handlePaste,
+			handleDrop,
+			attributes: {
+				class:
+					'prose prose-sm max-w-none prose-code:before:content-none prose-code:after:content-none prose-code:bg-transparent prose-code:p-0 prose-code:font-normal prose-table:table-fixed prose-td:p-2 prose-th:p-2 prose-td:border prose-th:border prose-td:border-outline-gray-2 prose-th:border-outline-gray-2 prose-td:relative prose-th:relative prose-th:bg-surface-gray-2 wiki-editor-content',
+			},
+		},
+		onUpdate: () => {
+			handleContentChange();
+		},
+	});
 }
 
 function handleContentChange() {
-    // Clear existing timer
-    if (autosaveTimer) {
-        clearTimeout(autosaveTimer);
-    }
+	// Clear existing timer
+	if (autosaveTimer) {
+		clearTimeout(autosaveTimer);
+	}
 
-    // Check if content has changed
-    const currentContent = editor.value?.getMarkdown();
-    if (currentContent !== undefined && currentContent !== lastSavedContent.value) {
-        hasUnsavedChanges.value = true;
+	// Check if content has changed
+	const currentContent = editor.value?.getMarkdown();
+	if (
+		currentContent !== undefined &&
+		currentContent !== lastSavedContent.value
+	) {
+		hasUnsavedChanges.value = true;
 
-        // Set up debounced autosave
-        autosaveTimer = setTimeout(() => {
-            autoSave();
-        }, AUTOSAVE_DELAY);
-    }
+		// Set up debounced autosave
+		autosaveTimer = setTimeout(() => {
+			autoSave();
+		}, AUTOSAVE_DELAY);
+	}
 }
 
 async function autoSave() {
-    if (props.saving || !editor.value) {
-        return;
-    }
+	if (props.saving || !editor.value) {
+		return;
+	}
 
-    // Notify components to sync their content before we read it
-    document.dispatchEvent(new CustomEvent('wiki-editor-before-save'));
+	// Notify components to sync their content before we read it
+	document.dispatchEvent(new CustomEvent('wiki-editor-before-save'));
 
-    const currentContent = editor.value.getMarkdown();
-    if (currentContent === undefined || currentContent === lastSavedContent.value) {
-        hasUnsavedChanges.value = false;
-        return;
-    }
+	const currentContent = editor.value.getMarkdown();
+	if (
+		currentContent === undefined ||
+		currentContent === lastSavedContent.value
+	) {
+		hasUnsavedChanges.value = false;
+		return;
+	}
 
-    emit('save', currentContent);
-    lastSavedContent.value = currentContent;
-    hasUnsavedChanges.value = false;
-    // Notify components that save is complete so they can restore focus
-    document.dispatchEvent(new CustomEvent('wiki-editor-after-save'));
+	emit('save', currentContent);
+	lastSavedContent.value = currentContent;
+	hasUnsavedChanges.value = false;
+	// Notify components that save is complete so they can restore focus
+	document.dispatchEvent(new CustomEvent('wiki-editor-after-save'));
 }
 
 function saveToDB() {
-    // Clear any pending autosave
-    if (autosaveTimer) {
-        clearTimeout(autosaveTimer);
-    }
+	// Clear any pending autosave
+	if (autosaveTimer) {
+		clearTimeout(autosaveTimer);
+	}
 
-    if (!editor.value) {
-        toast.error('Editor is not ready');
-        return;
-    }
+	if (!editor.value) {
+		toast.error('Editor is not ready');
+		return;
+	}
 
-    // Notify components to sync their content before we read it
-    document.dispatchEvent(new CustomEvent('wiki-editor-before-save'));
+	// Notify components to sync their content before we read it
+	document.dispatchEvent(new CustomEvent('wiki-editor-before-save'));
 
-    // Get markdown from the editor
-    const markdown = editor.value.getMarkdown();
-    if (markdown !== undefined) {
-        emit('save', markdown);
-        lastSavedContent.value = markdown;
-        hasUnsavedChanges.value = false;
-        // Notify components that save is complete so they can restore focus
-        document.dispatchEvent(new CustomEvent('wiki-editor-after-save'));
-    } else {
-        toast.error('Could not get content from editor');
-    }
+	// Get markdown from the editor
+	const markdown = editor.value.getMarkdown();
+	if (markdown !== undefined) {
+		emit('save', markdown);
+		lastSavedContent.value = markdown;
+		hasUnsavedChanges.value = false;
+		// Notify components that save is complete so they can restore focus
+		document.dispatchEvent(new CustomEvent('wiki-editor-after-save'));
+	} else {
+		toast.error('Could not get content from editor');
+	}
 }
 
 // Expose methods for parent component
 defineExpose({
-    saveToDB,
-    hasUnsavedChanges,
+	saveToDB,
+	hasUnsavedChanges,
 });
 
 // Keyboard shortcut: Cmd+S / Ctrl+S to save
 onKeyStroke('s', (e) => {
-    if (e.metaKey || e.ctrlKey) {
-        e.preventDefault();
-        saveToDB();
-    }
+	if (e.metaKey || e.ctrlKey) {
+		e.preventDefault();
+		saveToDB();
+	}
 });
 
 onMounted(() => {
-    initEditor();
-    // Expose editor on window for E2E testing
-    window.wikiEditor = editor.value;
-    // Listen for slash command image upload events
-    document.addEventListener('wiki-editor-upload-image', handleSlashImageUploadEvent);
+	initEditor();
+	// Expose editor on window for E2E testing
+	window.wikiEditor = editor.value;
+	// Listen for slash command image upload events
+	document.addEventListener(
+		'wiki-editor-upload-image',
+		handleSlashImageUploadEvent,
+	);
 });
 
 onUnmounted(() => {
-    // Remove event listener
-    document.removeEventListener('wiki-editor-upload-image', handleSlashImageUploadEvent);
-    // Hide any open link popup
-    hideLinkPopup();
-    // Clean up window reference
-    delete window.wikiEditor;
+	// Remove event listener
+	document.removeEventListener(
+		'wiki-editor-upload-image',
+		handleSlashImageUploadEvent,
+	);
+	// Hide any open link popup
+	hideLinkPopup();
+	// Clean up window reference
+	delete window.wikiEditor;
 
-    if (autosaveTimer) {
-        clearTimeout(autosaveTimer);
-    }
-    if (editor.value) {
-        editor.value.destroy();
-    }
+	if (autosaveTimer) {
+		clearTimeout(autosaveTimer);
+	}
+	if (editor.value) {
+		editor.value.destroy();
+	}
 });
 </script>
 

--- a/frontend/src/components/tiptap-extensions/SlashCommandsList.vue
+++ b/frontend/src/components/tiptap-extensions/SlashCommandsList.vue
@@ -20,99 +20,102 @@
 </template>
 
 <script setup>
-import { ref, watch, onMounted, onUnmounted } from 'vue';
 import {
-    Heading1,
-    Heading2,
-    Heading3,
-    List,
-    ListOrdered,
-    ListChecks,
-    Code,
-    Quote,
-    Minus,
-    Table,
-    Image,
-    Info,
-    Lightbulb,
-    AlertTriangle,
-    AlertOctagon,
-    HelpCircle,
+	AlertOctagon,
+	AlertTriangle,
+	Code,
+	Heading1,
+	Heading2,
+	Heading3,
+	HelpCircle,
+	Image,
+	Info,
+	Lightbulb,
+	List,
+	ListChecks,
+	ListOrdered,
+	Minus,
+	Quote,
+	Table,
+	Video,
 } from 'lucide-vue-next';
+import { onMounted, onUnmounted, ref, watch } from 'vue';
 
 const props = defineProps({
-    items: {
-        type: Array,
-        required: true,
-    },
-    command: {
-        type: Function,
-        required: true,
-    },
+	items: {
+		type: Array,
+		required: true,
+	},
+	command: {
+		type: Function,
+		required: true,
+	},
 });
 
 const selectedIndex = ref(0);
 
 // Icon mapping
 const iconMap = {
-    'heading-1': Heading1,
-    'heading-2': Heading2,
-    'heading-3': Heading3,
-    list: List,
-    'list-ordered': ListOrdered,
-    'list-checks': ListChecks,
-    code: Code,
-    quote: Quote,
-    minus: Minus,
-    table: Table,
-    image: Image,
-    info: Info,
-    lightbulb: Lightbulb,
-    'alert-triangle': AlertTriangle,
-    'alert-octagon': AlertOctagon,
+	'heading-1': Heading1,
+	'heading-2': Heading2,
+	'heading-3': Heading3,
+	list: List,
+	'list-ordered': ListOrdered,
+	'list-checks': ListChecks,
+	code: Code,
+	quote: Quote,
+	minus: Minus,
+	table: Table,
+	image: Image,
+	video: Video,
+	info: Info,
+	lightbulb: Lightbulb,
+	'alert-triangle': AlertTriangle,
+	'alert-octagon': AlertOctagon,
 };
 
 function getIcon(iconName) {
-    return iconMap[iconName] || HelpCircle;
+	return iconMap[iconName] || HelpCircle;
 }
 
 function selectItem(index) {
-    const item = props.items[index];
-    if (item) {
-        props.command(item);
-    }
+	const item = props.items[index];
+	if (item) {
+		props.command(item);
+	}
 }
 
 function onKeyDown(event) {
-    if (event.key === 'ArrowUp') {
-        event.preventDefault();
-        selectedIndex.value = (selectedIndex.value - 1 + props.items.length) % props.items.length;
-        return true;
-    }
-    if (event.key === 'ArrowDown') {
-        event.preventDefault();
-        selectedIndex.value = (selectedIndex.value + 1) % props.items.length;
-        return true;
-    }
-    if (event.key === 'Enter') {
-        event.preventDefault();
-        selectItem(selectedIndex.value);
-        return true;
-    }
-    return false;
+	if (event.key === 'ArrowUp') {
+		event.preventDefault();
+		selectedIndex.value =
+			(selectedIndex.value - 1 + props.items.length) % props.items.length;
+		return true;
+	}
+	if (event.key === 'ArrowDown') {
+		event.preventDefault();
+		selectedIndex.value = (selectedIndex.value + 1) % props.items.length;
+		return true;
+	}
+	if (event.key === 'Enter') {
+		event.preventDefault();
+		selectItem(selectedIndex.value);
+		return true;
+	}
+	return false;
 }
 
 // Reset selected index when items change
 watch(
-    () => props.items,
-    () => {
-        selectedIndex.value = 0;
-    }
+	() => props.items,
+	() => {
+		selectedIndex.value = 0;
+	},
 );
 
 // Expose onKeyDown for parent component
 defineExpose({
-    onKeyDown,
+	onKeyDown,
 });
 </script>
 

--- a/frontend/src/components/tiptap-extensions/VideoBlockView.vue
+++ b/frontend/src/components/tiptap-extensions/VideoBlockView.vue
@@ -83,8 +83,8 @@ const videoType = computed(() => {
     display: flex;
     flex-direction: column;
     align-items: center;
-    margin: 1rem 0;
-    padding: 0.5rem;
+    margin: 0.25rem 0;
+    padding: 0;
     border-radius: 8px;
     transition: background-color 0.2s ease;
 }

--- a/frontend/src/components/tiptap-extensions/WikiBubbleMenu.vue
+++ b/frontend/src/components/tiptap-extensions/WikiBubbleMenu.vue
@@ -2,6 +2,7 @@
     <BubbleMenu
         v-if="editor"
         :editor="editor"
+        :should-show="shouldShowBubbleMenu"
         :tippy-options="{
             duration: 100,
             maxWidth: 'none',
@@ -129,32 +130,45 @@
 </template>
 
 <script setup>
+import { NodeSelection } from '@tiptap/pm/state';
 import { BubbleMenu } from '@tiptap/vue-3/menus';
 import {
-    Bold,
-    Italic,
-    Strikethrough,
-    Code,
-    Link,
-    Heading1,
-    Heading2,
-    Heading3,
-    List,
-    ListOrdered,
-    Quote,
-    FileCode,
+	Bold,
+	Code,
+	FileCode,
+	Heading1,
+	Heading2,
+	Heading3,
+	Italic,
+	Link,
+	List,
+	ListOrdered,
+	Quote,
+	Strikethrough,
 } from 'lucide-vue-next';
 
 const props = defineProps({
-    editor: {
-        type: Object,
-        required: true,
-    },
+	editor: {
+		type: Object,
+		required: true,
+	},
 });
 
+function shouldShowBubbleMenu({ editor, state }) {
+	const selection = state.selection;
+
+	// Bubble menu is only for inline text formatting, not media/node selections.
+	if (selection instanceof NodeSelection) return false;
+	if (selection.empty) return false;
+	if (editor.isActive('videoBlock')) return false;
+	if (editor.isActive('image')) return false;
+
+	return true;
+}
+
 function toggleLink() {
-    // Use the openLinkEditor command from our custom link extension
-    props.editor.commands.openLinkEditor();
+	// Use the openLinkEditor command from our custom link extension
+	props.editor.commands.openLinkEditor();
 }
 </script>
 

--- a/frontend/src/components/tiptap-extensions/WikiToolbar.vue
+++ b/frontend/src/components/tiptap-extensions/WikiToolbar.vue
@@ -163,6 +163,15 @@
                 @change="handleImageSelect"
             />
 
+            <!-- Video -->
+            <button
+                class="toolbar-btn"
+                @click="editor.chain().focus().selectAndUploadVideo().run()"
+                title="Insert Video"
+            >
+                <VideoIcon class="icon" />
+            </button>
+
             <div class="toolbar-separator"></div>
 
             <!-- Undo/Redo -->
@@ -187,37 +196,38 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, onUnmounted } from 'vue';
 import {
-    LucideHeading1 as H1Icon,
-    LucideHeading2 as H2Icon,
-    LucideHeading3 as H3Icon,
-    LucideHeading4 as H4Icon,
-    LucideHeading5 as H5Icon,
-    LucideHeading6 as H6Icon,
-    LucideType as TextIcon,
-    LucideBold as BoldIcon,
-    LucideItalic as ItalicIcon,
-    LucideStrikethrough as StrikethroughIcon,
-    LucideCode as CodeIcon,
-    LucideList as ListIcon,
-    LucideListOrdered as ListOrderedIcon,
-    LucideListChecks as ListChecksIcon,
-    LucideQuote as QuoteIcon,
-    LucideSquareCode as CodeBlockIcon,
-    LucideMinus as MinusIcon,
-    LucideTable as TableIcon,
-    LucideLink as LinkIcon,
-    LucideImage as ImageIcon,
-    LucideUndo2 as UndoIcon,
-    LucideRedo2 as RedoIcon,
+	LucideBold as BoldIcon,
+	LucideSquareCode as CodeBlockIcon,
+	LucideCode as CodeIcon,
+	LucideHeading1 as H1Icon,
+	LucideHeading2 as H2Icon,
+	LucideHeading3 as H3Icon,
+	LucideHeading4 as H4Icon,
+	LucideHeading5 as H5Icon,
+	LucideHeading6 as H6Icon,
+	LucideImage as ImageIcon,
+	LucideItalic as ItalicIcon,
+	LucideLink as LinkIcon,
+	LucideListChecks as ListChecksIcon,
+	LucideList as ListIcon,
+	LucideListOrdered as ListOrderedIcon,
+	LucideMinus as MinusIcon,
+	LucideQuote as QuoteIcon,
+	LucideRedo2 as RedoIcon,
+	LucideStrikethrough as StrikethroughIcon,
+	LucideTable as TableIcon,
+	LucideType as TextIcon,
+	LucideUndo2 as UndoIcon,
+	LucideVideo as VideoIcon,
 } from 'lucide-vue-next';
+import { computed, onMounted, onUnmounted, ref } from 'vue';
 
 const props = defineProps({
-    editor: {
-        type: Object,
-        required: true,
-    },
+	editor: {
+		type: Object,
+		required: true,
+	},
 });
 
 const emit = defineEmits(['uploadImage']);
@@ -227,73 +237,80 @@ const headingsDropdown = ref(null);
 const imageInput = ref(null);
 
 const headingIcons = {
-    1: H1Icon,
-    2: H2Icon,
-    3: H3Icon,
-    4: H4Icon,
-    5: H5Icon,
-    6: H6Icon,
+	1: H1Icon,
+	2: H2Icon,
+	3: H3Icon,
+	4: H4Icon,
+	5: H5Icon,
+	6: H6Icon,
 };
 
 const currentHeadingIcon = computed(() => {
-    if (!props.editor) return TextIcon;
-    for (let level = 1; level <= 6; level++) {
-        if (props.editor.isActive('heading', { level })) {
-            return headingIcons[level];
-        }
-    }
-    return TextIcon;
+	if (!props.editor) return TextIcon;
+	for (let level = 1; level <= 6; level++) {
+		if (props.editor.isActive('heading', { level })) {
+			return headingIcons[level];
+		}
+	}
+	return TextIcon;
 });
 
 function toggleHeadingsDropdown() {
-    showHeadingsDropdown.value = !showHeadingsDropdown.value;
+	showHeadingsDropdown.value = !showHeadingsDropdown.value;
 }
 
 function setHeading(level) {
-    props.editor.chain().focus().toggleHeading({ level }).run();
-    showHeadingsDropdown.value = false;
+	props.editor.chain().focus().toggleHeading({ level }).run();
+	showHeadingsDropdown.value = false;
 }
 
 function setParagraph() {
-    props.editor.chain().focus().setParagraph().run();
-    showHeadingsDropdown.value = false;
+	props.editor.chain().focus().setParagraph().run();
+	showHeadingsDropdown.value = false;
 }
 
 function insertTable() {
-    props.editor.chain().focus().insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run();
+	props.editor
+		.chain()
+		.focus()
+		.insertTable({ rows: 3, cols: 3, withHeaderRow: true })
+		.run();
 }
 
 function toggleLink() {
-    // Use the openLinkEditor command from our custom link extension
-    props.editor.commands.openLinkEditor();
+	// Use the openLinkEditor command from our custom link extension
+	props.editor.commands.openLinkEditor();
 }
 
 function triggerImageUpload() {
-    imageInput.value?.click();
+	imageInput.value?.click();
 }
 
 function handleImageSelect(event) {
-    const file = event.target.files?.[0];
-    if (file) {
-        emit('uploadImage', file);
-    }
-    // Reset input so same file can be selected again
-    event.target.value = '';
+	const file = event.target.files?.[0];
+	if (file) {
+		emit('uploadImage', file);
+	}
+	// Reset input so same file can be selected again
+	event.target.value = '';
 }
 
 // Close dropdown when clicking outside
 function handleClickOutside(event) {
-    if (headingsDropdown.value && !headingsDropdown.value.contains(event.target)) {
-        showHeadingsDropdown.value = false;
-    }
+	if (
+		headingsDropdown.value &&
+		!headingsDropdown.value.contains(event.target)
+	) {
+		showHeadingsDropdown.value = false;
+	}
 }
 
 onMounted(() => {
-    document.addEventListener('click', handleClickOutside);
+	document.addEventListener('click', handleClickOutside);
 });
 
 onUnmounted(() => {
-    document.removeEventListener('click', handleClickOutside);
+	document.removeEventListener('click', handleClickOutside);
 });
 </script>
 

--- a/frontend/src/components/tiptap-extensions/image-extension.js
+++ b/frontend/src/components/tiptap-extensions/image-extension.js
@@ -1,6 +1,7 @@
 import { Node, mergeAttributes, nodeInputRule } from '@tiptap/core';
 import { VueNodeViewRenderer } from '@tiptap/vue-3';
 import ImageNodeView from './ImageNodeView.vue';
+import { isVideoUrl } from './video-block.js';
 
 // Markdown image regex: ![alt](src "title")
 const inputRegex = /(?:^|\s)(!\[(.+|:?)]\((\S+)(?:(?:\s+)["'](\S+)["'])?\))$/;
@@ -39,6 +40,9 @@ const imageCaptionTokenizer = {
 		}
 
 		const [imageRaw, alt, href, title] = imageMatch;
+		if (isVideoUrl(href)) {
+			return undefined;
+		}
 		let caption = null;
 		let raw = imageRaw;
 

--- a/frontend/src/components/tiptap-extensions/slash-commands.js
+++ b/frontend/src/components/tiptap-extensions/slash-commands.js
@@ -115,6 +115,14 @@ export const SLASH_COMMANDS = [
 		},
 	},
 	{
+		title: 'Video',
+		description: 'Upload a video',
+		icon: 'video',
+		command: ({ editor, range }) => {
+			editor.chain().focus().deleteRange(range).selectAndUploadVideo().run();
+		},
+	},
+	{
 		title: 'Note Callout',
 		description: 'Add a note callout block',
 		icon: 'info',

--- a/frontend/src/components/tiptap-extensions/video-block.js
+++ b/frontend/src/components/tiptap-extensions/video-block.js
@@ -29,8 +29,8 @@ export const VIDEO_EXTENSIONS = [
  */
 export function isVideoUrl(url) {
 	if (!url) return false;
-	const lowerUrl = url.toLowerCase();
-	return VIDEO_EXTENSIONS.some((ext) => lowerUrl.endsWith(ext));
+	const cleanUrl = String(url).split(/[?#]/)[0].toLowerCase();
+	return VIDEO_EXTENSIONS.some((ext) => cleanUrl.endsWith(ext));
 }
 
 export const VideoBlock = Node.create({
@@ -41,6 +41,13 @@ export const VideoBlock = Node.create({
 	atom: true,
 
 	draggable: true,
+
+	addOptions() {
+		return {
+			uploadFunction: null,
+			HTMLAttributes: {},
+		};
+	},
 
 	addAttributes() {
 		return {
@@ -76,7 +83,7 @@ export const VideoBlock = Node.create({
 	},
 
 	renderHTML({ node, HTMLAttributes }) {
-		const attrs = mergeAttributes(HTMLAttributes, {
+		const attrs = mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
 			'data-type': 'video-block',
 			'data-src': node.attrs.src,
 			'data-alt': node.attrs.alt,
@@ -111,6 +118,33 @@ export const VideoBlock = Node.create({
 						type: this.name,
 						attrs: attributes,
 					});
+				},
+			uploadVideo:
+				(file) =>
+				({ editor }) => {
+					const pos = editor.state.selection.from;
+					return uploadVideoInternal(file, editor.view, pos, this.options);
+				},
+			selectAndUploadVideo:
+				() =>
+				({ editor }) => {
+					if (!this.options.uploadFunction) {
+						console.error('uploadFunction option is not provided for videos.');
+						return false;
+					}
+
+					const input = document.createElement('input');
+					input.type = 'file';
+					input.accept = 'video/*';
+					input.onchange = (event) => {
+						const target = event.target;
+						if (target?.files?.length) {
+							const file = target.files[0];
+							editor.commands.uploadVideo(file);
+						}
+					};
+					input.click();
+					return true;
 				},
 		};
 	},
@@ -169,3 +203,38 @@ export const VideoBlock = Node.create({
 });
 
 export default VideoBlock;
+
+function uploadVideoInternal(file, view, pos, options) {
+	if (!options?.uploadFunction) {
+		console.error('uploadFunction option is not provided for videos.');
+		return false;
+	}
+
+	options
+		.uploadFunction(file)
+		.then((uploadedVideo) => {
+			const url =
+				typeof uploadedVideo === 'string'
+					? uploadedVideo
+					: uploadedVideo?.file_url;
+			if (!url) {
+				console.error('Video upload returned no URL.');
+				return;
+			}
+			const { schema } = view.state;
+			const node = schema.nodes.videoBlock.create({ src: url });
+
+			const transaction = view.state.tr;
+			if (pos != null) {
+				transaction.insert(pos, node);
+			} else {
+				transaction.replaceSelectionWith(node);
+			}
+			view.dispatch(transaction);
+		})
+		.catch((error) => {
+			console.error('Video upload failed:', error);
+		});
+
+	return true;
+}

--- a/frontend/src/pages/SpaceDetails.vue
+++ b/frontend/src/pages/SpaceDetails.vue
@@ -132,6 +132,23 @@
                             {{ __('Update') }}
                         </Button>
                     </div>
+                    <div class="flex items-center justify-between p-3 rounded-lg border border-outline-gray-2 bg-surface-gray-1">
+                        <div class="flex-1 mr-4">
+                            <p class="text-sm font-medium text-ink-gray-9">
+                                {{ __('Clone Space') }}
+                            </p>
+                            <p class="text-xs text-ink-gray-5 mt-0.5">
+                                {{ __('Create a new space with the same structure') }}
+                            </p>
+                        </div>
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            @click="openCloneSpaceDialog"
+                        >
+                            {{ __('Clone') }}
+                        </Button>
+                    </div>
                 </div>
             </template>
             <template #actions="{ close }">
@@ -172,6 +189,36 @@
                         @click="updateRoutes(close)"
                     >
                         {{ __('Update Routes') }}
+                    </Button>
+                </div>
+            </template>
+        </Dialog>
+
+        <Dialog v-model="showCloneSpaceDialog">
+            <template #body-title>
+                <h3 class="text-xl font-semibold text-ink-gray-9">
+                    {{ __('Clone Wiki Space') }}
+                </h3>
+            </template>
+            <template #body-content>
+                <div class="space-y-4 py-2">
+                    <FormControl
+                        type="text"
+                        :label="__('New Space Route')"
+                        v-model="cloneRoute"
+                        :placeholder="__('Enter new route (without leading slash)')"
+                    />
+                </div>
+            </template>
+            <template #actions="{ close }">
+                <div class="flex justify-end gap-2">
+                    <Button variant="outline" @click="close">{{ __('Cancel') }}</Button>
+                    <Button
+                        variant="solid"
+                        :loading="cloningSpace"
+                        @click="cloneSpace(close)"
+                    >
+                        {{ __('Start Cloning') }}
                     </Button>
                 </div>
             </template>
@@ -217,8 +264,11 @@ const isManager = computed(() => isWikiManager());
 
 const showSettingsDialog = ref(false);
 const showUpdateRoutesDialog = ref(false);
+const showCloneSpaceDialog = ref(false);
 const newRoute = ref('');
 const updatingRoutes = ref(false);
+const cloneRoute = ref('');
+const cloningSpace = ref(false);
 
 const enableFeedbackCollection = ref(false);
 const updatingFeedbackSetting = ref(false);
@@ -238,6 +288,7 @@ const space = createDocumentResource({
     auto: true,
     whitelistedMethods: {
         updateRoutes: 'update_routes',
+        cloneWikiSpace: 'clone_wiki_space_in_background',
     },
 });
 
@@ -281,6 +332,15 @@ function openUpdateRoutesDialog() {
     showUpdateRoutesDialog.value = true;
 }
 
+function openCloneSpaceDialog() {
+    if (space.doc?.route) {
+        cloneRoute.value = `${space.doc.route}-copy`;
+    } else {
+        cloneRoute.value = '';
+    }
+    showCloneSpaceDialog.value = true;
+}
+
 async function updateRoutes(close) {
     if (!newRoute.value?.trim()) {
         return;
@@ -296,6 +356,24 @@ async function updateRoutes(close) {
         console.error('Failed to update routes:', error);
     } finally {
         updatingRoutes.value = false;
+    }
+}
+
+async function cloneSpace(close) {
+    if (!cloneRoute.value?.trim()) {
+        return;
+    }
+
+    cloningSpace.value = true;
+    try {
+        await space.cloneWikiSpace.submit({ new_space_route: cloneRoute.value.trim() });
+        toast.success(__('Cloning started in background'));
+        close();
+    } catch (error) {
+        console.error('Failed to start clone:', error);
+        toast.error(error.messages?.[0] || __('Error starting clone'));
+    } finally {
+        cloningSpace.value = false;
     }
 }
 

--- a/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
@@ -51,7 +51,9 @@ class TestGetWebContext(IntegrationTestCase):
 				frappe.delete_doc("Wiki Space", space_name, force=True)
 		self.test_spaces = []
 
-	def _create_wiki_document(self, title, parent=None, is_group=False, is_published=True, sort_order=0):
+	def _create_wiki_document(
+		self, title, parent=None, is_group=False, is_published=True, sort_order=0, content=None
+	):
 		"""Helper to create a wiki document for testing."""
 		doc = frappe.get_doc(
 			{
@@ -61,7 +63,7 @@ class TestGetWebContext(IntegrationTestCase):
 				"is_group": is_group,
 				"is_published": is_published,
 				"sort_order": sort_order,
-				"content": f"Content for {title}",
+				"content": content if content is not None else f"Content for {title}",
 			}
 		)
 		doc.insert(ignore_permissions=True)
@@ -271,6 +273,27 @@ class TestGetWebContext(IntegrationTestCase):
 		# Content should still be rendered
 		self.assertIsNotNone(context.get("rendered_content"))
 		self.assertEqual(context.get("title"), "Orphan Published Document")
+
+	def test_get_web_context_renders_video_markdown_as_html_video_block(self):
+		"""Video markdown should render as HTML5 video in public page context."""
+		root_group = self._create_wiki_document("Root Video Group", is_group=True)
+		video_doc = self._create_wiki_document(
+			"Video Document",
+			parent=root_group.name,
+			content="![Demo Video](/files/demo-video.mp4)",
+		)
+		self._create_wiki_space("Video Space", "video-space", root_group.name)
+
+		video_doc.reload()
+		context = video_doc.get_web_context()
+
+		self.assertIn('<div data-type="video-block"', context["rendered_content"])
+		self.assertIn(
+			'<video src="/files/demo-video.mp4" controls preload="metadata">',
+			context["rendered_content"],
+		)
+		self.assertIn('<source src="/files/demo-video.mp4" />', context["rendered_content"])
+		self.assertNotIn('<img src="/files/demo-video.mp4"', context["rendered_content"])
 
 	def test_wiki_spaces_for_switcher_ordered_by_switcher_order_then_name(self):
 		"""

--- a/wiki/test_api.py
+++ b/wiki/test_api.py
@@ -864,6 +864,101 @@ class TestRebuildWikiTree(FrappeTestCase):
 		self.assertLess(page_b.lft, page_a.lft)
 
 
+class TestReorderPerformance(FrappeTestCase):
+	"""Performance test for reorder with a large wiki tree (80 groups, ~800 pages)."""
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		frappe.db.rollback()
+
+	def test_reorder_performance_large_tree(self):
+		"""Create 80 groups (up to 3 levels deep), ~800 pages, reorder, and measure time."""
+		import time
+
+		from wiki.api.wiki_space import reorder_wiki_documents
+
+		space = create_test_wiki_space()
+		root = space.root_group
+
+		all_groups = []
+		all_pages = []
+		page_count = 0
+
+		# Level 1: 20 groups directly under root
+		level1_groups = []
+		for i in range(20):
+			g = create_wiki_document(root, f"L1 Group {i}", is_group=True)
+			level1_groups.append(g)
+			all_groups.append(g)
+
+		# Level 2: 2 sub-groups under each L1 group (20 * 2 = 40)
+		level2_groups = []
+		for g1 in level1_groups:
+			for j in range(2):
+				g = create_wiki_document(g1.name, f"L2 Group {g1.name[-6:]}-{j}", is_group=True)
+				level2_groups.append(g)
+				all_groups.append(g)
+
+		# Level 3: 1 sub-group under each L2 group (40 * 1 = 40, but cap at 20 to hit 80 total)
+		level3_groups = []
+		for g2 in level2_groups[:20]:
+			g = create_wiki_document(g2.name, f"L3 Group {g2.name[-6:]}", is_group=True)
+			level3_groups.append(g)
+			all_groups.append(g)
+
+		# Total groups: 20 + 40 + 20 = 80
+		self.assertEqual(len(all_groups), 80)
+
+		# Distribute ~800 pages across all groups (10 per group)
+		for group in all_groups:
+			for _k in range(10):
+				p = create_wiki_document(group.name, f"Page {page_count}", content=f"Content {page_count}")
+				all_pages.append(p)
+				page_count += 1
+
+		self.assertEqual(len(all_pages), 800)
+		frappe.db.commit()  # nosemgrep
+
+		# Pick a group with 10 children and reverse their order
+		target_group = level1_groups[0]
+		children = frappe.get_all(
+			"Wiki Document",
+			filters={"parent_wiki_document": target_group.name, "is_group": 0},
+			fields=["name"],
+			order_by="sort_order asc, name asc",
+		)
+		siblings_reversed = [c["name"] for c in reversed(children)]
+
+		start = time.monotonic()
+		reorder_wiki_documents(
+			doc_name=siblings_reversed[0],
+			new_parent=target_group.name,
+			new_index=0,
+			siblings=json.dumps(siblings_reversed),
+		)
+		elapsed = time.monotonic() - start
+
+		# Verify the reorder actually took effect
+		children_after = frappe.get_all(
+			"Wiki Document",
+			filters={"parent_wiki_document": target_group.name, "is_group": 0},
+			fields=["name", "sort_order"],
+			order_by="sort_order asc",
+		)
+		names_after = [c["name"] for c in children_after]
+		self.assertEqual(names_after, siblings_reversed)
+
+		print(f"\n[PERF] Reorder within same parent (800 pages, 80 groups): {elapsed:.3f}s")
+
+		# Fail if unreasonably slow (> 30s is a red flag)
+		self.assertLess(elapsed, 30, f"Reorder took {elapsed:.3f}s which exceeds 30s threshold")
+
+	# Profiling tests removed — kept only the main perf test above.
+
+
 # Helper functions
 
 

--- a/wiki/wiki/doctype/wiki_space/test_wiki_space.py
+++ b/wiki/wiki/doctype/wiki_space/test_wiki_space.py
@@ -1,265 +1,93 @@
-# Copyright (c) 2023, Frappe and Contributors
+# Copyright (c) 2026, Frappe and Contributors
 # See license.txt
 
 import frappe
-from frappe.tests import IntegrationTestCase
+from frappe.tests.utils import FrappeTestCase
+
+from wiki.wiki.doctype.wiki_space.wiki_space import clone_wiki_space
 
 
-class TestWikiSpace(IntegrationTestCase):
-	pass
+class TestWikiSpaceClone(FrappeTestCase):
+	TEST_SITE = "wiki.localhost"
 
-
-class TestUpdateRoutes(IntegrationTestCase):
-	"""Tests for the update_routes method of WikiSpace."""
-
-	@classmethod
-	def setUpClass(cls):
-		super().setUpClass()
-		cls.test_docs = []
-		cls.test_spaces = []
-
-	def tearDown(self):
-		# Clean up test documents in reverse order (children first)
-		for doc_name in reversed(self.test_docs):
-			if frappe.db.exists("Wiki Document", doc_name):
-				frappe.delete_doc("Wiki Document", doc_name, force=True)
-		self.test_docs = []
-
-		# Clean up test spaces
-		for space_name in self.test_spaces:
-			if frappe.db.exists("Wiki Space", space_name):
-				frappe.delete_doc("Wiki Space", space_name, force=True)
-		self.test_spaces = []
-
-	def _create_wiki_document(
-		self, title, route, parent=None, is_group=False, is_published=True, sort_order=0
-	):
-		"""Helper to create a wiki document for testing."""
-		doc = frappe.get_doc(
-			{
-				"doctype": "Wiki Document",
-				"title": title,
-				"route": route,
-				"parent_wiki_document": parent,
-				"is_group": is_group,
-				"is_published": is_published,
-				"sort_order": sort_order,
-				"content": f"Content for {title}",
-			}
-		)
-		doc.insert(ignore_permissions=True)
-		self.test_docs.append(doc.name)
-		return doc
-
-	def _create_wiki_space(self, space_name, route, root_group=None, skip_root_group=False):
-		"""Helper to create a wiki space for testing."""
-		doc = frappe.get_doc(
+	def setUp(self):
+		frappe.set_user("Administrator")
+		self.space = frappe.get_doc(
 			{
 				"doctype": "Wiki Space",
-				"space_name": space_name,
-				"route": route,
-				"root_group": root_group,
+				"space_name": f"Clone Source {frappe.generate_hash(length=6)}",
+				"route": f"source-space-{frappe.generate_hash(length=6)}",
 			}
+		).insert()
+		self.group_doc = frappe.get_doc(
+			{
+				"doctype": "Wiki Document",
+				"title": "Group A",
+				"is_group": 1,
+				"parent_wiki_document": self.space.root_group,
+			}
+		).insert()
+
+		self.page_doc = frappe.get_doc(
+			{
+				"doctype": "Wiki Document",
+				"title": "Page A",
+				"parent_wiki_document": self.group_doc.name,
+				"content": "Hello from the source space.",
+			}
+		).insert()
+
+	def test_clone_wiki_space_copies_tree_and_routes(self):
+		new_route = f"clone-space-{frappe.generate_hash(length=6)}"
+		new_space_name = clone_wiki_space(self.space.name, new_route)
+		new_space = frappe.get_doc("Wiki Space", new_space_name)
+
+		self.assertEqual(new_space.route, new_route)
+		self.assertNotEqual(new_space.root_group, self.space.root_group)
+
+		new_root = frappe.get_doc("Wiki Document", new_space.root_group)
+		self.assertEqual(new_root.route, new_route)
+
+		root_lft, root_rgt = frappe.get_value("Wiki Document", self.space.root_group, ["lft", "rgt"])
+		new_root_lft, new_root_rgt = frappe.get_value("Wiki Document", new_space.root_group, ["lft", "rgt"])
+
+		original_docs = frappe.get_all(
+			"Wiki Document",
+			filters={"lft": (">=", root_lft), "rgt": ("<=", root_rgt)},
+			fields=["name"],
 		)
-		doc.insert(ignore_permissions=True)
-		self.test_spaces.append(doc.name)
-
-		# If skip_root_group is True, clear the root_group after insert
-		if skip_root_group and doc.root_group:
-			# Delete the auto-created root group
-			auto_root = doc.root_group
-			frappe.db.set_value("Wiki Space", doc.name, "root_group", None)
-			doc.root_group = None
-			if frappe.db.exists("Wiki Document", auto_root):
-				frappe.delete_doc("Wiki Document", auto_root, force=True)
-
-		return doc
-
-	def _create_space_with_tree(self, base_route="test-docs", space_name="Test Space"):
-		"""Create a Wiki Space with a tree of documents."""
-		# Create root group (note: Wiki Document strips leading slashes in validate)
-		root = self._create_wiki_document(f"{space_name} Root", base_route, is_group=True)
-
-		# Create child group
-		group1 = self._create_wiki_document(
-			"Getting Started",
-			f"{base_route}/getting-started",
-			parent=root.name,
-			is_group=True,
+		new_docs = frappe.get_all(
+			"Wiki Document",
+			filters={"lft": (">=", new_root_lft), "rgt": ("<=", new_root_rgt)},
+			fields=["name"],
 		)
+		self.assertEqual(len(original_docs), len(new_docs))
 
-		# Create leaf documents
-		page1 = self._create_wiki_document(
-			"Introduction",
-			f"{base_route}/getting-started/introduction",
-			parent=group1.name,
-		)
-		page2 = self._create_wiki_document(
-			"Installation",
-			f"{base_route}/getting-started/installation",
-			parent=group1.name,
-		)
+		new_group = frappe.get_all(
+			"Wiki Document",
+			filters={
+				"lft": (">=", new_root.lft),
+				"rgt": ("<=", new_root.rgt),
+				"title": self.group_doc.title,
+				"is_group": 1,
+			},
+			fields=["name", "slug", "route"],
+		)[0]
+		new_page = frappe.get_all(
+			"Wiki Document",
+			filters={
+				"lft": (">=", new_root.lft),
+				"rgt": ("<=", new_root.rgt),
+				"title": self.page_doc.title,
+				"is_group": 0,
+			},
+			fields=["name", "slug", "route", "content", "parent_wiki_document"],
+		)[0]
 
-		# Create space
-		space = self._create_wiki_space(space_name, base_route, root.name)
+		expected_route = f"{new_route}/{new_group['slug']}/{new_page['slug']}"
+		self.assertEqual(new_page["route"], expected_route)
+		self.assertEqual(new_page["content"], self.page_doc.content)
+		self.assertEqual(new_page["parent_wiki_document"], new_group["name"])
 
-		return space, root, group1, page1, page2
-
-	def test_update_routes_success(self):
-		"""Test successful route update."""
-		space, root, group1, page1, page2 = self._create_space_with_tree("old-docs", "Update Test Space")
-
-		# Update routes
-		result = space.update_routes("new-docs")
-
-		# Verify space route updated
-		space.reload()
-		self.assertEqual(space.route, "new-docs")
-
-		# Verify root group route updated
-		root.reload()
-		self.assertEqual(root.route, "new-docs")
-
-		# Verify group route updated
-		group1.reload()
-		self.assertEqual(group1.route, "new-docs/getting-started")
-
-		# Verify page routes updated
-		page1.reload()
-		self.assertEqual(page1.route, "new-docs/getting-started/introduction")
-
-		page2.reload()
-		self.assertEqual(page2.route, "new-docs/getting-started/installation")
-
-		# Check count
-		self.assertEqual(result["updated_count"], 4)  # root + group + 2 pages
-
-	def test_update_routes_empty_route_fails(self):
-		"""Test that empty route throws error."""
-		space, _, _, _, _ = self._create_space_with_tree("empty-test", "Empty Route Test")
-
-		self.assertRaises(Exception, space.update_routes, "")
-
-	def test_update_routes_whitespace_only_fails(self):
-		"""Test that whitespace-only route throws error."""
-		space, _, _, _, _ = self._create_space_with_tree("whitespace-test", "Whitespace Test")
-
-		self.assertRaises(Exception, space.update_routes, "   ")
-
-	def test_update_routes_same_route_fails(self):
-		"""Test that same route throws error."""
-		space, _, _, _, _ = self._create_space_with_tree("same-route", "Same Route Test")
-
-		self.assertRaises(Exception, space.update_routes, "same-route")
-
-	def test_update_routes_strips_leading_slash(self):
-		"""Test that leading slash is stripped from new route."""
-		space, root, group1, page1, _ = self._create_space_with_tree("strip-test", "Strip Test")
-
-		# Update with leading slash
-		space.update_routes("/stripped-route")
-
-		space.reload()
-		self.assertEqual(space.route, "stripped-route")
-
-		page1.reload()
-		self.assertEqual(page1.route, "stripped-route/getting-started/introduction")
-
-	def test_update_routes_strips_trailing_slash(self):
-		"""Test that trailing slash is stripped from new route."""
-		space, _, _, page1, _ = self._create_space_with_tree("trail-test", "Trail Test")
-
-		# Update with trailing slash
-		space.update_routes("trailed-route/")
-
-		space.reload()
-		self.assertEqual(space.route, "trailed-route")
-
-		page1.reload()
-		self.assertEqual(page1.route, "trailed-route/getting-started/introduction")
-
-	def test_update_routes_conflict_with_other_space(self):
-		"""Test that conflicting route with another space throws error."""
-		space1, _, _, _, _ = self._create_space_with_tree("space-one", "Space One")
-		self._create_space_with_tree("space-two", "Space Two")
-
-		self.assertRaises(Exception, space1.update_routes, "space-two")
-
-	def test_update_routes_no_root_group_fails(self):
-		"""Test that space without root_group throws error."""
-		# Create space without root_group (simulating pre-V3)
-		space = self._create_wiki_space("Legacy Space", "legacy-route", skip_root_group=True)
-
-		self.assertRaises(Exception, space.update_routes, "new-legacy")
-
-	def test_update_routes_with_nested_structure(self):
-		"""Test route update with deeply nested document structure."""
-		base_route = "nested-test"
-
-		# Create root (note: Wiki Document strips leading slashes)
-		root = self._create_wiki_document("Nested Root", base_route, is_group=True)
-
-		# Create level 1 group
-		level1 = self._create_wiki_document(
-			"Level 1", f"{base_route}/level-1", parent=root.name, is_group=True
-		)
-
-		# Create level 2 group
-		level2 = self._create_wiki_document(
-			"Level 2", f"{base_route}/level-1/level-2", parent=level1.name, is_group=True
-		)
-
-		# Create level 3 page
-		level3 = self._create_wiki_document(
-			"Deep Page", f"{base_route}/level-1/level-2/deep-page", parent=level2.name
-		)
-
-		# Create space
-		space = self._create_wiki_space("Nested Space", base_route, root.name)
-
-		# Update routes
-		result = space.update_routes("new-nested")
-
-		# Verify all routes updated correctly
-		root.reload()
-		self.assertEqual(root.route, "new-nested")
-
-		level1.reload()
-		self.assertEqual(level1.route, "new-nested/level-1")
-
-		level2.reload()
-		self.assertEqual(level2.route, "new-nested/level-1/level-2")
-
-		level3.reload()
-		self.assertEqual(level3.route, "new-nested/level-1/level-2/deep-page")
-
-		self.assertEqual(result["updated_count"], 4)
-
-	def test_update_routes_returns_correct_count(self):
-		"""Test that the method returns the correct count of updated documents."""
-		space, _, _, _, _ = self._create_space_with_tree("count-test", "Count Test")
-
-		result = space.update_routes("new-count")
-
-		# Should be 4: root_group + 1 group + 2 pages
-		self.assertEqual(result["updated_count"], 4)
-
-	def test_update_routes_with_similar_route_prefix(self):
-		"""Test that routes with similar prefixes don't get incorrectly updated."""
-		# Create first space (using unique routes to avoid conflict with default 'docs' route)
-		space1, _, _, _, _ = self._create_space_with_tree("prefix-test", "Prefix Test Space")
-
-		# Create second space with similar prefix
-		root2 = self._create_wiki_document("Prefix Test API Root", "prefix-test-api", is_group=True)
-		page2 = self._create_wiki_document("API Page", "prefix-test-api/endpoints", parent=root2.name)
-		space2 = self._create_wiki_space("Prefix Test API Space", "prefix-test-api", root2.name)
-
-		# Update first space's routes
-		space1.update_routes("documentation")
-
-		# Second space's routes should remain unchanged
-		space2.reload()
-		self.assertEqual(space2.route, "prefix-test-api")
-
-		page2.reload()
-		self.assertEqual(page2.route, "prefix-test-api/endpoints")
+	def tearDown(self):
+		frappe.db.rollback()

--- a/wiki/wiki/doctype/wiki_space/wiki_space.js
+++ b/wiki/wiki/doctype/wiki_space/wiki_space.js
@@ -5,7 +5,7 @@ frappe.ui.form.on("Wiki Space", {
   refresh(frm) {
     frm.add_web_link(`/${frm.doc.route}`, __("See on website"));
 
-    frm.add_custom_button("Clone Wiki Space", () => {
+    frm.add_custom_button(__("Clone Wiki Space"), () => {
       frappe.prompt(
         [
           {

--- a/wiki/wiki/doctype/wiki_space/wiki_space.js
+++ b/wiki/wiki/doctype/wiki_space/wiki_space.js
@@ -6,9 +6,31 @@ frappe.ui.form.on("Wiki Space", {
     frm.add_web_link(`/${frm.doc.route}`, __("See on website"));
 
     frm.add_custom_button("Clone Wiki Space", () => {
-      frappe.prompt("Enter new Wiki Space's route", ({ value }) => {
-        frm.call("clone_wiki_space_in_background", { new_space_route: value });
-      });
+      frappe.prompt(
+        [
+          {
+            fieldname: "new_space_route",
+            fieldtype: "Data",
+            label: __("New Space Route"),
+            reqd: 1,
+            description: __("Enter the new base route (without leading slash)"),
+          },
+        ],
+        (values) => {
+          frm
+            .call({
+              method: "clone_wiki_space_in_background",
+              args: { new_space_route: values.new_space_route },
+              freeze: true,
+              freeze_message: __("Starting clone..."),
+            })
+            .then(() => {
+              frappe.msgprint(__("Cloning started in background."));
+            });
+        },
+        __("Clone Wiki Space"),
+        __("Start Cloning"),
+      );
     });
 
     if (frm.doc.root_group) {

--- a/wiki/wiki/doctype/wiki_space/wiki_space.py
+++ b/wiki/wiki/doctype/wiki_space/wiki_space.py
@@ -3,6 +3,20 @@
 import frappe
 from frappe.model.document import Document
 
+_CHILD_ROW_META_FIELDS = {
+	"name",
+	"parent",
+	"parenttype",
+	"parentfield",
+	"idx",
+	"owner",
+	"creation",
+	"modified",
+	"modified_by",
+	"docstatus",
+	"doctype",
+}
+
 
 class WikiSpace(Document):
 	# begin: auto-generated types
@@ -195,3 +209,151 @@ class WikiSpace(Document):
 		)
 
 		return len(doc_names)
+
+	@frappe.whitelist()
+	def clone_wiki_space_in_background(self, new_space_route: str) -> dict:
+		frappe.only_for("Wiki Manager")
+
+		new_route = (new_space_route or "").strip().strip("/")
+		if not new_route:
+			frappe.throw("Route cannot be empty")
+
+		if new_route == self.route:
+			frappe.throw("New route is the same as current route")
+
+		existing = frappe.db.get_value("Wiki Space", {"route": new_route}, "name")
+		if existing:
+			frappe.throw(f"Route '{new_route}' is already used by another Wiki Space")
+
+		if not self.root_group:
+			frappe.throw("This Wiki Space has no root group. Migrate to Version 3 first.")
+
+		frappe.enqueue(
+			"wiki.wiki.doctype.wiki_space.wiki_space.clone_wiki_space",
+			queue="long",
+			job_name=f"clone_wiki_space:{self.name}:{new_route}",
+			wiki_space=self.name,
+			new_space_route=new_route,
+			user=frappe.session.user,
+		)
+
+		return {"status": "queued", "new_route": new_route}
+
+
+def clone_wiki_space(wiki_space: str, new_space_route: str, user: str | None = None) -> str:
+	if user:
+		frappe.set_user(user)
+
+	space = frappe.get_doc("Wiki Space", wiki_space)
+	if not space.root_group:
+		frappe.throw("This Wiki Space has no root group. Migrate to Version 3 first.")
+
+	new_route = (new_space_route or "").strip().strip("/")
+	if not new_route:
+		frappe.throw("Route cannot be empty")
+
+	new_space = _create_space_copy(space, new_route)
+	_clone_wiki_documents(space, new_space)
+	return new_space.name
+
+
+def _create_space_copy(space: Document, new_route: str) -> Document:
+	new_space = frappe.new_doc("Wiki Space")
+
+	for field in space.meta.fields:
+		if field.fieldtype in ("Section Break", "Tab Break", "Column Break", "HTML", "Button"):
+			continue
+		if field.fieldtype == "Table":
+			continue
+		if field.fieldname in ("route", "root_group", "main_revision"):
+			continue
+		new_space.set(field.fieldname, space.get(field.fieldname))
+
+	new_space.route = new_route
+
+	for field in space.meta.fields:
+		if field.fieldtype != "Table":
+			continue
+		fieldname = field.fieldname
+		new_space.set(fieldname, [])
+		for row in space.get(fieldname) or []:
+			row_data = row.as_dict()
+			for key in _CHILD_ROW_META_FIELDS:
+				row_data.pop(key, None)
+			new_space.append(fieldname, row_data)
+
+	new_space.insert(ignore_permissions=True)
+	return new_space
+
+
+def _clone_wiki_documents(space: Document, new_space: Document) -> None:
+	root = frappe.get_doc("Wiki Document", space.root_group)
+	docs = frappe.get_all(
+		"Wiki Document",
+		fields=[
+			"name",
+			"title",
+			"slug",
+			"route",
+			"is_group",
+			"is_published",
+			"is_private",
+			"is_external_link",
+			"external_url",
+			"content",
+			"parent_wiki_document",
+			"sort_order",
+			"lft",
+		],
+		filters={"lft": (">=", root.lft), "rgt": ("<=", root.rgt)},
+		order_by="lft asc",
+	)
+
+	old_root = space.root_group
+	new_root = new_space.root_group
+	name_map = {old_root: new_root}
+
+	for doc in docs:
+		if doc["name"] == old_root:
+			continue
+
+		parent_name = name_map.get(doc.get("parent_wiki_document"))
+		new_doc = frappe.new_doc("Wiki Document")
+		new_doc.title = doc.get("title")
+		new_doc.slug = doc.get("slug")
+		new_doc.route = _clone_route(doc.get("route"), space.route, new_space.route)
+		new_doc.is_group = doc.get("is_group")
+		new_doc.is_published = doc.get("is_published")
+		new_doc.is_private = doc.get("is_private")
+		new_doc.is_external_link = doc.get("is_external_link")
+		new_doc.external_url = doc.get("external_url")
+		new_doc.content = doc.get("content")
+		new_doc.parent_wiki_document = parent_name
+
+		new_doc.insert(ignore_permissions=True)
+
+		sort_order = doc.get("sort_order")
+		if sort_order is not None:
+			frappe.db.set_value(
+				"Wiki Document",
+				new_doc.name,
+				"sort_order",
+				sort_order,
+				update_modified=False,
+			)
+
+		name_map[doc["name"]] = new_doc.name
+
+
+def _clone_route(route: str, old_base: str, new_base: str):
+	if not route or not old_base or not new_base:
+		return route
+
+	if route == old_base:
+		return new_base
+
+	prefix = f"{old_base}/"
+	if route.startswith(prefix):
+		return f"{new_base}{route[len(old_base):]}"
+
+	return route

--- a/wiki/wiki/doctype/wiki_space/wiki_space.py
+++ b/wiki/wiki/doctype/wiki_space/wiki_space.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2023, Frappe and contributors
 # For license information, please see license.txt
 import frappe
+from frappe import _
 from frappe.model.document import Document
 
 _CHILD_ROW_META_FIELDS = {
@@ -147,19 +148,19 @@ class WikiSpace(Document):
 		new_route = new_route.strip().strip("/")
 
 		if not new_route:
-			frappe.throw("Route cannot be empty")
+			frappe.throw(_("Route cannot be empty"))
 
 		old_route = self.route
 		if old_route == new_route:
-			frappe.throw("New route is the same as current route")
+			frappe.throw(_("New route is the same as current route"))
 
 		if not self.root_group:
-			frappe.throw("This Wiki Space has no root group. Migrate to Version 3 first.")
+			frappe.throw(_("This Wiki Space has no root group. Migrate to Version 3 first."))
 
 		# Check for conflicts
 		existing = frappe.db.get_value("Wiki Space", {"route": new_route, "name": ("!=", self.name)})
 		if existing:
-			frappe.throw(f"Route '{new_route}' is already used by another Wiki Space")
+			frappe.throw(_("Route '{0}' is already used by another Wiki Space").format(new_route))
 
 		# Get all documents under this space
 		descendants = get_descendants_of("Wiki Document", self.root_group, ignore_permissions=True)
@@ -216,17 +217,17 @@ class WikiSpace(Document):
 
 		new_route = (new_space_route or "").strip().strip("/")
 		if not new_route:
-			frappe.throw("Route cannot be empty")
+			frappe.throw(_("Route cannot be empty"))
 
 		if new_route == self.route:
-			frappe.throw("New route is the same as current route")
+			frappe.throw(_("New route is the same as current route"))
 
 		existing = frappe.db.get_value("Wiki Space", {"route": new_route}, "name")
 		if existing:
-			frappe.throw(f"Route '{new_route}' is already used by another Wiki Space")
+			frappe.throw(_("Route '{0}' is already used by another Wiki Space").format(new_route))
 
 		if not self.root_group:
-			frappe.throw("This Wiki Space has no root group. Migrate to Version 3 first.")
+			frappe.throw(_("This Wiki Space has no root group. Migrate to Version 3 first."))
 
 		frappe.enqueue(
 			"wiki.wiki.doctype.wiki_space.wiki_space.clone_wiki_space",
@@ -242,15 +243,15 @@ class WikiSpace(Document):
 
 def clone_wiki_space(wiki_space: str, new_space_route: str, user: str | None = None) -> str:
 	if user:
-		frappe.set_user(user)
+		frappe.set_user(user)  # nosemgrep: frappe-setuser - restoring user context in background job
 
 	space = frappe.get_doc("Wiki Space", wiki_space)
 	if not space.root_group:
-		frappe.throw("This Wiki Space has no root group. Migrate to Version 3 first.")
+		frappe.throw(_("This Wiki Space has no root group. Migrate to Version 3 first."))
 
 	new_route = (new_space_route or "").strip().strip("/")
 	if not new_route:
-		frappe.throw("Route cannot be empty")
+		frappe.throw(_("Route cannot be empty"))
 
 	new_space = _create_space_copy(space, new_route)
 	_clone_wiki_documents(space, new_space)

--- a/wiki/wiki/markdown.py
+++ b/wiki/wiki/markdown.py
@@ -156,6 +156,93 @@ IMAGE_PATTERN = re.compile(
 	r'!\[([^\]]*)\]\(([^)"\s]+(?:\s[^)]*)?)\)',
 )
 
+VIDEO_EXTENSIONS = (
+	".mp4",
+	".webm",
+	".ogg",
+	".mov",
+	".avi",
+	".mkv",
+	".m4v",
+)
+
+
+def _is_video_url(url: str) -> bool:
+	"""Return True when URL points to a known video file extension."""
+	if not url:
+		return False
+
+	clean_url = str(url).split("?", 1)[0].split("#", 1)[0].lower()
+	return clean_url.endswith(VIDEO_EXTENSIONS)
+
+
+SCRIPT_TAG_PATTERN = re.compile(r"(?is)<script\b[^>]*>.*?</script>|</?script\b[^>]*>")
+
+
+def _remove_script_tags(value: str | None) -> str:
+	"""Remove only <script> tags/content; keep all other HTML unchanged."""
+	if not value:
+		return ""
+	return SCRIPT_TAG_PATTERN.sub("", str(value))
+
+
+# Match full-line markdown image syntax with optional title:
+# ![alt](url) or ![alt](url "title")
+VIDEO_MARKDOWN_PATTERN = re.compile(
+	r'^!\[(?P<alt>[^\]]*)\]\((?P<url>[^)"\s]+)(?:\s+"(?P<title>[^"]*)")?\)[ \t]*$',
+	re.MULTILINE,
+)
+
+
+def _generate_video_html(url: str, alt: str = "", title: str = "") -> str:
+	"""Generate HTML for a video block."""
+	safe_alt = _remove_script_tags(alt)
+	safe_title = _remove_script_tags(title)
+	title_attr = f' title="{safe_title}"' if safe_title else ""
+	data_alt_attr = f' data-alt="{safe_alt}"' if safe_alt else ""
+	return (
+		f'<div data-type="video-block" data-src="{url}"{data_alt_attr}>'
+		f'<video src="{url}" controls preload="metadata"{title_attr}>'
+		f'<source src="{url}" />'
+		"</video></div>"
+	)
+
+
+def _process_videos_with_placeholders(content: str) -> tuple[str, list[dict], str]:
+	"""
+	Replace full-line video markdown with placeholders so videos render as block HTML.
+	"""
+	videos = []
+	placeholder_prefix = "WIKIVIDEOPLACEHOLDER"
+
+	def replacer(match):
+		url = match.group("url") or ""
+		if not _is_video_url(url):
+			return match.group(0)
+
+		idx = len(videos)
+		videos.append(
+			{
+				"url": url,
+				"alt": match.group("alt") or "",
+				"title": match.group("title") or "",
+			}
+		)
+		# Force paragraph break around video block
+		return f"\n\n{placeholder_prefix}{idx}END\n\n"
+
+	return VIDEO_MARKDOWN_PATTERN.sub(replacer, content), videos, placeholder_prefix
+
+
+def _replace_video_placeholders(html: str, videos: list[dict], placeholder_prefix: str) -> str:
+	"""Replace video placeholders with block video HTML."""
+	for idx, video in enumerate(videos):
+		placeholder = f"{placeholder_prefix}{idx}END"
+		video_html = _generate_video_html(video["url"], video["alt"], video["title"])
+		html = html.replace(f"<p>{placeholder}</p>", video_html)
+		html = html.replace(placeholder, video_html)
+	return html
+
 
 def _encode_image_url_spaces(content: str) -> str:
 	"""
@@ -239,6 +326,27 @@ class WikiRenderer(mistune.HTMLRenderer):
 
 		return f'<h{level} id="{slug}">{text}</h{level}>\n'
 
+	def image(self, text: str, url: str, title: str | None = None) -> str:
+		"""Render video URLs as HTML5 video blocks; others as normal images."""
+		src = self.safe_url(url)
+		alt = _remove_script_tags(text)
+		safe_title = _remove_script_tags(title)
+
+		if _is_video_url(url):
+			title_attr = f' title="{safe_title}"' if safe_title else ""
+			data_alt_attr = f' data-alt="{alt}"' if alt else ""
+			return (
+				f'<div data-type="video-block" data-src="{src}"{data_alt_attr}>'
+				f'<video src="{src}" controls preload="metadata"{title_attr}>'
+				f'<source src="{src}" />'
+				"</video></div>"
+			)
+
+		s = f'<img src="{src}" alt="{alt}"'
+		if safe_title:
+			s += f' title="{safe_title}"'
+		return s + " />"
+
 	def get_headings(self) -> list:
 		"""Return the list of h2/h3 headings extracted during rendering."""
 		return self._headings
@@ -276,11 +384,17 @@ def render_markdown_with_toc(content: str) -> tuple[str, list]:
 	# Step 2: Extract callouts and replace with placeholders
 	processed_content, callouts, placeholder_prefix = _process_callouts_with_placeholders(processed_content)
 
-	# Step 3: Render markdown (placeholders will be wrapped in <p> tags)
+	# Step 3: Extract video blocks and replace with placeholders
+	processed_content, videos, video_placeholder_prefix = _process_videos_with_placeholders(processed_content)
+
+	# Step 4: Render markdown (placeholders may be wrapped in <p> tags)
 	html = md(processed_content)
 
-	# Step 4: Replace placeholders with actual callout HTML
+	# Step 5: Replace callout placeholders with actual callout HTML
 	html = _replace_callout_placeholders(html, callouts, placeholder_prefix, md)
+
+	# Step 6: Replace video placeholders with block video HTML
+	html = _replace_video_placeholders(html, videos, video_placeholder_prefix)
 
 	# Get the headings extracted during rendering
 	headings = renderer.get_headings()

--- a/wiki/wiki/test_markdown.py
+++ b/wiki/wiki/test_markdown.py
@@ -152,12 +152,33 @@ class TestImageCaptionSupport(unittest.TestCase):
 		self.assertNotIn("<figure", result)
 		self.assertNotIn("<figcaption", result)
 
-	def test_image_alt_escapes_html(self):
-		"""Test that alt text is properly escaped."""
+	def test_image_alt_removes_script_tags(self):
+		"""Strip script tags from alt text."""
 		result = render_markdown("![<script>alert('xss')</script>](/files/test.jpg)")
 
-		# Script tags should be escaped, not rendered as HTML
+		# Script tags should not be present in rendered HTML
 		self.assertNotIn("<script>alert", result)
+
+	def test_image_alt_and_title_preserve_non_script_html(self):
+		"""Keep non-script HTML in alt/title, but strip script tags only."""
+		result = render_markdown(
+			'![<b>Bold Alt</b><script>alert(1)</script>](/files/test.jpg "<i>Title</i><script>x</script>")'
+		)
+
+		self.assertIn('alt="<b>Bold Alt</b>"', result)
+		self.assertIn('title="<i>Title</i>"', result)
+		self.assertNotIn("<script>", result)
+
+	def test_video_markdown_renders_as_block_not_inline_caption_pattern(self):
+		"""Video markdown should render as a block and not merge with following italic text."""
+		content = """![Demo Video](/files/demo-video.mp4)
+*This should remain italic text*"""
+		result = render_markdown(content)
+
+		self.assertIn('<div data-type="video-block" data-src="/files/demo-video.mp4"', result)
+		self.assertIn('<video src="/files/demo-video.mp4" controls preload="metadata">', result)
+		self.assertIn("<p><em>This should remain italic text</em></p>", result)
+		self.assertNotIn("<p><div data-type=", result)
 
 	def test_multiple_images_with_captions(self):
 		"""Test multiple images with captions."""


### PR DESCRIPTION
Also adds Video block support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clone Space: duplicate a Wiki Space into a new route; runs in background with notifications and preserves nested content and routes.
  * Video support: Markdown and renderer now support embedded HTML5 video blocks.
  * Editor video workflow: upload/insert videos from toolbar and slash menu; improved editor popups and media handling.

* **Tests**
  * Added tests for space cloning, video rendering, and a large-tree reorder performance test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->