### PR TITLE
fix: wiki user unable to view editor sidebar

### DIFF
--- a/wiki/frappe_wiki/doctype/wiki_revision/wiki_revision.py
+++ b/wiki/frappe_wiki/doctype/wiki_revision/wiki_revision.py
@@ -115,7 +115,7 @@ def create_overlay_revision(
 	revision.tree_hash = base.tree_hash
 	revision.content_hash = base.content_hash
 	revision.doc_count = base.doc_count
-	revision.insert()
+	revision.insert(ignore_permissions=True)
 	return revision
 
 
@@ -361,7 +361,7 @@ def ensure_overlay_item(revision: str, doc_key: str) -> str | None:
 	new_item.order_index = base_item.order_index
 	new_item.content_blob = base_item.content_blob
 	new_item.is_deleted = base_item.is_deleted
-	new_item.insert()
+	new_item.insert(ignore_permissions=True)
 	return new_item.name
 
 


### PR DESCRIPTION
Added Ignore permissions not sidebar content is visible
<img width="337" height="790" alt="Screenshot 2026-02-17 at 11 32 41 AM" src="https://github.com/user-attachments/assets/8594833d-29a6-4eea-9784-1e25b9a12913" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wiki revision operations to work correctly in restricted permission contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->