### PR TITLE
feat: PWA support with per-space offline reading

### DIFF
--- a/wiki/api/wiki_space.py
+++ b/wiki/api/wiki_space.py
@@ -1,6 +1,116 @@
+import hashlib
+import re
+
 import frappe
 from frappe import _
 from frappe.utils.nestedset import get_descendants_of
+
+# Matches the `src` attribute of `<img>` tags in rendered markdown — used to
+# enumerate embedded assets so the service worker can precache them.
+_IMG_SRC_RE = re.compile(r'<img\b[^>]*?\bsrc=["\']([^"\']+)["\']', re.IGNORECASE)
+
+
+@frappe.whitelist(
+	allow_guest=True, methods=["GET"]
+)  # nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method
+def get_space_manifest(space_route: str) -> dict:
+	"""Return the precache manifest for a Wiki Space, used by the PWA service worker.
+
+	Only published, public, internal leaf pages are listed. External links and
+	groups are omitted from `pages` but kept in the tree metadata so the sidebar
+	renders correctly offline.
+	"""
+	space = frappe.db.get_value(
+		"Wiki Space",
+		{"route": space_route, "is_published": 1},
+		["name", "space_name", "route", "root_group", "favicon", "light_mode_logo"],
+		as_dict=True,
+	)
+	if not space or not space.root_group:
+		frappe.throw(_("Space not found"), frappe.DoesNotExistError)
+
+	descendants = get_descendants_of("Wiki Document", space.root_group, ignore_permissions=True)
+	if not descendants:
+		return _empty_manifest(space)
+
+	docs = frappe.db.get_all(
+		"Wiki Document",
+		fields=["name", "title", "route", "content", "modified", "is_group", "is_external_link"],
+		filters={
+			"name": ("in", descendants),
+			"is_published": 1,
+			"is_private": 0,
+			"is_group": 0,
+			"is_external_link": 0,
+		},
+		order_by="lft asc",
+	)
+
+	pages = []
+	hasher = hashlib.sha256()
+	for doc in docs:
+		page_hash = hashlib.sha256(
+			(doc.content or "").encode("utf-8") + str(doc.modified).encode("utf-8")
+		).hexdigest()[:12]
+
+		image_urls = sorted(
+			{src for src in _IMG_SRC_RE.findall(doc.content or "") if src.startswith("/files/")}
+		)
+
+		pages.append(
+			{
+				"route": doc.route,
+				"title": doc.title,
+				"hash": page_hash,
+				"images": image_urls,
+			}
+		)
+		hasher.update(page_hash.encode("utf-8"))
+
+	manifest = _empty_manifest(space)
+	manifest.update(
+		{
+			"version": hasher.hexdigest()[:16],
+			"pages": pages,
+			"shared_assets": _shared_assets(),
+		}
+	)
+	return manifest
+
+
+def _empty_manifest(space: dict) -> dict:
+	return {
+		"space": {
+			"name": space.name,
+			"space_name": space.space_name,
+			"route": space.route,
+			"favicon": space.favicon,
+			"logo": space.light_mode_logo,
+		},
+		"version": "",
+		"pages": [],
+		"shared_assets": _shared_assets(),
+	}
+
+
+def _shared_assets() -> list[str]:
+	"""Shared CSS/JS/font assets every wiki page needs, regardless of space.
+
+	These are precached when the service worker installs, before any space is
+	downloaded.
+	"""
+	from wiki.utils import get_tailwindcss_hash
+
+	return [
+		f"/assets/wiki/css/tailwind.css?v={get_tailwindcss_hash()}",
+		"/assets/wiki/css/hljs-github-light.css",
+		"/assets/wiki/js/vendor/alpinejs/plugins/persist.js",
+		"/assets/wiki/js/vendor/alpinejs/plugins/collapse.js",
+		"/assets/wiki/js/vendor/alpinejs/core.js",
+		"/assets/wiki/js/code-blocks.js",
+		"/assets/wiki/js/image-viewer.js",
+		"/assets/wiki/favicon.png",
+	]
 
 
 @frappe.whitelist()

