### PR TITLE
fix: prevent indexing wiki app routes

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
     <title>Frappe Wiki</title>
   </head>
   <body class="bg-surface-white">

--- a/wiki/www/wiki.py
+++ b/wiki/www/wiki.py
@@ -5,9 +5,13 @@ import frappe
 from frappe.utils import get_system_timezone
 
 no_cache = 1
+sitemap = 0
+
+ROBOTS_DIRECTIVE = "noindex, nofollow"
 
 
 def get_context():
+	frappe.local.response_headers.set("X-Robots-Tag", ROBOTS_DIRECTIVE)
 	csrf_token = frappe.sessions.get_csrf_token()
 	frappe.db.commit()  # nosemgrep
 	context = frappe._dict()


### PR DESCRIPTION
## Summary

- add a `noindex, nofollow` robots meta directive to the `/wiki` frontend entry
- return `X-Robots-Tag: noindex, nofollow` for the `wiki.html` controller used by `/wiki` and `/wiki/**`
- remove the app entry page from generated sitemaps with `sitemap = 0`

This intentionally applies to the Wiki application routes only; published Wiki Document routes remain indexable.

## Verification

- `python -m compileall -q wiki/www/wiki.py`
- `git diff --check`
- `yarn build` in `frontend/`
- verified `GET /wiki/spaces` and `GET /wiki.html` return `X-Robots-Tag: noindex, nofollow` and the matching HTML meta tag
- verified `/sitemap.xml` does not list `/wiki`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pages to prevent appearance in search engine results and prevent following of links by search engines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frappe/wiki/pull/632?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->