### PR TITLE
fix: auto refresh page while editing

### DIFF
--- a/frontend/src/components/DraftContributionPanel.vue
+++ b/frontend/src/components/DraftContributionPanel.vue
@@ -184,7 +184,6 @@ async function saveContent(content) {
 		);
 		toast.success(__('Draft updated'));
 		await loadChanges();
-		await loadCrPage();
 		emit('refresh');
 	} catch (error) {
 		console.error('Error saving draft:', error);

--- a/frontend/src/components/WikiDocumentPanel.vue
+++ b/frontend/src/components/WikiDocumentPanel.vue
@@ -232,7 +232,6 @@ async function saveContent(content) {
 		});
 		toast.success(__('Draft updated'));
 		await loadChanges();
-		await loadCrPage();
 		emit('refresh');
 	} catch (error) {
 		console.error('Error saving change request:', error);


### PR DESCRIPTION
Earlier after editing anything in wiki page Page gets reload and goes to top of screen.
Now I have removed loadcrPage() so it dont get's reload on every save

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the post-save workflow in draft and document panels to optimize data synchronization behavior. Page reloading after save operations has been adjusted to rely on incremental updates and refresh events instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->