### PR TITLE
fix: strip trailing whitespace in code blocks

### DIFF
--- a/wiki/public/js/code-blocks.js
+++ b/wiki/public/js/code-blocks.js
@@ -13,6 +13,12 @@ function initCodeBlocks() {
         if (pre.classList.contains('code-block-enhanced')) return;
         pre.classList.add('code-block-enhanced');
 
+        // Strip trailing whitespace so it doesn't render as empty rows.
+        const lastChild = codeBlock.lastChild;
+        if (lastChild && lastChild.nodeType === Node.TEXT_NODE) {
+            lastChild.nodeValue = lastChild.nodeValue.replace(/\s+$/, '\n');
+        }
+
         // Get language from hljs class
         const classes = codeBlock.className.split(' ');
         let language = '';

--- a/wiki/wiki/markdown.py
+++ b/wiki/wiki/markdown.py
@@ -345,6 +345,11 @@ class WikiRenderer(mistune.HTMLRenderer):
 		self._heading_slugs = {}  # Track used slugs to avoid duplicates
 		self._headings = []  # Track headings for TOC
 
+	def block_code(self, code: str, info: str | None = None) -> str:
+		# Trim trailing whitespace the author left inside the fence — spaces,
+		# tabs, and blank lines all render as phantom empty rows in <pre>.
+		return super().block_code(code.rstrip() + "\n", info)
+
 	def heading(self, text: str, level: int, **attrs) -> str:
 		"""Render heading with slugified ID for anchor links."""
 		# Generate base slug from heading text

--- a/wiki/wiki/test_markdown.py
+++ b/wiki/wiki/test_markdown.py
@@ -32,6 +32,12 @@ class TestMarkdownRenderer(unittest.TestCase):
 		self.assertIn('href="https://example.com"', result)
 		self.assertIn("Link text", result)
 
+	def test_code_block_strips_trailing_whitespace(self):
+		"""Trailing whitespace inside a fence shouldn't render as phantom empty rows."""
+		md = "```\nyarn install\nyarn dev   \n```\n"
+		result = render_markdown(md)
+		self.assertIn("<pre><code>yarn install\nyarn dev\n</code></pre>", result)
+
 
 class TestHeadingSlugGeneration(unittest.TestCase):
 	"""Tests for heading ID/slug generation."""


### PR DESCRIPTION
<img width="1980" height="1484" alt="image" src="https://github.com/user-attachments/assets/0e03465c-3b12-435c-8d8e-626656ee2cec" />


