### PR TITLE
fix: wiki pdf download misc fixes

### DIFF
--- a/wiki/frappe_wiki/print_format/standard_wiki_document/standard_wiki_document.html
+++ b/wiki/frappe_wiki/print_format/standard_wiki_document/standard_wiki_document.html
@@ -70,12 +70,16 @@
 	}
 
 	.wiki-document-content blockquote {
-		margin: 1.6em 0;
-		padding-left: 1em;
+		/* Reset Bootstrap defaults (full border + 10px 20px padding) that Frappe's print CSS layers in. */
+		border: 0;
 		border-left: 4px solid var(--gray-300);
+		padding: 0 0 0 1em;
+		margin: 1.6em 0;
+		font-size: inherit;
 		font-style: italic;
 		font-weight: 500;
 		color: var(--gray-800);
+		quotes: "\201C" "\201D" "\2018" "\2019";
 	}
 
 	.wiki-document-content blockquote p {

--- a/wiki/frappe_wiki/print_format/standard_wiki_document/standard_wiki_document.html
+++ b/wiki/frappe_wiki/print_format/standard_wiki_document/standard_wiki_document.html
@@ -19,6 +19,11 @@
 		color: var(--gray-600);
 	}
 
+	.wiki-document-eyebrow .sep {
+		margin: 0 0.4em;
+		color: var(--gray-400);
+	}
+
 	.wiki-document-title {
 		margin: 0 0 1rem;
 	}
@@ -65,18 +70,41 @@
 	}
 
 	.wiki-document-content blockquote {
-		margin: 1rem 0;
-		padding-left: 1rem;
-		border-left: 3px solid var(--gray-300);
+		margin: 1.6em 0;
+		padding-left: 1em;
+		border-left: 4px solid var(--gray-300);
+		font-style: italic;
+		font-weight: 500;
+		color: var(--gray-800);
+	}
+
+	.wiki-document-content blockquote p {
+		margin: 0.5em 0;
+	}
+
+	.wiki-document-content blockquote p:first-of-type::before {
+		content: open-quote;
+	}
+
+	.wiki-document-content blockquote p:last-of-type::after {
+		content: close-quote;
 	}
 </style>
 
-{% set wiki_space = doc.get_wiki_space() %}
+{% set breadcrumbs = doc.get_breadcrumbs() %}
+{% set space = breadcrumbs.space %}
+{# Skip the first ancestor — it's the wiki space's root group, already represented by the space name. #}
+{% set ancestors = breadcrumbs.ancestors[1:] if breadcrumbs.ancestors else [] %}
 <div class="page-break">
 	<div class="wiki-document-shell">
 		<header class="wiki-document-header">
-			{% if wiki_space %}
-			<div class="wiki-document-eyebrow">{{ wiki_space.space_name }}</div>
+			{% if space or ancestors %}
+			<div class="wiki-document-eyebrow">
+				{% if space %}{{ space.space_name }}{% endif %}
+				{% for ancestor in ancestors %}
+					<span class="sep">›</span>{{ ancestor.title }}
+				{% endfor %}
+			</div>
 			{% endif %}
 
 			<h1 class="wiki-document-title">{{ doc.title }}</h1>

--- a/wiki/templates/wiki/document.html
+++ b/wiki/templates/wiki/document.html
@@ -140,7 +140,6 @@
             // wikiDocument properties
             copied: false,
             downloadInProgress: false,
-            pageRoute: {{ doc.route | tojson }},
 
             get markdown() {
                 return this.$store.pageContent?.markdown || '';
@@ -161,7 +160,10 @@
                 if (this.downloadInProgress) return;
                 this.downloadInProgress = true;
 
-                const url = `/api/method/wiki.frappe_wiki.doctype.wiki_document.wiki_document.download_pdf?route=${encodeURIComponent(this.pageRoute)}`;
+                // Read the route fresh each click — SPA navigation updates window.location
+                // via history.pushState, so this stays in sync with the visible page.
+                const route = window.location.pathname.replace(/^\/+/, '');
+                const url = `/api/method/wiki.frappe_wiki.doctype.wiki_document.wiki_document.download_pdf?route=${encodeURIComponent(route)}`;
 
                 try {
                     const response = await fetch(url, { credentials: 'same-origin' });
@@ -172,7 +174,7 @@
                     const objectUrl = URL.createObjectURL(await response.blob());
                     const link = document.createElement('a');
                     link.href = objectUrl;
-                    link.download = `${this.pageRoute.split('/').pop() || 'wiki-document'}.pdf`;
+                    link.download = `${route.split('/').pop() || 'wiki-document'}.pdf`;
                     document.body.appendChild(link);
                     link.click();
                     link.remove();

--- a/wiki/templates/wiki/macros/buttons.html
+++ b/wiki/templates/wiki/macros/buttons.html
@@ -158,9 +158,10 @@
              class="absolute left-0 sm:left-auto sm:right-0 mt-10 w-72 bg-[var(--surface-white)] border border-[var(--outline-gray-1)] rounded-lg shadow-lg z-50 py-2">
 {% endmacro %}
 
-{# Dropdown row that triggers downloadPage() and reflects the downloadInProgress state. #}
+{# Dropdown row that triggers downloadPage() and reflects the downloadInProgress state.
+   Keeps the dropdown open while preparing the PDF so the loading state stays visible. #}
 {% macro download_action_item() %}
-<button @click="downloadPage(); open = false"
+<button @click="downloadPage().finally(() => open = false)"
         :disabled="downloadInProgress"
         :aria-busy="downloadInProgress"
         class="w-full flex items-start gap-3 px-4 py-3 text-left hover:bg-[var(--surface-gray-1)] transition-colors duration-200 cursor-pointer disabled:cursor-wait disabled:opacity-70">


### PR DESCRIPTION
## Summary

Follow-ups to #624:

- **Dropdown stays open while downloading.** The action item now closes the dropdown only *after* the download settles, so the loading spinner is actually visible.
- **Route is read on each click.** SPA navigation updates the URL via `history.pushState` but the cached `pageRoute` on the Alpine component was stale, so clicking download on page B would download page A. Now reads `window.location.pathname` at click time.
- **Breadcrumb in the PDF header.** Eyebrow now shows the full path `Space › Group › Subgroup` instead of just the space name.
- **Blockquote styling matches the public wiki.** Italic, thicker left rule, open/close quote marks on the first/last paragraph.

## Test plan
- [ ] Open a page in a space, click the actions dropdown → Download. Spinner stays visible until the file lands; dropdown closes after.
- [ ] Open page A, SPA-navigate to page B (sidebar click), click Download. Downloaded PDF is for page B, not A.
- [ ] PDF header shows breadcrumb trail when the page is nested under a group.
- [ ] PDF blockquotes look italic with a vertical bar and curly quotes around the text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced wiki PDF print format with improved breadcrumb separator styling, colors, margins, and refined blockquote appearance with better borders, padding, and typography.

* **Bug Fixes**
  * Fixed PDF download functionality to correctly derive the download file location from the current page pathname.
  * Download dropdown menu now remains open while file downloads complete for improved user feedback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frappe/wiki/pull/625)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->