### PR TITLE
chore: enable HTML syntax highlighting for head_html field

### DIFF
--- a/wiki/wiki/doctype/wiki_settings/wiki_settings.json
+++ b/wiki/wiki/doctype/wiki_settings/wiki_settings.json
@@ -99,14 +99,15 @@
    "description": "Will be included in all public Wiki pages",
    "fieldname": "head_html",
    "fieldtype": "Code",
-   "label": "&lt;head&gt; HTML"
+   "label": "&lt;head&gt; HTML",
+   "options": "HTML"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-04-28 17:34:33.386653",
+ "modified": "2026-04-28 17:55:14.973293",
  "modified_by": "Administrator",
  "module": "Wiki",
  "name": "Wiki Settings",


### PR DESCRIPTION
## Summary
- Sets `options: "HTML"` on the `head_html` field in Wiki Settings so the Code editor renders HTML syntax highlighting when editing the snippet.

## Test plan
- [ ] Open Wiki Settings → \<head\> HTML field, confirm the editor highlights HTML/CSS/JS instead of falling back to plain text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)