### PR TITLE
fix: make v3 wiki migration resumable

### DIFF
--- a/wiki/patches.txt
+++ b/wiki/patches.txt
@@ -11,8 +11,8 @@ wiki.wiki.doctype.wiki_page.patches.convert_wiki_content_to_markdown
 wiki.wiki.doctype.wiki_page.patches.update_escaped_code_content
 wiki.wiki.doctype.wiki_page.patches.update_escaped_chars
 wiki.wiki.doctype.wiki_space.patches.wiki_navbar_app_switcher_migration
-wiki.wiki.doctype.wiki_space.patches.v3.migrate_to_new_tree_document_structure
+wiki.wiki.doctype.wiki_space.patches.v3.migrate_to_new_tree_document_structure #2026-05-07 rerun-patch
 wiki.wiki.doctype.wiki_space.patches.v3.assign_wiki_user_to_active_users
-wiki.wiki.doctype.wiki_space.patches.v3.migrate_orphan_pages_to_wiki_document
+wiki.wiki.doctype.wiki_space.patches.v3.migrate_orphan_pages_to_wiki_document #2026-05-07 rerun-patch
 wiki.frappe_wiki.doctype.wiki_revision.patches.convert_open_crs_to_overlay
 wiki.frappe_wiki.doctype.wiki_content_blob.patches.unescape_iframe_embeds

--- a/wiki/patches.txt
+++ b/wiki/patches.txt
@@ -11,8 +11,8 @@ wiki.wiki.doctype.wiki_page.patches.convert_wiki_content_to_markdown
 wiki.wiki.doctype.wiki_page.patches.update_escaped_code_content
 wiki.wiki.doctype.wiki_page.patches.update_escaped_chars
 wiki.wiki.doctype.wiki_space.patches.wiki_navbar_app_switcher_migration
-wiki.wiki.doctype.wiki_space.patches.v3.migrate_to_new_tree_document_structure #2026-05-07 rerun-patch
+wiki.wiki.doctype.wiki_space.patches.v3.migrate_to_new_tree_document_structure
 wiki.wiki.doctype.wiki_space.patches.v3.assign_wiki_user_to_active_users
-wiki.wiki.doctype.wiki_space.patches.v3.migrate_orphan_pages_to_wiki_document #2026-05-07 rerun-patch
+wiki.wiki.doctype.wiki_space.patches.v3.migrate_orphan_pages_to_wiki_document
 wiki.frappe_wiki.doctype.wiki_revision.patches.convert_open_crs_to_overlay
 wiki.frappe_wiki.doctype.wiki_content_blob.patches.unescape_iframe_embeds

--- a/wiki/wiki/doctype/wiki_page/wiki_page.py
+++ b/wiki/wiki/doctype/wiki_page/wiki_page.py
@@ -12,15 +12,29 @@ class WikiPage(WebsiteGenerator):
 			)
 		)
 
-	def _migrate_to_wiki_document(self):
-		frappe.get_doc(
-			{
-				"doctype": "Wiki Document",
-				"title": self.title,
-				"content": self.content,
-				"route": self.route,
-				"is_group": 0,
-				"is_published": self.published,
-				"is_private": not self.allow_guest,
-			}
-		).insert()
+	def _migrate_to_wiki_document(self, parent_wiki_document=None, sort_order=None):
+		existing_name = frappe.db.get_value("Wiki Document", {"route": self.route, "is_group": 0}, "name")
+		if existing_name:
+			wiki_document = frappe.get_doc("Wiki Document", existing_name)
+		else:
+			wiki_document = frappe.new_doc("Wiki Document")
+
+		wiki_document.title = self.title
+		wiki_document.content = self.content
+		wiki_document.route = self.route
+		wiki_document.is_group = 0
+		wiki_document.is_published = self.published
+		wiki_document.is_private = not self.allow_guest
+
+		if parent_wiki_document is not None:
+			wiki_document.parent_wiki_document = parent_wiki_document
+
+		if sort_order is not None:
+			wiki_document.sort_order = sort_order
+
+		if existing_name:
+			wiki_document.save(ignore_permissions=True)
+		else:
+			wiki_document.insert(ignore_permissions=True)
+
+		return wiki_document

