### PR TITLE
fix: sidebar-title-icon-misalignment

### DIFF
--- a/frontend/src/components/NestedDraggable.vue
+++ b/frontend/src/components/NestedDraggable.vue
@@ -47,7 +47,7 @@
                         <LucideFileText v-else class="size-4 text-ink-gray-5 flex-shrink-0" />
 
                         <span
-                            class="text-sm truncate"
+                            class="text-sm truncate flex-1 min-w-0"
                             :class="getTitleClass(element)"
                         >
                             {{ element.title }}


### PR DESCRIPTION
Before -  title and icon are misaligned 

<img width="245" height="165" alt="Screenshot 2026-02-19 at 6 03 22 PM" src="https://github.com/user-attachments/assets/11e0ae81-6a43-4220-9d97-cc4ba84162c8" />

After - 

https://github.com/user-attachments/assets/801ef580-3495-4ef7-ad06-1b17055c59a2

Closes- #555 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved title layout flexibility to enable dynamic width adjustment within flex containers while preserving text truncation capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->