### PR TITLE
fix: bubble menu hidden behind sticky toolbar

### DIFF
--- a/frontend/src/components/WikiEditor.vue
+++ b/frontend/src/components/WikiEditor.vue
@@ -583,7 +583,6 @@ onUnmounted(() => {
     display: flex;
     flex-direction: column;
     height: 100%;
-    isolation: isolate; /* Create new stacking context to contain z-index */
 }
 
 .wiki-editor-loading {

--- a/frontend/src/components/tiptap-extensions/WikiBubbleMenu.vue
+++ b/frontend/src/components/tiptap-extensions/WikiBubbleMenu.vue
@@ -175,6 +175,8 @@ function toggleLink() {
 <style scoped>
 .wiki-bubble-menu {
     display: flex;
+    position: relative;
+    z-index: 50; 
 }
 
 .bubble-menu-buttons {


### PR DESCRIPTION
## Problem
The wiki bubble menu was being rendered behind the sticky toolbar,
making text formatting options inaccessible when selecting text near
the top of the editor.

## Root Cause
Two compounding stacking context issues:

1. `isolation: isolate` on `.wiki-editor-container` was confining all
   child z-index values within the container, preventing them from
   painting above sibling elements.

2. `.wiki-bubble-menu` had no `position` or `z-index`, so it had no
   stacking context of its own to compete with the toolbar's
   `position: sticky; z-index: 40`.

Neither fix alone was sufficient — both needed to be addressed together.

## Changes
- `WikiEditor.vue` — removed `isolation: isolate` from `.wiki-editor-container`
- `WikiBubbleMenu.vue` — added `position: relative; z-index: 50` to `.wiki-bubble-menu`

## Testing
- Select text near the top of the editor — bubble menu should appear above the toolbar
- Verify toolbar dropdown menus still render correctly
- Verify slash command popup still renders correctly

## Now
<img width="1784" height="531" alt="image" src="https://github.com/user-attachments/assets/14fc773c-63f3-4c73-ac19-2c4b848c5c12" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted CSS stacking context and layering for wiki editor components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->