### PR TITLE
fix: Avoid timestamp mismatch error during migration

### DIFF
--- a/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
@@ -579,6 +579,8 @@ def _sync_document_to_revision(doc):
 		return
 	if getattr(frappe.flags, "in_reorder_wiki_documents", False):
 		return
+	if getattr(frappe.flags, "in_wiki_v3_migration", False):
+		return
 
 	from wiki.api.wiki_space import _get_wiki_space_for_document, _sync_main_revision_for_space
 

--- a/wiki/wiki/doctype/wiki_space/wiki_space.py
+++ b/wiki/wiki/doctype/wiki_space/wiki_space.py
@@ -77,19 +77,21 @@ class WikiSpace(Document):
 		if self.root_group:
 			return  # Migration already done
 
-		self.create_root_group()
-		self.save()
+		frappe.flags.in_wiki_v3_migration = True
+		try:
+			self.create_root_group()
+			self.save()
 
-		sidebar = self.wiki_sidebars
-		if not sidebar:
-			return
+			sidebar = self.wiki_sidebars
+			if not sidebar:
+				return
 
-		groups, group_order = self._group_sidebar_items(sidebar)
+			groups, group_order = self._group_sidebar_items(sidebar)
 
-		for sort_order, group_label in enumerate(group_order):
-			self._create_group_with_pages(group_label, groups[group_label], sort_order)
-
-		self.save()
+			for sort_order, group_label in enumerate(group_order):
+				self._create_group_with_pages(group_label, groups[group_label], sort_order)
+		finally:
+			frappe.flags.in_wiki_v3_migration = False
 
 	def _group_sidebar_items(self, sidebar):
 		"""Group sidebar items by parent_label while maintaining order"""


### PR DESCRIPTION
Hi,

First of all, thanks for the new Wiki version, it looks great !

Currently, when migrating a site with an older version of the Wiki application, I get the following error from the following patch `migrate_to_new_tree_document_structure.py` :

```
Error: Wiki Space bed0eacc22 has been modified after you have opened it (2026-03-17 09:26:36.246034, 2026-03-17 09:26:36.252558). Please refresh to get the latest document.
```

This PR aims at fixing it by passing a flag during the migration in a similar way than `in_reorder_wiki_documents` and `in_apply_merge_revision`.

Thanks for your feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Wiki v3 migration reliability with improved safeguards to prevent conflicting operations during the migration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->