### PR TITLE
fix(wiki): order feedback reactions bad -> good

### DIFF
--- a/wiki/templates/wiki/includes/feedback_widget.html
+++ b/wiki/templates/wiki/includes/feedback_widget.html
@@ -5,9 +5,9 @@
 
         <!-- Reaction Buttons (pill-shaped toggle group) -->
         {% set reactions = [
-            {"type": "Good", "mouth": '<path d="M8 14s1.5 2 4 2 4-2 4-2"/>'},
+            {"type": "Bad", "mouth": '<path d="M16 16s-1.5-2-4-2-4 2-4 2"/>'},
             {"type": "Ok", "mouth": '<line x1="8" y1="15" x2="16" y2="15"/>'},
-            {"type": "Bad", "mouth": '<path d="M16 16s-1.5-2-4-2-4 2-4 2"/>'}
+            {"type": "Good", "mouth": '<path d="M8 14s1.5 2 4 2 4-2 4-2"/>'}
         ] %}
         <fieldset class="inline-flex rounded-full bg-[var(--surface-gray-2)] p-0.5" role="radiogroup" aria-label="Feedback rating">
             {% for reaction in reactions %}


### PR DESCRIPTION
## Summary
Swap reaction order in wiki feedback widget from Good/Ok/Bad to Bad/Ok/Good.

<img width="389" height="163" alt="image" src="https://github.com/user-attachments/assets/5d65d89e-7f89-491d-b715-ec70a4adfa32" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reordered feedback widget reaction buttons to display in a new visual sequence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frappe/wiki/pull/628?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->