### PR TITLE
fix: dialog/popover elements stacking below the wiki components

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -8,7 +8,7 @@ setConfig("localTimezone", window.timezone?.user || null);
 
 <template>
 	<FrappeUIProvider>
-		<MainLayout>
+		<MainLayout class="isolate">
 			<router-view />
 		</MainLayout>
 	</FrappeUIProvider>


### PR DESCRIPTION
**Before:**

<img width="1512" height="857" alt="wiki-stacking-before" src="https://github.com/user-attachments/assets/8d38f742-0927-4e11-9891-0630e8c69da3" />

<img width="1512" height="857" alt="wiki-stacking-before-2" src="https://github.com/user-attachments/assets/99bacb6f-9d60-4e43-aca7-db8fc8e83616" />

**After:**

https://github.com/user-attachments/assets/f087e90c-9e5e-4f56-9371-69581fec4d99

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Applied styling enhancement to the application layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->