### PR TITLE
fix: resolve group docs to first child in SPA navigation

### DIFF
--- a/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
@@ -542,11 +542,24 @@ def get_breadcrumbs(name: str) -> dict:
 @frappe.whitelist(allow_guest=True)
 def get_page_data(route: str) -> dict:
 	"""Returns all data needed to render a page dynamically for client-side navigation."""
-	doc_name = frappe.db.get_value("Wiki Document", {"route": route, "is_published": 1}, "name")
-	if not doc_name:
+	document = frappe.db.get_value(
+		"Wiki Document", {"route": route, "is_published": 1}, ["name", "is_group"], as_dict=True
+	)
+	if not document:
 		frappe.throw(frappe._("Page not found"), frappe.DoesNotExistError)
 
-	doc = frappe.get_cached_doc("Wiki Document", doc_name)
+	# If this is a group document (folder), resolve to its first published child
+	if document.is_group:
+		child_docs = get_descendants_of(
+			"Wiki Document", document.name, order_by="lft asc, sort_order desc", ignore_permissions=True
+		)
+		for child_name in child_docs:
+			child_doc = frappe.get_cached_doc("Wiki Document", child_name)
+			if not child_doc.is_group and child_doc.is_published:
+				return child_doc.get_web_context()
+		frappe.throw(frappe._("Page not found"), frappe.DoesNotExistError)
+
+	doc = frappe.get_cached_doc("Wiki Document", document.name)
 	return doc.get_web_context()
 
 

--- a/wiki/templates/wiki/includes/sidebar.html
+++ b/wiki/templates/wiki/includes/sidebar.html
@@ -136,10 +136,11 @@
                     const data = await response.json();
 
                     if (data.message) {
+                        const resolvedRoute = data.message.route || route;
                         this.updateContent(data.message);
-                        this.currentRoute = route;
+                        this.currentRoute = resolvedRoute;
                         if (pushState) {
-                            history.pushState({ route }, '', '/' + route);
+                            history.pushState({ route: resolvedRoute }, '', '/' + resolvedRoute);
                         }
                     } else {
                         throw new Error('Invalid response');


### PR DESCRIPTION
- `get_page_data()` now detects group/folder documents and returns the first published child

- Search indexing already excludes groups. Rebuild index if stale entries exist?

closes #550 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation handling for group pages—when accessing a group, the app now correctly resolves and displays the first published child page
  * Fixed browser URL synchronization to ensure the displayed URL matches the actual page content
  * Enhanced error messaging when pages are inaccessible or not found

<!-- end of auto-generated comment: release notes by coderabbit.ai -->