### PR TITLE
fix: reload document after save in v3 migration

### DIFF
--- a/wiki/wiki/doctype/wiki_space/wiki_space.py
+++ b/wiki/wiki/doctype/wiki_space/wiki_space.py
@@ -79,6 +79,7 @@ class WikiSpace(Document):
 
 		self.create_root_group()
 		self.save()
+		self.reload()
 
 		sidebar = self.wiki_sidebars
 		if not sidebar:


### PR DESCRIPTION
## Summary
- Fixes `TimestampMismatchError` during the v3 migration patch (`migrate_to_new_tree_document_structure`)
- The `migrate_to_v3` method calls `save()` twice — once after creating the root group and again after creating child groups. The first save updates the `modified` timestamp in the database but the in-memory document retains the old timestamp, causing the error on the second save.
- Adds `self.reload()` after the first save to sync the in-memory document with the database before the second save


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Wiki space migration now properly synchronizes document state during the upgrade process to maintain data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->