### PR TITLE
fix: add dark mode syntax highlighting to wiki editor

### DIFF
--- a/frontend/src/components/WikiEditor.vue
+++ b/frontend/src/components/WikiEditor.vue
@@ -894,4 +894,103 @@ onUnmounted(() => {
 .wiki-editor-content .hljs-property {
     color: #005cc5;
 }
+
+/* Syntax highlighting - Dark theme overrides (matches public page theme) */
+[data-theme="dark"] .wiki-editor-content .hljs-comment,
+[data-theme="dark"] .wiki-editor-content .hljs-quote {
+    color: #8b949e;
+}
+
+[data-theme="dark"] .wiki-editor-content .hljs-keyword,
+[data-theme="dark"] .wiki-editor-content .hljs-selector-tag {
+    color: #ff7b72;
+}
+
+[data-theme="dark"] .wiki-editor-content .hljs-deletion {
+    color: #ffa198;
+    background-color: rgba(248, 81, 73, 0.15);
+}
+
+[data-theme="dark"] .wiki-editor-content .hljs-string,
+[data-theme="dark"] .wiki-editor-content .hljs-doctag {
+    color: #a5d6ff;
+}
+
+[data-theme="dark"] .wiki-editor-content .hljs-addition {
+    color: #7ee787;
+    background-color: rgba(46, 160, 67, 0.15);
+}
+
+[data-theme="dark"] .wiki-editor-content .hljs-number,
+[data-theme="dark"] .wiki-editor-content .hljs-literal {
+    color: #79c0ff;
+}
+
+[data-theme="dark"] .wiki-editor-content .hljs-symbol,
+[data-theme="dark"] .wiki-editor-content .hljs-bullet {
+    color: #ffa657;
+}
+
+[data-theme="dark"] .wiki-editor-content .hljs-function {
+    color: #d2a8ff;
+}
+
+[data-theme="dark"] .wiki-editor-content .hljs-title {
+    color: #d2a8ff;
+}
+
+[data-theme="dark"] .wiki-editor-content .hljs-built_in {
+    color: #79c0ff;
+}
+
+[data-theme="dark"] .wiki-editor-content .hljs-class .hljs-title,
+[data-theme="dark"] .wiki-editor-content .hljs-type {
+    color: #7ee787;
+}
+
+[data-theme="dark"] .wiki-editor-content .hljs-attr {
+    color: #79c0ff;
+}
+
+[data-theme="dark"] .wiki-editor-content .hljs-variable,
+[data-theme="dark"] .wiki-editor-content .hljs-template-variable {
+    color: #ffa657;
+}
+
+[data-theme="dark"] .wiki-editor-content .hljs-name {
+    color: #7ee787;
+}
+
+[data-theme="dark"] .wiki-editor-content .hljs-selector-id,
+[data-theme="dark"] .wiki-editor-content .hljs-selector-class {
+    color: #d2a8ff;
+}
+
+[data-theme="dark"] .wiki-editor-content .hljs-regexp {
+    color: #a5d6ff;
+}
+
+[data-theme="dark"] .wiki-editor-content .hljs-link {
+    color: #79c0ff;
+}
+
+[data-theme="dark"] .wiki-editor-content .hljs-meta {
+    color: #8b949e;
+}
+
+[data-theme="dark"] .wiki-editor-content .hljs-operator {
+    color: #ff7b72;
+}
+
+[data-theme="dark"] .wiki-editor-content .hljs-punctuation {
+    color: #c9d1d9;
+}
+
+[data-theme="dark"] .wiki-editor-content .hljs-params {
+    color: #c9d1d9;
+}
+
+[data-theme="dark"] .wiki-editor-content .hljs-property {
+    color: #79c0ff;
+}
 </style>


### PR DESCRIPTION
Closes #578 

Before:

<img width="2022" height="1190" alt="CleanShot 2026-03-09 at 16 44 13@2x" src="https://github.com/user-attachments/assets/7cd6546e-82d7-4268-be29-697b1b1f600f" />


After:

<img width="2024" height="1190" alt="CleanShot 2026-03-09 at 16 44 34@2x" src="https://github.com/user-attachments/assets/c4d71e3d-dfde-43f6-b6eb-c5f5dd74b7a3" />

(matches rendered pages)