--- a/wiki/wiki/doctype/wiki_space/patches/v3/migrate_orphan_pages_to_wiki_document.py
+++ b/wiki/wiki/doctype/wiki_space/patches/v3/migrate_orphan_pages_to_wiki_document.py
@@ -2,16 +2,7 @@ import frappe
 
 
 def execute():
-	migrated_routes = frappe.db.get_all("Wiki Document", pluck="route")
-	# Filter out None values - SQL NOT IN fails when list contains NULL
-	migrated_routes = [r for r in migrated_routes if r is not None]
-	orphan_pages = frappe.db.get_all(
-		"Wiki Page",
-		filters={"route": ["not in", migrated_routes]},
-		pluck="name",
-	)
-
-	for page in orphan_pages:
+	for page in frappe.db.get_all("Wiki Page", pluck="name"):
 		wiki_page = frappe.get_doc("Wiki Page", page)
 		wiki_page._migrate_to_wiki_document()
 		frappe.db.commit()

--- a/wiki/wiki/doctype/wiki_space/patches/v3/migrate_to_new_tree_document_structure.py
+++ b/wiki/wiki/doctype/wiki_space/patches/v3/migrate_to_new_tree_document_structure.py
@@ -2,7 +2,7 @@ import frappe
 
 
 def execute():
-	spaces = frappe.db.get_all("Wiki Space", filters={"root_group": ["is", "not set"]}, pluck="name")
+	spaces = frappe.db.get_all("Wiki Space", pluck="name")
 	for space in spaces:
 		frappe.get_doc("Wiki Space", space).migrate_to_v3()
 		frappe.db.commit()

--- a/wiki/wiki/doctype/wiki_space/test_wiki_space.py
+++ b/wiki/wiki/doctype/wiki_space/test_wiki_space.py
@@ -3,7 +3,12 @@
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
+from frappe.utils.nestedset import get_descendants_of
 
+from wiki.wiki.doctype.wiki_space.patches.v3 import (
+	migrate_orphan_pages_to_wiki_document,
+	migrate_to_new_tree_document_structure,
+)
 from wiki.wiki.doctype.wiki_space.wiki_space import clone_wiki_space
 
 
