### PR TITLE
feat: disable merge during rearrange

### DIFF
--- a/frontend/src/components/ContributionBanner.vue
+++ b/frontend/src/components/ContributionBanner.vue
@@ -27,6 +27,8 @@
 					v-if="canShowMerge"
 					size="sm"
 					:loading="mergeResource?.loading"
+					:disabled="mergeDisabled"
+					:title="mergeButtonTitle"
 					@click="$emit('merge')"
 				>
 					{{ __('Merge') }}
@@ -49,6 +51,8 @@
 					v-if="canShowMerge"
 					size="sm"
 					:loading="mergeResource?.loading"
+					:disabled="mergeDisabled"
+					:title="mergeButtonTitle"
 					@click="$emit('merge')"
 				>
 					{{ __('Merge') }}
@@ -211,6 +215,10 @@ const props = defineProps({
 		type: Boolean,
 		default: false,
 	},
+	mergeDisabled: {
+		type: Boolean,
+		default: false,
+	},
 });
 
 const emit = defineEmits(['submit', 'withdraw', 'merge']);
@@ -225,6 +233,13 @@ function confirmSubmit(closeDialog) {
 
 const canShowMerge = computed(() => {
 	return props.canMerge && props.changeCount > 0;
+});
+
+const mergeButtonTitle = computed(() => {
+	if (props.mergeDisabled) {
+		return __('Please wait for reordering to finish before merging');
+	}
+	return '';
 });
 
 const canShowArchive = computed(() => {

--- a/frontend/src/components/NestedDraggable.vue
+++ b/frontend/src/components/NestedDraggable.vue
@@ -92,6 +92,7 @@
                         @rename="(n) => emit('rename', n)"
                         @external-link="(parent) => emit('external-link', parent)"
                         @edit-external-link="(el) => emit('edit-external-link', el)"
+                        @drag-state-change="handleNestedDragStateChange"
                         @update="handleNestedUpdate"
                     />
                     <!-- Empty group actions -->
@@ -122,7 +123,7 @@
 </template>
 
 <script setup>
-import { ref, watch, computed } from 'vue';
+import { ref, watch, computed, onBeforeUnmount } from 'vue';
 import { useRouter } from 'vue-router';
 import { useStorage } from '@vueuse/core';
 import { Dropdown, Badge, Button, toast } from 'frappe-ui';
@@ -168,7 +169,15 @@ const props = defineProps({
     },
 });
 
-const emit = defineEmits(['create', 'delete', 'update', 'rename', 'external-link', 'edit-external-link']);
+const emit = defineEmits([
+    'create',
+    'delete',
+    'update',
+    'rename',
+    'external-link',
+    'edit-external-link',
+    'drag-state-change',
+]);
 const router = useRouter();
 const { updatePage } = useChangeRequest();
 
@@ -250,6 +259,7 @@ function getTitleClass(element) {
 
 function onDragStart() {
     isDragging.value = true;
+    emit('drag-state-change', true);
     if (dragSettleTimer) {
         clearTimeout(dragSettleTimer);
         dragSettleTimer = null;
@@ -260,6 +270,8 @@ function onDragEnd() {
     if (dragSettleTimer) clearTimeout(dragSettleTimer);
     dragSettleTimer = setTimeout(() => {
         isDragging.value = false;
+        emit('drag-state-change', false);
+        dragSettleTimer = null;
     }, 1000);
 }
 
@@ -280,6 +292,10 @@ function handleChange(evt) {
 
 function handleNestedUpdate(payload) {
     emit('update', payload);
+}
+
+function handleNestedDragStateChange(state) {
+    emit('drag-state-change', state);
 }
 
 async function togglePublish(element) {
@@ -358,6 +374,14 @@ function getDropdownOptions(element) {
 
     return options;
 }
+
+onBeforeUnmount(() => {
+    if (dragSettleTimer) {
+        clearTimeout(dragSettleTimer);
+        dragSettleTimer = null;
+    }
+    emit('drag-state-change', false);
+});
 </script>
 
 <style scoped>

--- a/frontend/src/components/WikiDocumentList.vue
+++ b/frontend/src/components/WikiDocumentList.vue
@@ -179,7 +179,7 @@
 </template>
 
 <script setup>
-import { ref, toRef, computed, onBeforeUnmount } from 'vue';
+import { ref, toRef, computed, watch, onBeforeUnmount } from 'vue';
 import { useStorage } from '@vueuse/core';
 import { toast, FormControl } from 'frappe-ui';
 import NestedDraggable from './NestedDraggable.vue';
@@ -273,21 +273,18 @@ let pendingReorder = null;
 let reorderInFlight = false;
 const isDragActive = ref(false);
 const isReorderBusy = ref(false);
+const isReorderActive = computed(() => isDragActive.value || isReorderBusy.value);
 
-function emitReorderState() {
-	emit('reorder-state-change', isDragActive.value || isReorderBusy.value);
-}
-
-function setReorderBusy(value) {
-	if (isReorderBusy.value === value) return;
-	isReorderBusy.value = value;
-	emitReorderState();
-}
+watch(
+	isReorderActive,
+	(value) => {
+		emit('reorder-state-change', value);
+	},
+	{ immediate: true },
+);
 
 function handleDragStateChange(isDragging) {
-	if (isDragActive.value === isDragging) return;
 	isDragActive.value = isDragging;
-	emitReorderState();
 }
 
 function handleTreeUpdate(payload) {
@@ -297,7 +294,7 @@ function handleTreeUpdate(payload) {
 	}
 
 	if (payload.type === 'added' || payload.type === 'moved') {
-		setReorderBusy(true);
+		isReorderBusy.value = true;
 		pendingReorder = payload;
 		if (reorderTimer) clearTimeout(reorderTimer);
 		reorderTimer = setTimeout(() => {
@@ -310,7 +307,7 @@ function handleTreeUpdate(payload) {
 async function flushReorder() {
 	if (reorderInFlight) return;
 	if (!pendingReorder) {
-		if (!reorderTimer) setReorderBusy(false);
+		if (!reorderTimer) isReorderBusy.value = false;
 		return;
 	}
 
@@ -327,7 +324,7 @@ async function flushReorder() {
 		if (pendingReorder) {
 			flushReorder();
 		} else if (!reorderTimer) {
-			setReorderBusy(false);
+			isReorderBusy.value = false;
 		}
 	}
 }

--- a/frontend/src/components/WikiDocumentList.vue
+++ b/frontend/src/components/WikiDocumentList.vue
@@ -39,6 +39,7 @@
 				@rename="openRenameDialog"
 				@external-link="openExternalLinkDialog"
 				@edit-external-link="openEditExternalLinkDialog"
+				@drag-state-change="handleDragStateChange"
 				@update="handleTreeUpdate"
 			/>
 		</div>
@@ -178,7 +179,7 @@
 </template>
 
 <script setup>
-import { ref, toRef, computed } from 'vue';
+import { ref, toRef, computed, onBeforeUnmount } from 'vue';
 import { useStorage } from '@vueuse/core';
 import { toast, FormControl } from 'frappe-ui';
 import NestedDraggable from './NestedDraggable.vue';
@@ -211,7 +212,7 @@ const props = defineProps({
 	},
 });
 
-const emit = defineEmits(['refresh']);
+const emit = defineEmits(['refresh', 'reorder-state-change']);
 const treeKey = computed(() => {
 	const getNodeIds = (nodes) => {
 		if (!nodes) return '';
@@ -270,6 +271,24 @@ const editExternalLinkNode = ref(null);
 let reorderTimer = null;
 let pendingReorder = null;
 let reorderInFlight = false;
+const isDragActive = ref(false);
+const isReorderBusy = ref(false);
+
+function emitReorderState() {
+	emit('reorder-state-change', isDragActive.value || isReorderBusy.value);
+}
+
+function setReorderBusy(value) {
+	if (isReorderBusy.value === value) return;
+	isReorderBusy.value = value;
+	emitReorderState();
+}
+
+function handleDragStateChange(isDragging) {
+	if (isDragActive.value === isDragging) return;
+	isDragActive.value = isDragging;
+	emitReorderState();
+}
 
 function handleTreeUpdate(payload) {
 	if (payload.type === 'refresh') {
@@ -278,16 +297,22 @@ function handleTreeUpdate(payload) {
 	}
 
 	if (payload.type === 'added' || payload.type === 'moved') {
+		setReorderBusy(true);
 		pendingReorder = payload;
 		if (reorderTimer) clearTimeout(reorderTimer);
 		reorderTimer = setTimeout(() => {
+			reorderTimer = null;
 			flushReorder();
 		}, 1000);
 	}
 }
 
 async function flushReorder() {
-	if (!pendingReorder || reorderInFlight) return;
+	if (reorderInFlight) return;
+	if (!pendingReorder) {
+		if (!reorderTimer) setReorderBusy(false);
+		return;
+	}
 
 	const payload = pendingReorder;
 	pendingReorder = null;
@@ -301,6 +326,8 @@ async function flushReorder() {
 		reorderInFlight = false;
 		if (pendingReorder) {
 			flushReorder();
+		} else if (!reorderTimer) {
+			setReorderBusy(false);
 		}
 	}
 }
@@ -542,4 +569,16 @@ async function updateExternalLink(close) {
 		toast.error(error.messages?.[0] || __('Error updating external link'));
 	}
 }
+
+onBeforeUnmount(() => {
+	if (reorderTimer) {
+		clearTimeout(reorderTimer);
+		reorderTimer = null;
+	}
+	pendingReorder = null;
+	reorderInFlight = false;
+	isDragActive.value = false;
+	isReorderBusy.value = false;
+	emit('reorder-state-change', false);
+});
 </script>

--- a/frontend/src/pages/SpaceDetails.vue
+++ b/frontend/src/pages/SpaceDetails.vue
@@ -45,6 +45,7 @@
                     :selected-page-id="currentPageId"
                     :selected-draft-key="currentDraftKey"
                     @refresh="refreshTree"
+                    @reorder-state-change="handleReorderStateChange"
                 />
             </div>
 
@@ -65,6 +66,7 @@
                 :archiveChangeRequestResource="archiveChangeRequestResource"
                 :mergeResource="mergeChangeRequestResource"
                 :canMerge="isManager"
+                :mergeDisabled="isTreeReordering"
                 @submit="handleSubmitChangeRequest"
                 @withdraw="handleArchiveChangeRequest"
                 @merge="handleMergeChangeRequest"
@@ -278,6 +280,7 @@ const updatingPublishSetting = ref(false);
 
 const sidebarRef = ref(null);
 const { sidebarWidth, sidebarResizing, startResize } = useSidebarResize(sidebarRef);
+const isTreeReordering = ref(false);
 
 const currentPageId = computed(() => route.params.pageId || null);
 const currentDraftKey = computed(() => route.params.docKey || null);
@@ -438,6 +441,10 @@ async function refreshTree() {
     }
     await crTree.reload();
     await loadChanges();
+}
+
+function handleReorderStateChange(isReordering) {
+    isTreeReordering.value = Boolean(isReordering);
 }
 
 async function handleSubmitChangeRequest() {


### PR DESCRIPTION

https://github.com/user-attachments/assets/cbe1460e-ef4a-4a9b-9035-b04eff6aec29



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added drag and reorder state tracking for wiki trees with user-facing feedback.
  * Merge buttons are now automatically disabled during active reordering operations to prevent conflicts.
  * Reorder operation status is now propagated through the component hierarchy for coordinated state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->