### PR TITLE
fix: don't optimize image uploads by default

### DIFF
--- a/frontend/src/components/WikiEditor.vue
+++ b/frontend/src/components/WikiEditor.vue
@@ -121,7 +121,6 @@ async function uploadFile(file) {
 		const isImage = file.type.includes('image');
 		const result = await fileUploader.upload(file, {
 			private: false,
-			optimize: isImage,
 		});
 
 		toast.success(`${isImage ? 'Image' : 'File'} uploaded successfully`);


### PR DESCRIPTION
Leads to low quality images in docs

Wiki can have a feature to convert images to webp later instead of relying on this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated file upload behavior for images to use default optimization settings instead of custom configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->