--- a/wiki/templates/wiki/includes/install_prompt.html
+++ b/wiki/templates/wiki/includes/install_prompt.html
@@ -1,0 +1,168 @@
+{% from "templates/wiki/macros/buttons.html" import render_icon %}
+
+{# Install + offline nudge. Mobile-focused, one-shot per space.
+   - Android-class browsers: capture beforeinstallprompt → show dialog → on accept, install + bulk-download the current space.
+   - iOS: no install API → show popover with manual Share → Add to Home Screen instructions, plus a "Save for offline" button.
+   - Already-installed or non-mobile: silent. Desktop users discover offline via /wiki-offline.
+#}
+{% if wiki_space and wiki_space.is_published %}
+<div x-data='installNudge({{ wiki_space.route | tojson }}, {{ (wiki_space.space_name or "Wiki") | tojson }})'
+     x-init="init()"
+     class="lg:hidden">
+
+    {# Android install dialog #}
+    <div x-show="dialogOpen"
+         x-cloak
+         x-transition.opacity
+         class="fixed inset-0 z-[100] flex items-end sm:items-center justify-center bg-black/40 p-4"
+         @click.self="dismiss()">
+        <div class="bg-[var(--surface-modal)] rounded-2xl shadow-2xl max-w-sm w-full p-5 space-y-4"
+             x-transition:enter="transition ease-out duration-200"
+             x-transition:enter-start="translate-y-4 opacity-0"
+             x-transition:enter-end="translate-y-0 opacity-100">
+            <div class="flex items-start justify-between gap-3">
+                <div class="flex-1">
+                    <h2 class="text-base font-semibold text-[var(--ink-gray-9)]" x-text="dialogTitle"></h2>
+                    <p class="text-sm text-[var(--ink-gray-6)] mt-1" x-text="dialogBody"></p>
+                </div>
+                <button @click="dismiss()" aria-label="Dismiss"
+                        class="p-1 -m-1 text-[var(--ink-gray-5)] hover:text-[var(--ink-gray-9)] rounded">
+                    {{ render_icon("x", "w-4 h-4") }}
+                </button>
+            </div>
+            <div class="flex gap-2 pt-1">
+                <button @click="dismiss()"
+                        class="flex-1 px-4 py-2 text-sm font-medium text-[var(--ink-gray-7)] bg-[var(--surface-gray-2)] hover:bg-[var(--surface-gray-3)] rounded-lg transition-colors">
+                    Not now
+                </button>
+                <button @click="accept()"
+                        class="flex-1 inline-flex items-center justify-center gap-1.5 px-4 py-2 text-sm font-medium text-white bg-[var(--ink-gray-9)] hover:opacity-90 rounded-lg transition-opacity">
+                    {{ render_icon("download", "w-4 h-4") }}
+                    <span x-text="acceptLabel"></span>
+                </button>
+            </div>
+        </div>
+    </div>
+
+    {# iOS instructional popover #}
+    <div x-show="iosPopoverOpen"
+         x-cloak
+         x-transition
+         class="fixed bottom-4 left-4 right-4 z-[100] bg-[var(--surface-modal)] rounded-xl shadow-2xl p-4 space-y-3 border border-[var(--outline-gray-1)]">
+        <div class="flex items-start justify-between gap-3">
+            <div class="flex-1">
+                <h2 class="text-sm font-semibold text-[var(--ink-gray-9)]"
+                    x-text="`Read ${spaceName} offline`"></h2>
+                <p class="text-xs text-[var(--ink-gray-6)] mt-1 leading-relaxed">
+                    Tap <span class="inline-flex items-center align-middle">
+                        <svg class="inline w-3.5 h-3.5 text-blue-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2v13M5 9l7-7 7 7M5 21h14"/></svg>
+                    </span>
+                    in Safari then "Add to Home Screen" to install. You can also save this space for offline reading right now.
+                </p>
+            </div>
+            <button @click="dismiss()" aria-label="Dismiss"
+                    class="p-1 -m-1 text-[var(--ink-gray-5)] hover:text-[var(--ink-gray-9)] rounded">
+                {{ render_icon("x", "w-4 h-4") }}
+            </button>
+        </div>
+        <button @click="accept()"
+                class="w-full inline-flex items-center justify-center gap-1.5 px-3 py-2 text-sm font-medium text-white bg-[var(--ink-gray-9)] hover:opacity-90 rounded-lg transition-opacity">
+            {{ render_icon("download", "w-4 h-4") }}
+            <span>Save for offline</span>
+        </button>
+    </div>
+</div>
+
+<script>
+    function installNudge(spaceRoute, spaceName) {
+        return {
+            spaceRoute,
+            spaceName,
+            dialogOpen: false,
+            iosPopoverOpen: false,
+            deferredPrompt: null,
+            dialogTitle: '',
+            dialogBody: '',
+            acceptLabel: '',
+
+            init() {
+                if (!('serviceWorker' in navigator)) return;
+                if (this.dismissedForThisSpace()) return;
+
+                const isIos = /iphone|ipad|ipod/i.test(navigator.userAgent);
+                const isStandalone = window.matchMedia('(display-mode: standalone)').matches
+                    || window.navigator.standalone === true;
+
+                // Capture the Android install prompt as soon as it fires —
+                // calling preventDefault() is required to defer it for later.
+                window.addEventListener('beforeinstallprompt', (e) => {
+                    e.preventDefault();
+                    this.deferredPrompt = e;
+                });
+
+                // Defer the decision by ~2s so the SW has time to report which
+                // spaces are already downloaded and so beforeinstallprompt has
+                // had a chance to fire.
+                setTimeout(() => {
+                    if (this.dismissedForThisSpace() || this.alreadyDownloaded()) return;
+
+                    if (this.deferredPrompt || isStandalone) {
+                        this.showDialog(isStandalone);
+                    } else if (isIos && !isStandalone) {
+                        this.iosPopoverOpen = true;
+                    }
+                    // Other browsers without install API: silent. User can use /wiki-offline.
+                }, 2000);
+            },
+
+            showDialog(alreadyInstalled) {
+                this.dialogTitle = alreadyInstalled
+                    ? `Read ${this.spaceName} offline`
+                    : `Install Wiki for offline reading`;
+                this.dialogBody = alreadyInstalled
+                    ? `Save this space to your device so you can read it without an internet connection.`
+                    : `Install the app and save ${this.spaceName} so you can read it without an internet connection.`;
+                this.acceptLabel = alreadyInstalled ? 'Save offline' : 'Install';
+                this.dialogOpen = true;
+            },
+
+            async accept() {
+                this.dialogOpen = false;
+                this.iosPopoverOpen = false;
+                this.markDismissed();
+
+                // Trigger the OS install prompt first (Android-class only).
+                if (this.deferredPrompt) {
+                    try {
+                        this.deferredPrompt.prompt();
+                        await this.deferredPrompt.userChoice;
+                    } catch (e) { /* user dismissed, continue with download */ }
+                    this.deferredPrompt = null;
+                }
+
+                // Kick off the per-space download via the shared pwa store.
+                Alpine.store('pwa').download(this.spaceRoute);
+            },
+
+            dismiss() {
+                this.dialogOpen = false;
+                this.iosPopoverOpen = false;
+                this.markDismissed();
+            },
+
+            dismissedKey() { return `wikiOfflineNudge:${this.spaceRoute}`; },
+            dismissedForThisSpace() {
+                try { return localStorage.getItem(this.dismissedKey()) === '1'; }
+                catch (e) { return false; }
+            },
+            markDismissed() {
+                try { localStorage.setItem(this.dismissedKey(), '1'); } catch (e) {}
+            },
+            alreadyDownloaded() {
+                const s = Alpine.store('pwa')?.spaces?.[this.spaceRoute];
+                return s && s.downloaded;
+            },
+        };
+    }
+</script>
+{% endif %}

--- a/wiki/templates/wiki/layout.html
+++ b/wiki/templates/wiki/layout.html
@@ -9,6 +9,12 @@
         {% endblock %}
     </title>
 
+    <link rel="manifest" href="/manifest.json">
+    <meta name="theme-color" content="#171717">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="default">
+
     <link rel="stylesheet" href="/assets/wiki/css/tailwind.css?v={{get_tailwindcss_hash()}}">
     <link rel="stylesheet" href="/assets/wiki/css/hljs-github-light.css">
 
@@ -40,6 +46,9 @@
 
         // CSRF token for API requests
         window.CSRF_TOKEN = '{{ csrf_token }}';
+
+        // Space route the current page belongs to (used by the PWA store).
+        window.WIKI_SPACE_ROUTE = {{ (wiki_space.route if wiki_space else "") | tojson }};
     </script>
 
     <script src="/assets/wiki/js/vendor/alpinejs/plugins/persist.js"></script>
@@ -86,9 +95,186 @@
              class="min-w-[45rem] max-w-[60vw] max-h-[80vh] object-contain cursor-zoom-out max-[768px]:min-w-[100vw]" />
     </div>
 
+    {% if not hide_chrome %}
+    {% include "templates/wiki/includes/install_prompt.html" %}
+    {% endif %}
+
+    {# PWA update-available banner — shown when cached version of current space is stale #}
+    {% if wiki_space and wiki_space.is_published %}
+    <div x-data
+         x-show="$store.pwa.statusFor('{{ wiki_space.route }}') === 'update-available'"
+         x-cloak
+         x-transition.opacity
+         class="fixed top-0 inset-x-0 z-[80] bg-amber-50 border-b border-amber-200 text-amber-900">
+        <div class="max-w-5xl mx-auto px-4 py-2 flex items-center justify-between gap-3 text-sm">
+            <span>New content available for offline reading.</span>
+            <div class="flex items-center gap-2 flex-shrink-0">
+                <button @click="$store.pwa.download('{{ wiki_space.route }}')"
+                        class="px-3 py-1 bg-amber-900 text-white rounded-md text-xs font-medium hover:bg-amber-800 transition-colors">
+                    Update offline copy
+                </button>
+                <button @click="$store.pwa.spaces['{{ wiki_space.route }}'].updateAvailable = false"
+                        aria-label="Dismiss"
+                        class="p-1 text-amber-700 hover:text-amber-900">
+                    <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+                </button>
+            </div>
+        </div>
+    </div>
+    {% endif %}
+
+    {# PWA download progress + completion toast — shown across all wiki pages #}
+    <div x-data
+         x-show="$store.pwa.inProgress || $store.pwa.completed"
+         x-cloak
+         x-transition.opacity
+         class="fixed bottom-4 left-1/2 -translate-x-1/2 z-[90] pointer-events-none">
+        <div class="pointer-events-auto bg-[var(--ink-gray-9)] text-white text-sm rounded-full shadow-lg px-4 py-2 inline-flex items-center gap-2">
+            <template x-if="$store.pwa.inProgress">
+                <span class="inline-flex items-center gap-2">
+                    <svg class="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M21 12a9 9 0 11-6.219-8.56"/>
+                    </svg>
+                    <span x-text="$store.pwa.progress.total
+                        ? `Saving for offline — ${$store.pwa.progress.done}/${$store.pwa.progress.total}`
+                        : 'Saving for offline — starting…'"></span>
+                </span>
+            </template>
+            <template x-if="!$store.pwa.inProgress && $store.pwa.completed">
+                <span class="inline-flex items-center gap-2">
+                    <svg class="w-4 h-4 text-emerald-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M20 6L9 17l-5-5"/>
+                    </svg>
+                    <span>Available offline</span>
+                    <button @click="$store.pwa.completed = null"
+                            aria-label="Dismiss"
+                            class="ml-1 -mr-1 text-white/60 hover:text-white">
+                        <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+                    </button>
+                </span>
+            </template>
+        </div>
+    </div>
+
     {{ include_script("syntax_highlighting.bundle.js") }}
     <script src="/assets/wiki/js/code-blocks.js"></script>
     <script src="/assets/wiki/js/image-viewer.js"></script>
+
+    <script>
+        // PWA: register service worker and expose an Alpine store the install
+        // nudge, update banner, and management page all read from.
+        document.addEventListener('alpine:init', () => {
+            Alpine.store('pwa', {
+                supported: 'serviceWorker' in navigator,
+                spaces: {},          // route -> { version, downloaded, updateAvailable }
+                inProgress: null,    // route currently downloading
+                progress: { done: 0, total: 0 },
+                completed: null,     // { route, name, failed } — clears after 6s
+                completedTimer: null,
+
+                async init() {
+                    if (!this.supported) return;
+                    try {
+                        await navigator.serviceWorker.register('/sw.js', { scope: '/' });
+                    } catch (e) {
+                        console.warn('SW registration failed', e);
+                        return;
+                    }
+
+                    navigator.serviceWorker.addEventListener('message', (event) => {
+                        const msg = event.data || {};
+                        if (msg.type === 'PRECACHE_PROGRESS') {
+                            this.progress = { done: msg.done, total: msg.total };
+                        } else if (msg.type === 'PRECACHE_DONE') {
+                            this.inProgress = null;
+                            this.progress = { done: 0, total: 0 };
+                            this.spaces[msg.spaceRoute] = {
+                                version: msg.version,
+                                downloaded: true,
+                                updateAvailable: false,
+                                failed: (msg.failed || []).length,
+                            };
+                            this.completed = {
+                                route: msg.spaceRoute,
+                                failed: (msg.failed || []).length,
+                            };
+                            if (this.completedTimer) clearTimeout(this.completedTimer);
+                            this.completedTimer = setTimeout(() => { this.completed = null; }, 6000);
+                        } else if (msg.type === 'SPACES_LIST') {
+                            (msg.spaces || []).forEach((m) => {
+                                const route = m.space.route;
+                                this.spaces[route] = Object.assign({
+                                    version: m.version,
+                                    downloaded: true,
+                                    updateAvailable: false,
+                                }, this.spaces[route] || {});
+                            });
+                        }
+                    });
+
+                    await navigator.serviceWorker.ready;
+                    this.refreshSpaces();
+                    document.addEventListener('visibilitychange', () => {
+                        if (document.visibilityState === 'visible') this.checkCurrentSpaceForUpdates();
+                    });
+                },
+
+                refreshSpaces() {
+                    if (navigator.serviceWorker.controller) {
+                        navigator.serviceWorker.controller.postMessage({ type: 'LIST_SPACES' });
+                    }
+                },
+
+                async download(spaceRoute) {
+                    if (this.inProgress) return;
+                    this.inProgress = spaceRoute;
+                    this.progress = { done: 0, total: 0 };
+                    try {
+                        const url = `/api/method/wiki.api.wiki_space.get_space_manifest?space_route=${encodeURIComponent(spaceRoute)}`;
+                        const res = await fetch(url, { credentials: 'same-origin' });
+                        const data = await res.json();
+                        const manifest = data.message;
+                        const controller = navigator.serviceWorker.controller || (await navigator.serviceWorker.ready).active;
+                        controller.postMessage({ type: 'PRECACHE_SPACE', manifest });
+                    } catch (e) {
+                        console.warn('Failed to start precache', e);
+                        this.inProgress = null;
+                    }
+                },
+
+                async remove(spaceRoute) {
+                    const controller = navigator.serviceWorker.controller;
+                    if (!controller) return;
+                    controller.postMessage({ type: 'REMOVE_SPACE', spaceRoute });
+                    delete this.spaces[spaceRoute];
+                },
+
+                async checkCurrentSpaceForUpdates() {
+                    const current = window.WIKI_SPACE_ROUTE;
+                    if (!current || !this.spaces[current]) return;
+                    try {
+                        const url = `/api/method/wiki.api.wiki_space.get_space_manifest?space_route=${encodeURIComponent(current)}`;
+                        const res = await fetch(url, { credentials: 'same-origin' });
+                        const data = await res.json();
+                        const remoteVersion = data.message && data.message.version;
+                        if (remoteVersion && remoteVersion !== this.spaces[current].version) {
+                            this.spaces[current].updateAvailable = true;
+                        }
+                    } catch (e) { /* offline — ignore */ }
+                },
+
+                statusFor(spaceRoute) {
+                    if (this.inProgress === spaceRoute) return 'downloading';
+                    const s = this.spaces[spaceRoute];
+                    if (!s) return 'not-downloaded';
+                    if (s.updateAvailable) return 'update-available';
+                    return 'downloaded';
+                },
+            });
+
+            Alpine.store('pwa').init();
+        });
+    </script>
 </body>
 {% block scripts %} {% endblock %}
 </html>

--- a/wiki/www/manifest.json
+++ b/wiki/www/manifest.json
@@ -1,0 +1,25 @@
+{
+	"name": "Frappe Wiki",
+	"short_name": "Wiki",
+	"description": "Documentation reader. Browse spaces online, take them offline.",
+	"start_url": "/",
+	"scope": "/",
+	"display": "standalone",
+	"orientation": "portrait",
+	"theme_color": "#171717",
+	"background_color": "#ffffff",
+	"icons": [
+		{
+			"src": "/assets/wiki/favicon.png",
+			"sizes": "192x192",
+			"type": "image/png",
+			"purpose": "any maskable"
+		},
+		{
+			"src": "/assets/wiki/favicon.png",
+			"sizes": "512x512",
+			"type": "image/png",
+			"purpose": "any maskable"
+		}
+	]
+}

--- a/wiki/www/offline.html
+++ b/wiki/www/offline.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Offline — Frappe Wiki</title>
+	<link rel="stylesheet" href="/assets/wiki/css/tailwind.css">
+	<style>
+		[data-theme="light"] { color-scheme: light; }
+	</style>
+</head>
+<body class="min-h-screen flex items-center justify-center bg-[var(--surface-white)] text-[var(--ink-gray-9)] p-6" data-theme="light">
+	<main class="max-w-md text-center space-y-4">
+		<div class="text-5xl">📡</div>
+		<h1 class="text-2xl font-semibold">You're offline</h1>
+		<p class="text-[var(--ink-gray-6)]">
+			This page hasn't been downloaded for offline reading. Open a space you've
+			made available offline, or reconnect to the internet.
+		</p>
+		<div class="flex items-center justify-center gap-2 pt-2">
+			<button type="button" onclick="history.back()"
+				class="px-4 py-2 rounded-lg border border-[var(--outline-gray-2)] text-sm font-medium hover:bg-[var(--surface-gray-1)]">
+				Go back
+			</button>
+			<button type="button" onclick="window.location.reload()"
+				class="px-4 py-2 rounded-lg bg-[var(--ink-gray-9)] text-white text-sm font-medium hover:opacity-90">
+				Retry
+			</button>
+		</div>
+	</main>
+</body>
+</html>

--- a/wiki/www/sw.js
+++ b/wiki/www/sw.js
@@ -1,0 +1,199 @@
+/**
+ * Frappe Wiki service worker.
+ *
+ * Strategy (v1):
+ *  - App shell (CSS/JS/fonts) precached on install.
+ *  - Wiki pages cached on demand when the user taps "Make available offline"
+ *    for a space. Each space gets its own cache: `wiki-space-<route>-v<n>`.
+ *  - Fetch handler: cache-first for any URL we've stored, network-first for
+ *    everything else, navigation fallback to /offline when both fail.
+ *  - POST requests (e.g. the SPA's get_page_data) are never intercepted.
+ *    When offline, the page's existing try/catch falls through to
+ *    `window.location.href`, which then hits this SW's HTML cache.
+ */
+
+const SHELL_CACHE = 'wiki-shell-v1';
+const SPACE_CACHE_PREFIX = 'wiki-space-';
+
+const SHELL_ASSETS = ['/offline'];
+
+self.addEventListener('install', (event) => {
+	event.waitUntil(
+		caches
+			.open(SHELL_CACHE)
+			.then((cache) => cache.addAll(SHELL_ASSETS))
+			.then(() => self.skipWaiting()),
+	);
+});
+
+self.addEventListener('activate', (event) => {
+	event.waitUntil(
+		caches
+			.keys()
+			.then((keys) =>
+				Promise.all(
+					keys
+						.filter((k) => k === 'wiki-shell-v0')
+						.map((k) => caches.delete(k)),
+				),
+			)
+			.then(() => self.clients.claim()),
+	);
+});
+
+self.addEventListener('fetch', (event) => {
+	const request = event.request;
+
+	// Only handle GETs. POSTs (get_page_data, form submits) pass through so the
+	// page's own error handling kicks in when offline.
+	if (request.method !== 'GET') return;
+
+	const url = new URL(request.url);
+
+	// Same-origin only — don't interfere with third-party assets.
+	if (url.origin !== self.location.origin) return;
+
+	// Never cache API endpoints — too dynamic.
+	if (url.pathname.startsWith('/api/')) return;
+
+	event.respondWith(handleFetch(request));
+});
+
+async function handleFetch(request) {
+	const cacheMatch = await caches.match(request, { ignoreSearch: false });
+	if (cacheMatch) return cacheMatch;
+
+	try {
+		return await fetch(request);
+	} catch (err) {
+		// Network failed and we have no cached copy.
+		if (request.mode === 'navigate') {
+			const offline = await caches.match('/offline');
+			if (offline) return offline;
+		}
+		throw err;
+	}
+}
+
+self.addEventListener('message', (event) => {
+	const data = event.data || {};
+	if (data.type === 'PRECACHE_SPACE') {
+		event.waitUntil(precacheSpace(data.manifest, event.source));
+	} else if (data.type === 'REMOVE_SPACE') {
+		event.waitUntil(removeSpace(data.spaceRoute));
+	} else if (data.type === 'LIST_SPACES') {
+		event.waitUntil(
+			listSpaces().then((spaces) => {
+				event.source?.postMessage({ type: 'SPACES_LIST', spaces });
+			}),
+		);
+	}
+});
+
+/**
+ * Download every page + image + shared asset for a space into a dedicated
+ * cache. Reports progress back to the calling client.
+ */
+async function precacheSpace(manifest, client) {
+	const spaceRoute = manifest.space.route;
+	const cacheName = `${SPACE_CACHE_PREFIX}${spaceRoute}-v1`;
+
+	// Drop any older copy of this space so leftover URLs don't linger.
+	const existing = await caches.keys();
+	await Promise.all(
+		existing
+			.filter(
+				(k) =>
+					k.startsWith(`${SPACE_CACHE_PREFIX}${spaceRoute}-`) &&
+					k !== cacheName,
+			)
+			.map((k) => caches.delete(k)),
+	);
+
+	const cache = await caches.open(cacheName);
+
+	// Build the URL list: shared assets + page HTMLs + embedded images.
+	const urls = new Set();
+	for (const u of manifest.shared_assets || []) urls.add(u);
+	for (const page of manifest.pages) {
+		urls.add(`/${page.route}`);
+		for (const img of page.images || []) urls.add(img);
+	}
+
+	const allUrls = Array.from(urls);
+	let done = 0;
+	const failed = [];
+
+	// Fetch one at a time so we can report progress and don't hammer the server.
+	for (const url of allUrls) {
+		try {
+			const res = await fetch(url, {
+				credentials: 'same-origin',
+				redirect: 'follow',
+			});
+			if (res.ok || res.type === 'opaqueredirect') {
+				await cache.put(url, res.clone());
+			} else {
+				failed.push({ url, status: res.status });
+			}
+		} catch (err) {
+			failed.push({ url, error: String(err) });
+		}
+		done++;
+		if (client) {
+			client.postMessage({
+				type: 'PRECACHE_PROGRESS',
+				spaceRoute,
+				done,
+				total: allUrls.length,
+			});
+		}
+	}
+
+	// Persist the manifest itself so we can detect updates later.
+	await cache.put(
+		`__manifest__/${spaceRoute}`,
+		new Response(JSON.stringify(manifest), {
+			headers: { 'Content-Type': 'application/json' },
+		}),
+	);
+
+	if (client) {
+		client.postMessage({
+			type: 'PRECACHE_DONE',
+			spaceRoute,
+			version: manifest.version,
+			failed,
+		});
+	}
+}
+
+async function removeSpace(spaceRoute) {
+	const keys = await caches.keys();
+	await Promise.all(
+		keys
+			.filter((k) => k.startsWith(`${SPACE_CACHE_PREFIX}${spaceRoute}-`))
+			.map((k) => caches.delete(k)),
+	);
+}
+
+/**
+ * Returns the cached manifest for each space currently stored offline.
+ * The page UI uses this to render "downloaded / update available" state.
+ */
+async function listSpaces() {
+	const keys = await caches.keys();
+	const spaceCaches = keys.filter((k) => k.startsWith(SPACE_CACHE_PREFIX));
+	const out = [];
+	for (const name of spaceCaches) {
+		const cache = await caches.open(name);
+		// Find the manifest inside this cache.
+		const requests = await cache.keys();
+		const manifestReq = requests.find((r) => r.url.includes('/__manifest__/'));
+		if (!manifestReq) continue;
+		const res = await cache.match(manifestReq);
+		if (!res) continue;
+		out.push(await res.json());
+	}
+	return out;
+}

--- a/wiki/www/wiki-offline.html
+++ b/wiki/www/wiki-offline.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Offline Spaces — Frappe Wiki</title>
+	<link rel="manifest" href="/manifest.json">
+	<meta name="theme-color" content="#171717">
+	<link rel="stylesheet" href="/assets/wiki/css/tailwind.css">
+	<style>
+		[x-cloak] { display: none !important; }
+	</style>
+	<script>
+		document.documentElement.setAttribute('data-theme', localStorage.getItem('wiki-theme') || 'light');
+	</script>
+	<script src="/assets/wiki/js/vendor/alpinejs/plugins/persist.js"></script>
+	<script defer src="/assets/wiki/js/vendor/alpinejs/core.js"></script>
+</head>
+<body class="min-h-screen bg-[var(--surface-white)] text-[var(--ink-gray-9)]" data-theme="light">
+	<main class="max-w-3xl mx-auto px-4 py-10" x-data="offlineManager()" x-init="init()">
+		<header class="mb-8">
+			<h1 class="text-2xl font-semibold">Offline spaces</h1>
+			<p class="text-sm text-[var(--ink-gray-6)] mt-1">Manage the wiki spaces you've saved for offline reading.</p>
+		</header>
+
+		{# Not supported #}
+		<div x-show="!supported" x-cloak class="rounded-lg border border-[var(--outline-gray-2)] p-6 text-center text-sm text-[var(--ink-gray-6)]">
+			Your browser doesn't support offline reading. Try a recent version of Chrome, Edge, Firefox, or Safari.
+		</div>
+
+		{# Loading #}
+		<div x-show="supported && loading" x-cloak class="text-sm text-[var(--ink-gray-5)]">Loading…</div>
+
+		{# Empty state #}
+		<div x-show="supported && !loading && spaces.length === 0" x-cloak
+			 class="rounded-lg border border-dashed border-[var(--outline-gray-2)] p-8 text-center">
+			<p class="text-sm text-[var(--ink-gray-6)]">No spaces saved for offline reading yet.</p>
+			<p class="text-xs text-[var(--ink-gray-5)] mt-2">Visit a wiki space and accept the install prompt to save it.</p>
+		</div>
+
+		{# List #}
+		<ul x-show="supported && !loading && spaces.length > 0" x-cloak class="space-y-3">
+			<template x-for="space in spaces" :key="space.route">
+				<li class="border border-[var(--outline-gray-1)] rounded-lg p-4 flex items-center justify-between gap-4">
+					<div class="min-w-0 flex-1">
+						<a :href="'/' + space.route"
+						   class="block font-medium text-[var(--ink-gray-9)] hover:underline truncate"
+						   x-text="space.name"></a>
+						<p class="text-xs text-[var(--ink-gray-5)] mt-0.5">
+							<span x-text="`${space.pageCount} page${space.pageCount === 1 ? '' : 's'}`"></span>
+							<span class="mx-1">·</span>
+							<span x-text="`version ${space.version.slice(0, 7)}`"></span>
+							<template x-if="space.updateAvailable">
+								<span class="ml-2 text-amber-700 font-medium">update available</span>
+							</template>
+						</p>
+					</div>
+					<div class="flex items-center gap-2 flex-shrink-0">
+						<button x-show="space.updateAvailable"
+								@click="refresh(space.route)"
+								class="px-3 py-1.5 text-xs font-medium bg-amber-50 text-amber-800 border border-amber-200 rounded-md hover:bg-amber-100">
+							Update
+						</button>
+						<button @click="remove(space.route)"
+								class="px-3 py-1.5 text-xs font-medium text-red-700 border border-red-200 rounded-md hover:bg-red-50">
+							Remove
+						</button>
+					</div>
+				</li>
+			</template>
+		</ul>
+
+		<footer class="mt-10 pt-6 border-t border-[var(--outline-gray-1)] text-xs text-[var(--ink-gray-5)] flex items-center justify-between">
+			<div>
+				<span x-show="quota.usage !== null" x-cloak
+					  x-text="`Using ${formatBytes(quota.usage)} of ${formatBytes(quota.quota)}`"></span>
+			</div>
+			<a href="/" class="hover:text-[var(--ink-gray-9)]">← Back to wiki</a>
+		</footer>
+	</main>
+
+<script>
+	function offlineManager() {
+		return {
+			supported: 'serviceWorker' in navigator,
+			loading: true,
+			spaces: [],
+			quota: { usage: null, quota: null },
+
+			async init() {
+				if (!this.supported) return;
+				// Register the SW (in case the user landed here directly before visiting a wiki page).
+				try { await navigator.serviceWorker.register('/sw.js', { scope: '/' }); } catch (e) {}
+
+				navigator.serviceWorker.addEventListener('message', (event) => {
+					const msg = event.data || {};
+					if (msg.type === 'SPACES_LIST') {
+						this.spaces = (msg.spaces || []).map((m) => ({
+							route: m.space.route,
+							name: m.space.space_name || m.space.route,
+							version: m.version || '',
+							pageCount: (m.pages || []).length,
+							updateAvailable: false,
+						}));
+						this.loading = false;
+						this.checkForUpdates();
+					} else if (msg.type === 'PRECACHE_DONE') {
+						this.requestList();
+					}
+				});
+
+				await navigator.serviceWorker.ready;
+				this.requestList();
+
+				if (navigator.storage && navigator.storage.estimate) {
+					try {
+						const e = await navigator.storage.estimate();
+						this.quota = { usage: e.usage, quota: e.quota };
+					} catch (err) {}
+				}
+			},
+
+			requestList() {
+				const controller = navigator.serviceWorker.controller;
+				if (controller) controller.postMessage({ type: 'LIST_SPACES' });
+				else this.loading = false;
+			},
+
+			async remove(route) {
+				if (!confirm('Remove this space from offline storage?')) return;
+				navigator.serviceWorker.controller.postMessage({ type: 'REMOVE_SPACE', spaceRoute: route });
+				this.spaces = this.spaces.filter((s) => s.route !== route);
+			},
+
+			async refresh(route) {
+				try {
+					const url = `/api/method/wiki.api.wiki_space.get_space_manifest?space_route=${encodeURIComponent(route)}`;
+					const res = await fetch(url, { credentials: 'same-origin' });
+					const data = await res.json();
+					navigator.serviceWorker.controller.postMessage({ type: 'PRECACHE_SPACE', manifest: data.message });
+				} catch (e) { alert('Could not fetch latest manifest — are you online?'); }
+			},
+
+			async checkForUpdates() {
+				for (const space of this.spaces) {
+					try {
+						const url = `/api/method/wiki.api.wiki_space.get_space_manifest?space_route=${encodeURIComponent(space.route)}`;
+						const res = await fetch(url, { credentials: 'same-origin' });
+						const data = await res.json();
+						if (data.message && data.message.version && data.message.version !== space.version) {
+							space.updateAvailable = true;
+						}
+					} catch (e) { /* offline — skip */ }
+				}
+			},
+
+			formatBytes(bytes) {
+				if (bytes === null || bytes === undefined) return '–';
+				const units = ['B', 'KB', 'MB', 'GB'];
+				let i = 0;
+				while (bytes >= 1024 && i < units.length - 1) { bytes /= 1024; i++; }
+				return `${bytes.toFixed(bytes >= 10 || i === 0 ? 0 : 1)} ${units[i]}`;
+			},
+		};
+	}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds Progressive Web App support to the wiki with a per-space, on-demand offline reading model — modeled on Kiwix / DevDocs.

- **Service worker** (`/sw.js`, scope `/`) precaches the app shell on install and stores each downloaded space in its own cache (`wiki-space-<route>-vN`). Fetch handler is cache-first for stored URLs, network-passthrough otherwise, with `/offline` as the navigation fallback.
- **Manifest endpoint** `wiki.api.wiki_space.get_space_manifest(space_route)` returns the version, list of published-leaf-public pages, embedded `/files/...` image URLs, and shared CSS/JS asset URLs for a space.
- **Install nudge** (mobile, one-shot per space, LMS-style): captures `beforeinstallprompt` for Android-class browsers (modal → install + download), shows a Share → Add to Home Screen popover on iOS. Accepting in either flow kicks off the per-space bulk download via the SW.
- **Update banner** at the top of cached pages when the space's version hash has changed server-side, with a one-click re-download.
- **Progress + completion toast** (bottom-center) showing live `Saving for offline — N/M` and a brief `Available offline` on completion.
- **Management page** `/wiki-offline` listing every saved space with version, page count, storage estimate, and Remove / Update buttons. Discoverable for desktop users (who don't get the nudge).

## How offline navigation works

The wiki already has client-side SPA navigation that POSTs to `get_page_data` and falls back to `window.location.href` on error (`sidebar.html`). When offline, the POST fails → the existing fallback triggers a full nav → the SW serves the cached HTML. **No JSON caching, no SPA changes needed.**

## What's in scope for v1

- Public, published, leaf, internal wiki documents in published spaces.
- Read-only offline browsing.

## What's deliberately out of scope (v2+)

- Offline search (server-side SQLite-backed today; would need a per-space prebuilt index).
- Offline editing / change requests.
- Private spaces (button hidden; auth + offline is a separate problem).
- Periodic background sync (no Safari support; manual update banner is enough).

## Test plan

- [ ] Visit a published space on mobile (or DevTools mobile emulation). After ~2s, an install/save dialog appears.
- [ ] Accept → progress toast shows `Saving for offline — N/M`, then `Available offline`.
- [ ] DevTools → Network → Offline. Refresh the page → loads from cache.
- [ ] Click a sibling page link while offline → SPA POST fails → full nav serves cached HTML.
- [ ] Navigate to a page not in the cached space while offline → `/offline` fallback page.
- [ ] Edit a Wiki Document on the server → revisit the cached space → "New content available" banner appears.
- [ ] Visit `/wiki-offline` → shows the downloaded space with Remove + Update buttons; remove clears the cache.
- [ ] Dismiss the nudge → it doesn't reappear for that space (localStorage flag).
- [ ] iOS Safari: popover appears with Share-icon instructions and a "Save for offline" button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Progressive Web App (PWA) support enabling offline wiki access
  * One-time install prompt allowing users to save wiki spaces for offline reading
  * Offline spaces management page to view, update, and remove cached wikis
  * Automatic update notifications when cached content becomes stale

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frappe/wiki/pull/630?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->