### PR TITLE
revert: bubble menu hidden behind sticky toolbar

### DIFF
--- a/frontend/src/components/WikiEditor.vue
+++ b/frontend/src/components/WikiEditor.vue
@@ -613,6 +613,7 @@ onUnmounted(() => {
     display: flex;
     flex-direction: column;
     height: 100%;
+    isolation: isolate; /* Create new stacking context to contain z-index */
 }
 
 .wiki-editor-loading {

--- a/frontend/src/components/tiptap-extensions/WikiBubbleMenu.vue
+++ b/frontend/src/components/tiptap-extensions/WikiBubbleMenu.vue
@@ -175,8 +175,6 @@ function toggleLink() {
 <style scoped>
 .wiki-bubble-menu {
     display: flex;
-    position: relative;
-    z-index: 50; 
 }
 
 .bubble-menu-buttons {


### PR DESCRIPTION
# Issue
<img width="2540" height="1031" alt="image" src="https://github.com/user-attachments/assets/93411750-fd88-43c7-923d-92867e8a2cd4" />

<img width="573" height="253" alt="image" src="https://github.com/user-attachments/assets/6942ebd7-b3ad-4d0e-a9b2-576748d23a26" />

- The sticky toolbar is rendering on top of the modal ("Create New Page") 
- The dropdown ("Unpublish") from the top-right toolbar is also likely clipping/overlapping incorrectly.

PR - #540 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved z-index layering and stacking context for the editor interface to ensure proper visual component layering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->