@@ -88,6 +93,216 @@ class TestWikiSpaceClone(FrappeTestCase):
 		self.assertEqual(new_page["route"], expected_route)
 		self.assertEqual(new_page["content"], self.page_doc.content)
 		self.assertEqual(new_page["parent_wiki_document"], new_group["name"])
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+
+class TestWikiSpaceMigration(FrappeTestCase):
+	def setUp(self):
+		frappe.set_user("Administrator")
+
+	def create_legacy_wiki_page(self, route: str, title: str, content: str, published=1, allow_guest=1):
+		page = frappe.get_doc(
+			{
+				"doctype": "Wiki Page",
+				"title": title,
+				"route": route,
+				"content": content,
+				"published": published,
+				"allow_guest": allow_guest,
+			}
+		)
+		page.db_insert()
+		return page
+
+	def create_legacy_space(self, route: str, sidebar_rows: list[dict]):
+		space = frappe.get_doc(
+			{
+				"doctype": "Wiki Space",
+				"space_name": f"Legacy Space {frappe.generate_hash(length=6)}",
+				"route": route,
+			}
+		)
+		for row in sidebar_rows:
+			space.append("wiki_sidebars", row)
+		return space.insert()
+
+	def test_migrate_to_v3_is_idempotent_and_resumable(self):
+		page_one = self.create_legacy_wiki_page(
+			route=f"legacy-page-{frappe.generate_hash(length=6)}",
+			title="Legacy Page One",
+			content="Page one content",
+		)
+		page_two = self.create_legacy_wiki_page(
+			route=f"legacy-page-{frappe.generate_hash(length=6)}",
+			title="Legacy Page Two",
+			content="Page two content",
+			allow_guest=0,
+		)
+		space = self.create_legacy_space(
+			route=f"space-{frappe.generate_hash(length=6)}",
+			sidebar_rows=[
+				{"wiki_page": page_one.name, "parent_label": "Getting Started"},
+				{"wiki_page": page_two.name, "parent_label": "Getting Started"},
+			],
+		)
+
+		self.assertEqual(get_descendants_of("Wiki Document", space.root_group, ignore_permissions=True), [])
+
+		space.migrate_to_v3()
+		space.reload()
+
+		first_descendants = get_descendants_of("Wiki Document", space.root_group, ignore_permissions=True)
+		self.assertEqual(len(first_descendants), 3)
+
+		group_name = frappe.db.get_value(
+			"Wiki Document",
+			{
+				"parent_wiki_document": space.root_group,
+				"is_group": 1,
+				"route": f"{space.route}/getting-started",
+			},
+			"name",
+		)
+		self.assertTrue(group_name)
+
+		page_one_doc = frappe.get_doc(
+			"Wiki Document",
+			frappe.db.get_value("Wiki Document", {"route": page_one.route, "is_group": 0}, "name"),
+		)
+		page_two_doc = frappe.get_doc(
+			"Wiki Document",
+			frappe.db.get_value("Wiki Document", {"route": page_two.route, "is_group": 0}, "name"),
+		)
+		self.assertEqual(page_one_doc.parent_wiki_document, group_name)
+		self.assertEqual(page_one_doc.sort_order, 0)
+		self.assertEqual(page_two_doc.parent_wiki_document, group_name)
+		self.assertEqual(page_two_doc.sort_order, 1)
+		self.assertEqual(page_two_doc.is_private, 1)
+
+		space.migrate_to_v3()
+		second_descendants = get_descendants_of("Wiki Document", space.root_group, ignore_permissions=True)
+
+		self.assertEqual(first_descendants, second_descendants)
+		self.assertEqual(
+			frappe.db.count("Wiki Document", {"route": page_one.route, "is_group": 0}),
+			1,
+		)
+		self.assertEqual(
+			frappe.db.count("Wiki Document", {"route": f"{space.route}/getting-started", "is_group": 1}),
+			1,
+		)
+
+	def test_migrate_to_v3_repairs_partial_migration(self):
+		page_one = self.create_legacy_wiki_page(
+			route=f"partial-page-{frappe.generate_hash(length=6)}",
+			title="Partial Page One",
+			content="Fresh content",
+		)
+		page_two = self.create_legacy_wiki_page(
+			route=f"partial-page-{frappe.generate_hash(length=6)}",
+			title="Partial Page Two",
+			content="Second content",
+		)
+		space = self.create_legacy_space(
+			route=f"partial-space-{frappe.generate_hash(length=6)}",
+			sidebar_rows=[
+				{"wiki_page": page_one.name, "parent_label": "Docs"},
+				{"wiki_page": page_two.name, "parent_label": "Docs"},
+			],
+		)
+
+		group_doc = frappe.get_doc(
+			{
+				"doctype": "Wiki Document",
+				"title": "Docs",
+				"route": f"{space.route}/docs",
+				"is_group": 1,
+				"is_published": 1,
+				"parent_wiki_document": space.root_group,
+				"sort_order": 0,
+			}
+		).insert()
+		stale_doc = frappe.get_doc(
+			{
+				"doctype": "Wiki Document",
+				"title": "Stale Title",
+				"route": page_one.route,
+				"is_group": 0,
+				"is_published": 0,
+				"is_private": 1,
+				"content": "stale",
+				"parent_wiki_document": group_doc.name,
+				"sort_order": 99,
+			}
+		).insert()
+
+		space.migrate_to_v3()
+
+		stale_doc.reload()
+		self.assertEqual(stale_doc.title, page_one.title)
+		self.assertEqual(stale_doc.content, page_one.content)
+		self.assertEqual(stale_doc.is_published, page_one.published)
+		self.assertEqual(stale_doc.is_private, 0)
+		self.assertEqual(stale_doc.sort_order, 0)
+
+		page_two_name = frappe.db.get_value("Wiki Document", {"route": page_two.route, "is_group": 0}, "name")
+		self.assertTrue(page_two_name)
+		self.assertEqual(frappe.db.count("Wiki Document", {"parent_wiki_document": group_doc.name}), 2)
+
+	def test_v3_patch_migrates_spaces_even_when_root_group_exists(self):
+		page = self.create_legacy_wiki_page(
+			route=f"patch-page-{frappe.generate_hash(length=6)}",
+			title="Patch Page",
+			content="Patch content",
+		)
+		space = self.create_legacy_space(
+			route=f"patch-space-{frappe.generate_hash(length=6)}",
+			sidebar_rows=[{"wiki_page": page.name, "parent_label": "Guides"}],
+		)
+
+		self.assertTrue(space.root_group)
+		self.assertEqual(get_descendants_of("Wiki Document", space.root_group, ignore_permissions=True), [])
+
+		migrate_to_new_tree_document_structure.execute()
+
+		self.assertEqual(
+			frappe.db.count("Wiki Document", {"route": page.route, "is_group": 0}),
+			1,
+		)
+		self.assertEqual(
+			frappe.db.count("Wiki Document", {"route": f"{space.route}/guides", "is_group": 1}),
+			1,
+		)
+
+	def test_orphan_patch_upserts_existing_documents(self):
+		page = self.create_legacy_wiki_page(
+			route=f"orphan-page-{frappe.generate_hash(length=6)}",
+			title="Orphan Page",
+			content="Canonical content",
+			allow_guest=0,
+		)
+		existing_doc = frappe.get_doc(
+			{
+				"doctype": "Wiki Document",
+				"title": "Old Title",
+				"route": page.route,
+				"is_group": 0,
+				"is_published": 0,
+				"is_private": 0,
+				"content": "old content",
+			}
+		).insert()
+
+		migrate_orphan_pages_to_wiki_document.execute()
+
+		existing_doc.reload()
+		self.assertEqual(existing_doc.title, page.title)
+		self.assertEqual(existing_doc.content, page.content)
+		self.assertEqual(existing_doc.is_private, 1)
+		self.assertEqual(existing_doc.is_published, page.published)
+		self.assertEqual(frappe.db.count("Wiki Document", {"route": page.route, "is_group": 0}), 1)
 
 	def tearDown(self):
 		frappe.db.rollback()

