### PR TITLE
fix: allow Ctrl/Cmd+Click to open sidebar links in new tab

### DIFF
--- a/wiki/templates/wiki/macros/sidebar_tree.html
+++ b/wiki/templates/wiki/macros/sidebar_tree.html
@@ -38,7 +38,7 @@
                     {% else %}
                         {# Page/leaf item #}
                         <a href="/{{ node.route }}"
-                           @click.prevent="$store.navigation.navigateTo('{{ node.route }}')"
+                           @click.prevent.exact="$store.navigation.navigateTo('{{ node.route }}')"
                            @mouseenter="$store.navigation.prefetch('{{ node.route }}')"
                            class="wiki-item-content wiki-link group w-full flex items-center h-7 rounded px-2 text-[var(--ink-gray-7)] no-underline transition-all duration-200"
                            :class="$store.navigation.currentRoute === '{{ node.route }}' ? 'bg-[var(--surface-selected)] shadow-sm text-[var(--ink-gray-9)]' : 'hover:bg-[var(--surface-gray-2)]'"


### PR DESCRIPTION
## Problem
Sidebar navigation links were not respecting browser modifier keys. When users tried to open links in new tabs using Ctrl+Click (Windows/Linux) or Cmd+Click (Mac), which was not working, breaking expected browser behavior.

## Root Cause
The `@click.prevent` directive was unconditionally preventing all default link behaviors, including modifier key combinations.

## Solution
- Replaced `@click.prevent` method with @click.prevent.exact`

## Changes
- `sidebar_tree.html`: Replaced `@click.prevent` with `@click.prevent.exact` and method call