### PR TITLE
fix: correct wiki edit links redirection

### DIFF
--- a/e2e/tests/sidebar.spec.ts
+++ b/e2e/tests/sidebar.spec.ts
@@ -277,7 +277,7 @@ test.describe('Public Sidebar', () => {
 			await expect(lastUpdated).toContainText('Last updated');
 
 			// Get initial edit link href
-			const editLinks = publicPage.locator('#wiki-edit-link');
+			const editLinks = publicPage.locator('.wiki-edit-link, #wiki-edit-link');
 			const initialEditHref = await editLinks.first().getAttribute('href');
 
 			// Click the second page link in sidebar

--- a/wiki/templates/wiki/includes/sidebar.html
+++ b/wiki/templates/wiki/includes/sidebar.html
@@ -170,9 +170,11 @@
                     Alpine.store('pageContent').markdown = data.raw_markdown;
                 }
 
-                // Update edit link
-                const editLink = document.getElementById('wiki-edit-link');
-                if (editLink) editLink.setAttribute('href', data.edit_link);
+                // Update edit links
+                const editLinks = document.querySelectorAll('.wiki-edit-link');
+                if (editLinks) {
+                    editLinks.forEach(link => link.setAttribute('href', data.edit_link));
+                }
 
                 // Update last updated
                 const lastUpdatedEl = document.getElementById('wiki-last-updated');

--- a/wiki/templates/wiki/macros/buttons.html
+++ b/wiki/templates/wiki/macros/buttons.html
@@ -133,8 +133,7 @@
         <div class="inline-flex rounded-lg border border-[var(--outline-gray-2)] overflow-hidden">
             <!-- Edit button (navigates to edit page) -->
             <a href="{{ edit_href }}"
-               id="wiki-edit-link"
-               class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-[var(--ink-gray-7)] bg-[var(--surface-white)] hover:bg-[var(--surface-gray-1)] transition-colors duration-200">
+               class="wiki-edit-link inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-[var(--ink-gray-7)] bg-[var(--surface-white)] hover:bg-[var(--surface-gray-1)] transition-colors duration-200">
                 {{ render_icon("edit", "w-4 h-4") }}
                 <span>{{ edit_text }}</span>
             </a>


### PR DESCRIPTION
**Fix**: Wiki Edit Links

**Problem:**
The wiki edit links were not functioning correctly, potentially leading to incorrect redirection.

**Solution:**
This commit addresses and resolves the issue with wiki edit links, ensuring they now work as intended and guide users to the proper editing section.

**Impact:**
Users can now reliably access the edit functionality for wiki pages, improving the overall user experience and content management.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Edit links now update consistently across all instances on a page so every edit option reflects the current target.
  * Link markup standardized to recognize and refresh multiple edit elements, improving navigation and editing consistency.
  * Improved reliability when multiple edit links are present so the correct edit target is resolved predictably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->