--- a/wiki/wiki/doctype/wiki_space/wiki_space.js
+++ b/wiki/wiki/doctype/wiki_space/wiki_space.js
@@ -80,10 +80,10 @@ frappe.ui.form.on("Wiki Space", {
       });
     }
 
-    if (!frm.doc.root_group) {
+    if ((frm.doc.wiki_sidebars || []).length) {
       frm.add_custom_button(__("Migrate to Version 3"), () => {
       frappe.confirm(
-        __("This will migrate the sidebar to tree-based Wiki Documents. Continue?"),
+        __("This will sync the sidebar into tree-based Wiki Documents. Continue?"),
         () => {
           frm.call("migrate_to_v3").then(() => {
             frappe.msgprint(__("Migration completed successfully."));

--- a/wiki/wiki/doctype/wiki_space/wiki_space.py
+++ b/wiki/wiki/doctype/wiki_space/wiki_space.py
@@ -74,12 +74,10 @@ class WikiSpace(Document):
 	@frappe.whitelist()
 	def migrate_to_v3(self):
 		frappe.only_for("Wiki Manager")
-		if self.root_group:
-			return  # Migration already done
-
-		self.create_root_group()
-		self.save()
-		self.reload()
+		if not self.root_group:
+			self.create_root_group()
+			self.save()
+			self.reload()
 
 		sidebar = self.wiki_sidebars
 		if not sidebar:
@@ -102,41 +100,45 @@ class WikiSpace(Document):
 		return groups, group_order
 
 	def _create_group_with_pages(self, group_label, items, sort_order):
-		"""Create a group Wiki Document and its child page documents"""
-		group_doc = frappe.get_doc(
+		"""Create or update a group Wiki Document and sync its child page documents."""
+		group_route = f"{self.route}/{frappe.scrub(group_label).replace('_', '-')}"
+		existing_name = frappe.db.get_value(
+			"Wiki Document",
 			{
-				"doctype": "Wiki Document",
-				"title": group_label,
-				"route": f"{self.route}/{frappe.scrub(group_label).replace('_', '-')}",
+				"route": group_route,
 				"is_group": 1,
-				"is_published": 1,
-				"content": "",
 				"parent_wiki_document": self.root_group,
-				"sort_order": sort_order,
-			}
+			},
+			"name",
 		)
-		group_doc.insert(ignore_permissions=True)
+		if existing_name:
+			group_doc = frappe.get_doc("Wiki Document", existing_name)
+		else:
+			group_doc = frappe.new_doc("Wiki Document")
+
+		group_doc.title = group_label
+		group_doc.route = group_route
+		group_doc.is_group = 1
+		group_doc.is_published = 1
+		group_doc.content = ""
+		group_doc.parent_wiki_document = self.root_group
+		group_doc.sort_order = sort_order
+
+		if existing_name:
+			group_doc.save(ignore_permissions=True)
+		else:
+			group_doc.insert(ignore_permissions=True)
 
 		for page_sort_order, item in enumerate(items):
 			self._create_page_document(item.wiki_page, group_doc.name, page_sort_order)
 
 	def _create_page_document(self, wiki_page_name, parent_group, sort_order):
-		"""Create a leaf Wiki Document from a Wiki Page"""
+		"""Create or update a leaf Wiki Document from a Wiki Page."""
 		wiki_page = frappe.get_cached_doc("Wiki Page", wiki_page_name)
-		leaf_doc = frappe.get_doc(
-			{
-				"doctype": "Wiki Document",
-				"title": wiki_page.title,
-				"route": wiki_page.route,
-				"is_group": 0,
-				"is_published": wiki_page.published,
-				"is_private": not wiki_page.allow_guest,
-				"content": wiki_page.content,
-				"parent_wiki_document": parent_group,
-				"sort_order": sort_order,
-			}
+		wiki_page._migrate_to_wiki_document(
+			parent_wiki_document=parent_group,
+			sort_order=sort_order,
 		)
-		leaf_doc.insert(ignore_permissions=True)
 
 	@frappe.whitelist()
 	def update_routes(self, new_route: str) -> dict:


### PR DESCRIPTION
## Summary
- make wiki page -> wiki document v3 migration resumable instead of treating `root_group` as a completion marker
- upsert migrated wiki documents by route so reruns repair partial migrations instead of skipping or duplicating rows
- add regression coverage for reruns, partial migrations, existing-route upserts, and patch execution when `root_group` already exists

## Testing
- `bench --site wiki.localhost run-tests --module wiki.wiki.doctype.wiki_space.test_wiki_space`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Version 3 migration with idempotent and resumable behavior
  * Enhanced document synchronization that upserts existing records instead of creating duplicates

* **Bug Fixes**
  * Updated migration button visibility in wiki space forms based on sidebar status

* **Tests**
  * Added comprehensive migration test coverage for idempotence, recovery scenarios, and data consistency during migration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->