### PR TITLE
fix: archive btn not visible in contribution banner

### DIFF
--- a/frontend/src/components/ContributionBanner.vue
+++ b/frontend/src/components/ContributionBanner.vue
@@ -41,17 +41,6 @@
 				</Button>
 			</template>
 
-			<template v-else-if="changeRequestStatus === 'In Review'">
-				<Button
-					variant="outline"
-					size="sm"
-					:loading="archiveChangeRequestResource?.loading"
-					@click="$emit('withdraw')"
-				>
-					{{ __('Archive') }}
-				</Button>
-			</template>
-
 			<template v-else-if="changeRequestStatus === 'Approved'">
 				<span class="text-sm font-medium text-green-700">
 					{{ __('Approved! Ready to merge.') }}
@@ -65,6 +54,17 @@
 					{{ __('Merge') }}
 				</Button>
 			</template>
+
+			<Button
+				v-if="canShowArchive"
+				variant="outline"
+				theme="red"
+				size="sm"
+				:loading="archiveChangeRequestResource?.loading"
+				@click="$emit('withdraw')"
+			>
+				{{ __('Archive') }}
+			</Button>
 		</div>
 
 		<Dialog v-model="showChangesDialog" :options="{ size: 'lg' }">
@@ -226,6 +226,10 @@ function confirmSubmit(closeDialog) {
 const canShowMerge = computed(() => {
 	return props.canMerge && props.changeCount > 0;
 });
+
+const canShowArchive = computed(() => {
+	return props.changeCount > 0 && (props.changeRequestStatus === 'Draft' || props.changeRequestStatus === 'In Review' || props.changeRequestStatus === 'Changes Requested');
+})
 
 function getChangeIcon(changeType) {
 	switch (changeType) {

--- a/frontend/src/pages/SpaceDetails.vue
+++ b/frontend/src/pages/SpaceDetails.vue
@@ -456,6 +456,10 @@ async function handleArchiveChangeRequest() {
     try {
         await archiveChangeRequest();
         toast.success(__('Change request archived'));
+        currentChangeRequest.value = null;
+        await initChangeRequest();
+        await loadChanges();
+        await refreshTree();
     } catch (error) {
         toast.error(error.messages?.[0] || __('Error archiving change request'));
     }


### PR DESCRIPTION
Archive btn should be visible in Draft, In Review, Changes Requested state

**Before:**

Archive button not visible:

<img width="1512" height="857" alt="image" src="https://github.com/user-attachments/assets/e0a93e04-355c-4e1b-995b-aa74a78ac93c" />


**After:**

https://github.com/user-attachments/assets/d72864a1-4aef-42d5-8108-20e978943c24



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Archive action is now available in additional change request states: when drafts have changes, during review, or when revisions are requested.

* **Bug Fixes**
  * Archive operation now properly refreshes the interface to reflect the archived state immediately after completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->