### PR TITLE
fix: handle duplicate doc_key during merge

### DIFF
--- a/wiki/frappe_wiki/doctype/wiki_change_request/wiki_change_request.py
+++ b/wiki/frappe_wiki/doctype/wiki_change_request/wiki_change_request.py
@@ -1195,8 +1195,13 @@ def apply_merge_revision(space: Document, revision: Document) -> None:
 		if doc_key in key_to_name:
 			doc = frappe.get_doc("Wiki Document", key_to_name[doc_key])
 		else:
-			doc = frappe.new_doc("Wiki Document")
-			doc.doc_key = doc_key
+			# Check if a document with this doc_key exists outside the space's tree
+			existing_name = frappe.db.get_value("Wiki Document", {"doc_key": doc_key}, "name")
+			if existing_name:
+				doc = frappe.get_doc("Wiki Document", existing_name)
+			else:
+				doc = frappe.new_doc("Wiki Document")
+				doc.doc_key = doc_key
 
 		doc.title = item.get("title")
 		doc.slug = item.get("slug") or cleanup_page_name(item.get("title") or "")


### PR DESCRIPTION
## Summary
- `apply_merge_revision` builds its `key_to_name` map only from documents within the space's nested set range (`lft`/`rgt`). If a Wiki Document with a given `doc_key` exists outside that range (e.g. orphaned after a tree rebuild or a prior failed merge), the code would attempt to insert a new document, hitting the unique constraint on `doc_key` and raising `UniqueValidationError`.
- Added a global lookup for existing documents with the same `doc_key` before creating a new one. If found, the existing document is loaded and updated (re-parented into the space) instead of inserting a duplicate.

## Test plan
- [ ] Reproduce by having a Wiki Document with a `doc_key` that exists in the DB but falls outside the space's nested set tree, then merge a change request referencing that `doc_key`
- [ ] Verify the merge completes without `UniqueValidationError`
- [ ] Verify the document is correctly re-parented into the space after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wiki document merge handling to prevent duplicate documents by reusing existing documents when available, resulting in a cleaner repository structure and more efficient document management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->