### PR TITLE
fix: prevent DiffViewer Shadow DOM from overlaying dialogs

### DIFF
--- a/frontend/src/pages/ContributionReview.vue
+++ b/frontend/src/pages/ContributionReview.vue
@@ -112,7 +112,7 @@
 						</div>
 
 						<div v-if="expandedChanges.has(change.doc_key)" class="border-t border-outline-gray-2">
-							<div class="p-4">
+							<div class="p-4 relative z-0 isolate">
 								<DiffViewer
 									v-if="diffsByDocKey[change.doc_key]"
 									:old-content="diffsByDocKey[change.doc_key]?.base?.content || ''"


### PR DESCRIPTION
closes #510

## Problem
The Request Changes dialog was being overlaid by the DiffViewer component, making it inaccessible. This occurred because the `@pierre/diffs` library uses Shadow DOM under the hood, which can escape normal CSS stacking contexts and overlay other elements.

## Root Cause
Shadow DOM creates its own isolated rendering context that doesn't respect parent z-index hierarchies, allowing diff viewer elements to appear above dialogs.

## Solution
Wrapped the DiffViewer component with Tailwind utility classes (`isolate`, `relative`, `z-0`) to create a new stacking context. This contains all Shadow DOM elements within their proper boundary, preventing them from overlaying the dialog.

## Changes
- Add `isolate relative z-0` classes to DiffViewer container wrapper

## Testing
- ✅ Request Changes dialog displays correctly above expanded diffs
- ✅ DiffViewer renders properly without visual regressions
- ✅ Dialog interactions work as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved visual presentation and layout structure in the diff review section. Enhanced positioning and stacking context of interface elements to create better visual hierarchy and organization, resulting in a more polished and refined appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->