### PR TITLE
fix(wiki): render image paths with parens; replace Mistune with markdown-it-py

### DIFF
--- a/frontend/src/components/tiptap-extensions/image-extension.js
+++ b/frontend/src/components/tiptap-extensions/image-extension.js
@@ -31,7 +31,10 @@ const imageCaptionTokenizer = {
 
 	tokenize(src, tokens, lexer) {
 		// Match: ![alt](src) or ![alt](src "title") optionally followed by \n*caption*
-		const imagePattern = /^!\[([^\]]*)\]\(([^)"]+)(?:\s+"([^"]*)")?\)/;
+		// URL allows one level of balanced parens so Frappe filenames like
+		// `/files/image (24).png` survive (otherwise the inner `)` closes the markdown).
+		const imagePattern =
+			/^!\[([^\]]*)\]\(((?:[^()"\s]|\([^()"]*\))+)(?:\s+"([^"]*)")?\)/;
 		const captionPattern = /^\n\*([^*]+)\*/;
 
 		const imageMatch = imagePattern.exec(src);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ requires-python = ">=3.14"
 readme = "README.md"
 dynamic = ["version"]
 dependencies = [
-    "mistune>=3.0",
+    "markdown-it-py>=3.0",
+    "mdit-py-plugins>=0.4",
 ]
 
 [project.urls]

--- a/wiki/wiki/markdown.py
+++ b/wiki/wiki/markdown.py
@@ -151,9 +151,12 @@ def _replace_callout_placeholders(html, callouts, placeholder_prefix, md_instanc
 
 
 # Pattern to match markdown image syntax: ![alt](url) or ![alt](url "title")
-# Captures: alt text, URL, and optional title
+# Captures: alt text, URL, and optional title.
+# URL allows one level of balanced parens so Frappe uploads named like
+# `/files/image (14).png` are matched whole (otherwise the inner `)` closes
+# the markdown and the rest of the filename leaks out as plain text).
 IMAGE_PATTERN = re.compile(
-	r'!\[([^\]]*)\]\(([^)"\s]+(?:\s[^)]*)?)\)',
+	r'!\[([^\]]*)\]\(((?:[^()"]|\([^()"]*\))+?)(?:\s+"([^"]*)")?\)',
 )
 
 VIDEO_EXTENSIONS = (
@@ -287,40 +290,31 @@ def _escape_table_inline_code_pipes(content: str) -> str:
 	return "\n".join(lines)
 
 
-def _encode_image_url_spaces(content: str) -> str:
+def _encode_image_url_unsafe_chars(content: str) -> str:
 	"""
-	Pre-process markdown to URL-encode spaces in image URLs.
+	Pre-process markdown to URL-encode characters in image URLs that Mistune
+	mishandles.
 
-	Mistune (unlike markdown2) doesn't handle spaces in URLs, so we need to
-	encode them before parsing. This function finds all image syntax and
-	encodes spaces in the URL portion.
+	Mistune (unlike markdown2) doesn't allow spaces in URLs, and its image
+	parser stops at the first `)` even when parens are balanced — so a Frappe
+	upload like `/files/image (14).png` ends up with src=`/files/image%20(14`
+	and `.png)` leaking out as text. We pre-encode literal `(`, `)`, and ` `
+	so Mistune sees a clean URL.
 
 	Args:
 	    content: Markdown string
 
 	Returns:
-	    Markdown string with spaces in image URLs encoded as %20
+	    Markdown string with unsafe chars in image URLs percent-encoded
 	"""
 
 	def encode_url(match):
 		alt_text = match.group(1)
-		url_part = match.group(2)
+		url = match.group(2).strip()
+		title = match.group(3)
 
-		# Split URL and optional title (title is in quotes after a space)
-		# e.g., '/path/to/image.png "Image Title"'
-		title_match = re.match(r'^([^"]+?)(?:\s+"([^"]*)")?$', url_part)
-		if title_match:
-			url = title_match.group(1).strip()
-			title = title_match.group(2)
-		else:
-			url = url_part
-			title = None
+		encoded_url = url.replace("(", "%28").replace(")", "%29").replace(" ", "%20")
 
-		# Only encode spaces, preserve other characters
-		# quote() with safe='' would encode everything, but we only want spaces
-		encoded_url = url.replace(" ", "%20")
-
-		# Reconstruct the image syntax
 		if title:
 			return f'![{alt_text}]({encoded_url} "{title}")'
 		return f"![{alt_text}]({encoded_url})"
@@ -428,8 +422,9 @@ def render_markdown_with_toc(content: str) -> tuple[str, list]:
 		],
 	)
 
-	# Step 1: URL-encode spaces in image URLs (mistune doesn't handle them)
-	processed_content = _encode_image_url_spaces(content)
+	# Step 1: URL-encode unsafe chars (spaces, parens) in image URLs that
+	# Mistune would otherwise mishandle.
+	processed_content = _encode_image_url_unsafe_chars(content)
 
 	# Step 1b: Escape `|` inside inline-code spans on table rows so Mistune's
 	# table plugin doesn't miscount columns and drop the table.

--- a/wiki/wiki/markdown.py
+++ b/wiki/wiki/markdown.py
@@ -1,10 +1,7 @@
 """
-Custom Markdown Renderer with Callout/Aside Support
+Wiki markdown → HTML renderer (markdown-it-py + custom callout/aside support).
 
-This module provides a custom markdown-to-HTML renderer using Mistune,
-with support for Astro Starlight-style callouts/asides.
-
-Syntax:
+Callout syntax:
     :::note
     Content here
     :::
@@ -17,10 +14,11 @@ Supported types: note, tip, caution, danger, warning (alias for caution)
 """
 
 import re
-from html import unescape
-from urllib.parse import quote
 
-import mistune
+from markdown_it import MarkdownIt
+from markdown_it.common.utils import escapeHtml
+from mdit_py_plugins.footnote import footnote_plugin
+from mdit_py_plugins.tasklists import tasklists_plugin
 
 
 def slugify(text: str) -> str:
@@ -103,7 +101,6 @@ def _process_callouts_with_placeholders(content):
 	and a list of callout data to be processed later.
 	"""
 	callouts = []
-	# Use HTML comment-like placeholder that won't be parsed as markdown
 	placeholder_prefix = "WIKICALLOUTPLACEHOLDER"
 
 	def replacer(match):
@@ -123,7 +120,6 @@ def _process_callouts_with_placeholders(content):
 				"content": inner_content.strip(),
 			}
 		)
-		# Return placeholder - use format that won't be parsed as markdown
 		return f"\n\n{placeholder_prefix}{idx}END\n\n"
 
 	# Process callouts (may be nested, so we process iteratively)
@@ -135,12 +131,11 @@ def _process_callouts_with_placeholders(content):
 	return content, callouts, placeholder_prefix
 
 
-def _replace_callout_placeholders(html, callouts, placeholder_prefix, md_instance):
+def _replace_callout_placeholders(html, callouts, placeholder_prefix, render_inner):
 	"""Replace callout placeholders with actual HTML after markdown rendering."""
 	for idx, callout in enumerate(callouts):
 		placeholder = f"{placeholder_prefix}{idx}END"
-		# The placeholder might be wrapped in <p> tags, so handle both cases
-		inner_html = md_instance(callout["content"]) if callout["content"] else ""
+		inner_html = render_inner(callout["content"]) if callout["content"] else ""
 		callout_html = _generate_callout_html(callout["type"], callout["title"], inner_html)
 
 		# Replace placeholder (may be wrapped in <p> tags)
@@ -151,10 +146,8 @@ def _replace_callout_placeholders(html, callouts, placeholder_prefix, md_instanc
 
 
 # Pattern to match markdown image syntax: ![alt](url) or ![alt](url "title")
-# Captures: alt text, URL, and optional title.
 # URL allows one level of balanced parens so Frappe uploads named like
-# `/files/image (14).png` are matched whole (otherwise the inner `)` closes
-# the markdown and the rest of the filename leaks out as plain text).
+# `/files/image (14).png` are matched whole.
 IMAGE_PATTERN = re.compile(
 	r'!\[([^\]]*)\]\(((?:[^()"]|\([^()"]*\))+?)(?:\s+"([^"]*)")?\)',
 )
@@ -231,7 +224,6 @@ def _process_videos_with_placeholders(content: str) -> tuple[str, list[dict], st
 				"title": match.group("title") or "",
 			}
 		)
-		# Force paragraph break around video block
 		return f"\n\n{placeholder_prefix}{idx}END\n\n"
 
 	return VIDEO_MARKDOWN_PATTERN.sub(replacer, content), videos, placeholder_prefix
@@ -247,24 +239,38 @@ def _replace_video_placeholders(html: str, videos: list[dict], placeholder_prefi
 	return html
 
 
+def _encode_image_url_spaces(content: str) -> str:
+	"""
+	Pre-process markdown to URL-encode literal spaces in image URLs.
+
+	CommonMark forbids unescaped whitespace in URLs, but Frappe uploads
+	routinely contain spaces (e.g. `/files/my image.png`). The matching
+	regex tolerates balanced parens so URLs like `/files/image (14).png`
+	are captured whole — the parser handles those parens natively.
+	"""
+
+	def encode_url(match):
+		alt_text = match.group(1)
+		url = match.group(2).strip().replace(" ", "%20")
+		title = match.group(3)
+
+		if title:
+			return f'![{alt_text}]({url} "{title}")'
+		return f"![{alt_text}]({url})"
+
+	return IMAGE_PATTERN.sub(encode_url, content)
+
+
 # Private-use Unicode sentinel — stands in for `|` inside inline-code on table
-# rows during Mistune parsing, then gets swapped back after rendering. Chosen
-# from the PUA block so it cannot collide with authored markdown content.
+# rows during parsing, then gets swapped back after rendering. Both Mistune and
+# markdown-it-py count raw pipes per row in their table plugin and reject the
+# whole block on mismatch, dropping the table to a paragraph; hiding the inner
+# pipes behind a PUA sentinel keeps the column count honest.
 _TABLE_CODE_PIPE_SENTINEL = ""
 
 
 def _escape_table_inline_code_pipes(content: str) -> str:
-	"""
-	Swap `|` characters inside inline-code spans on table-row lines for a
-	sentinel, which is restored after Mistune renders.
-
-	GFM-compliant parsers (marked, markdown-it) treat a backtick-delimited span
-	like `` `dict | list` `` as a single code token, so its `|` is not a column
-	separator. Mistune's table plugin instead counts raw pipes per row and,
-	finding a mismatch, rejects the entire block — the table collapses to a
-	paragraph. Hiding those pipes behind a sentinel makes the column count
-	match, and a post-render replace restores the `|` inside `<code>`.
-	"""
+	"""Swap `|` inside inline-code spans on table-row lines for a sentinel."""
 	lines = content.split("\n")
 	in_fence = False
 	fence_marker: str | None = None
@@ -290,94 +296,41 @@ def _escape_table_inline_code_pipes(content: str) -> str:
 	return "\n".join(lines)
 
 
-def _encode_image_url_unsafe_chars(content: str) -> str:
-	"""
-	Pre-process markdown to URL-encode characters in image URLs that Mistune
-	mishandles.
+def _build_markdown() -> MarkdownIt:
+	"""Build a configured markdown-it-py instance with our render overrides."""
+	md = (
+		MarkdownIt("commonmark", {"html": True, "linkify": False, "typographer": False})
+		.enable(["table", "strikethrough"])
+		.use(footnote_plugin)
+		.use(tasklists_plugin, enabled=True)
+	)
 
-	Mistune (unlike markdown2) doesn't allow spaces in URLs, and its image
-	parser stops at the first `)` even when parens are balanced — so a Frappe
-	upload like `/files/image (14).png` ends up with src=`/files/image%20(14`
-	and `.png)` leaking out as text. We pre-encode literal `(`, `)`, and ` `
-	so Mistune sees a clean URL.
-
-	Args:
-	    content: Markdown string
-
-	Returns:
-	    Markdown string with unsafe chars in image URLs percent-encoded
-	"""
-
-	def encode_url(match):
-		alt_text = match.group(1)
-		url = match.group(2).strip()
-		title = match.group(3)
-
-		encoded_url = url.replace("(", "%28").replace(")", "%29").replace(" ", "%20")
-
-		if title:
-			return f'![{alt_text}]({encoded_url} "{title}")'
-		return f"![{alt_text}]({encoded_url})"
-
-	return IMAGE_PATTERN.sub(encode_url, content)
-
-
-class WikiRenderer(mistune.HTMLRenderer):
-	"""Custom HTML renderer.
-
-	Image captions use the Stack Overflow pattern:
-	    ![alt text](image.jpg)
-	    *caption text*
-
-	This renders as <p><img ...><em>caption</em></p> (no blank line between).
-	Style with CSS: img + em { ... }
-	Alt text remains for accessibility, caption is separate.
-	"""
-
-	def __init__(self, **kwargs):
-		super().__init__(**kwargs)
-		self._heading_slugs = {}  # Track used slugs to avoid duplicates
-		self._headings = []  # Track headings for TOC
-
-	def block_code(self, code: str, info: str | None = None) -> str:
+	def _render_codeblock_html(content: str, lang: str = "") -> str:
 		# Trim trailing whitespace the author left inside the fence — spaces,
 		# tabs, and blank lines all render as phantom empty rows in <pre>.
-		return super().block_code(code.rstrip() + "\n", info)
+		content = content.rstrip() + "\n"
+		cls = f' class="language-{escapeHtml(lang)}"' if lang else ""
+		return f"<pre><code{cls}>{escapeHtml(content)}</code></pre>\n"
 
-	def heading(self, text: str, level: int, **attrs) -> str:
-		"""Render heading with slugified ID for anchor links."""
-		# Generate base slug from heading text
-		slug = slugify(text)
+	def fence_rstrip(tokens, idx, options, env):
+		tok = tokens[idx]
+		lang = next(iter((tok.info or "").split()), "")
+		return _render_codeblock_html(tok.content, lang)
 
-		# Handle empty slugs
-		if not slug:
-			slug = "heading"
+	def code_block_rstrip(tokens, idx, options, env):
+		return _render_codeblock_html(tokens[idx].content)
 
-		# Ensure unique slugs by appending numbers for duplicates
-		original_slug = slug
-		counter = 1
-		while slug in self._heading_slugs:
-			slug = f"{original_slug}-{counter}"
-			counter += 1
+	md.renderer.rules["fence"] = fence_rstrip
+	md.renderer.rules["code_block"] = code_block_rstrip
 
-		self._heading_slugs[slug] = True
+	def image_render(tokens, idx, options, env):
+		tok = tokens[idx]
+		src = tok.attrGet("src") or ""
+		alt = _remove_script_tags(tok.content)
+		title = _remove_script_tags(tok.attrGet("title") or "")
 
-		# Track h2 and h3 headings for TOC
-		if level in (2, 3):
-			self._headings.append(
-				{"id": slug, "text": unescape(re.sub(r"<[^>]+>", "", text)), "level": level}
-			)
-
-		return f'<h{level} id="{slug}">{text}</h{level}>\n'
-
-	def image(self, text: str, url: str, title: str | None = None) -> str:
-		"""Render video URLs as HTML5 video blocks; others as normal images."""
-		src = self.safe_url(url)
-		alt = _remove_script_tags(text)
-		safe_title = _remove_script_tags(title)
-
-		if _is_video_url(url):
-			title_attr = f' title="{safe_title}"' if safe_title else ""
+		if _is_video_url(src):
+			title_attr = f' title="{title}"' if title else ""
 			data_alt_attr = f' data-alt="{alt}"' if alt else ""
 			return (
 				f'<div data-type="video-block" data-src="{src}"{data_alt_attr}>'
@@ -385,15 +338,44 @@ class WikiRenderer(mistune.HTMLRenderer):
 				f'<source src="{src}" />'
 				"</video></div>"
 			)
-
 		s = f'<img src="{src}" alt="{alt}"'
-		if safe_title:
-			s += f' title="{safe_title}"'
+		if title:
+			s += f' title="{title}"'
 		return s + " />"
 
-	def get_headings(self) -> list:
-		"""Return the list of h2/h3 headings extracted during rendering."""
-		return self._headings
+	md.renderer.rules["image"] = image_render
+	return md
+
+
+def _apply_heading_slugs_and_toc(tokens, md: MarkdownIt) -> list[dict]:
+	"""
+	Walk parsed tokens, assign unique slug IDs to every heading, and collect
+	h2/h3 entries for the table of contents.
+	"""
+	used: set[str] = set()
+	headings: list[dict] = []
+
+	for i, tok in enumerate(tokens):
+		if tok.type != "heading_open":
+			continue
+		inline = tokens[i + 1] if i + 1 < len(tokens) else None
+		raw_text = inline.content if inline and inline.type == "inline" else ""
+
+		slug = base = slugify(raw_text) or "heading"
+		counter = 1
+		while slug in used:
+			slug = f"{base}-{counter}"
+			counter += 1
+		used.add(slug)
+		tok.attrSet("id", slug)
+
+		level = int(tok.tag[1])  # "h2" -> 2
+		if level in (2, 3):
+			# Render the inline as plain text so TOC entries drop markdown syntax
+			text = md.renderer.renderInlineAsText(inline.children or [], md.options, {})
+			headings.append({"id": slug, "text": text, "level": level})
+
+	return headings
 
 
 def render_markdown_with_toc(content: str) -> tuple[str, list]:
@@ -409,48 +391,23 @@ def render_markdown_with_toc(content: str) -> tuple[str, list]:
 	if not content:
 		return "", []
 
-	# Create a base Mistune markdown instance with custom renderer
-	# Note: escape=False must be passed to the renderer, not create_markdown
-	renderer = WikiRenderer(escape=False)
-	md = mistune.create_markdown(
-		renderer=renderer,
-		plugins=[
-			"strikethrough",
-			"footnotes",
-			"table",
-			"task_lists",
-		],
-	)
+	md = _build_markdown()
 
-	# Step 1: URL-encode unsafe chars (spaces, parens) in image URLs that
-	# Mistune would otherwise mishandle.
-	processed_content = _encode_image_url_unsafe_chars(content)
-
-	# Step 1b: Escape `|` inside inline-code spans on table rows so Mistune's
-	# table plugin doesn't miscount columns and drop the table.
+	processed_content = _encode_image_url_spaces(content)
 	processed_content = _escape_table_inline_code_pipes(processed_content)
+	processed_content, callouts, callout_prefix = _process_callouts_with_placeholders(processed_content)
+	processed_content, videos, video_prefix = _process_videos_with_placeholders(processed_content)
 
-	# Step 2: Extract callouts and replace with placeholders
-	processed_content, callouts, placeholder_prefix = _process_callouts_with_placeholders(processed_content)
+	env: dict = {}
+	tokens = md.parse(processed_content, env)
+	headings = _apply_heading_slugs_and_toc(tokens, md)
+	html = md.renderer.render(tokens, md.options, env)
 
-	# Step 3: Extract video blocks and replace with placeholders
-	processed_content, videos, video_placeholder_prefix = _process_videos_with_placeholders(processed_content)
+	html = _replace_callout_placeholders(html, callouts, callout_prefix, md.render)
+	html = _replace_video_placeholders(html, videos, video_prefix)
 
-	# Step 4: Render markdown (placeholders may be wrapped in <p> tags)
-	html = md(processed_content)
-
-	# Step 5: Replace callout placeholders with actual callout HTML
-	html = _replace_callout_placeholders(html, callouts, placeholder_prefix, md)
-
-	# Step 6: Replace video placeholders with block video HTML
-	html = _replace_video_placeholders(html, videos, video_placeholder_prefix)
-
-	# Step 7: Restore pipes that were hidden from the table parser.
 	if _TABLE_CODE_PIPE_SENTINEL in html:
 		html = html.replace(_TABLE_CODE_PIPE_SENTINEL, "|")
-
-	# Get the headings extracted during rendering
-	headings = renderer.get_headings()
 
 	return html, headings
 

--- a/wiki/wiki/test_markdown.py
+++ b/wiki/wiki/test_markdown.py
@@ -413,31 +413,28 @@ class TestImageUrlSpaceEncoding(unittest.TestCase):
 		self.assertNotIn("%2520", result)
 
 
-class TestImageUrlParensEncoding(unittest.TestCase):
-	"""Frappe uploads commonly produce names like `image (14).png`. Mistune's
-	image parser stops at the first `)`, so the URL must be pre-encoded for
-	the public page to render correctly."""
+class TestImageUrlWithParens(unittest.TestCase):
+	"""Frappe uploads commonly produce names like `image (14).png`. CommonMark
+	allows one level of balanced parens in URLs, so the parser handles them
+	natively; only literal spaces still need pre-encoding."""
 
 	def test_image_with_literal_parens(self):
 		content = "![](/files/image (14).png)"
 		result = render_markdown(content)
-		self.assertIn('<img src="/files/image%20%2814%29.png"', result)
-		self.assertNotIn(".png)", result)
+		self.assertIn('<img src="/files/image%20(14).png"', result)
+		self.assertNotIn(".png)</p>", result)
 
 	def test_image_with_encoded_space_and_literal_parens(self):
-		"""The form actually emitted by Frappe: space encoded, parens literal.
-
-		This is the case from the Helpdesk docs that triggered the bug.
-		"""
+		"""The form Frappe actually emits: space encoded, parens literal."""
 		content = "![](/files/image%20(14).png)"
 		result = render_markdown(content)
-		self.assertIn('<img src="/files/image%20%2814%29.png"', result)
-		self.assertNotIn(".png)", result)
+		self.assertIn('<img src="/files/image%20(14).png"', result)
+		self.assertNotIn(".png)</p>", result)
 
 	def test_image_with_parens_and_alt_and_title(self):
 		content = '![logo](/files/image (24).png "App Logo")'
 		result = render_markdown(content)
-		self.assertIn('<img src="/files/image%20%2824%29.png"', result)
+		self.assertIn('<img src="/files/image%20(24).png"', result)
 		self.assertIn('alt="logo"', result)
 		self.assertIn('title="App Logo"', result)
 
@@ -445,16 +442,16 @@ class TestImageUrlParensEncoding(unittest.TestCase):
 		"""Image embedded in a sentence still renders as an inline image."""
 		content = "See ![](/files/image (14).png) for context."
 		result = render_markdown(content)
-		self.assertIn('<img src="/files/image%20%2814%29.png"', result)
-		self.assertNotIn(".png)", result)
+		self.assertIn('<img src="/files/image%20(14).png"', result)
+		self.assertNotIn(".png) for", result)
 		self.assertIn("See ", result)
 		self.assertIn(" for context.", result)
 
 	def test_multiple_images_with_parens(self):
-		content = "![](/files/image (14).png)\n\n" "Some text.\n\n" "![](/files/image (15).png)"
+		content = "![](/files/image (14).png)\n\nSome text.\n\n![](/files/image (15).png)"
 		result = render_markdown(content)
-		self.assertIn('<img src="/files/image%20%2814%29.png"', result)
-		self.assertIn('<img src="/files/image%20%2815%29.png"', result)
+		self.assertIn('<img src="/files/image%20(14).png"', result)
+		self.assertIn('<img src="/files/image%20(15).png"', result)
 
 
 class TestRawHTMLRendering(unittest.TestCase):

--- a/wiki/wiki/test_markdown.py
+++ b/wiki/wiki/test_markdown.py
@@ -413,6 +413,50 @@ class TestImageUrlSpaceEncoding(unittest.TestCase):
 		self.assertNotIn("%2520", result)
 
 
+class TestImageUrlParensEncoding(unittest.TestCase):
+	"""Frappe uploads commonly produce names like `image (14).png`. Mistune's
+	image parser stops at the first `)`, so the URL must be pre-encoded for
+	the public page to render correctly."""
+
+	def test_image_with_literal_parens(self):
+		content = "![](/files/image (14).png)"
+		result = render_markdown(content)
+		self.assertIn('<img src="/files/image%20%2814%29.png"', result)
+		self.assertNotIn(".png)", result)
+
+	def test_image_with_encoded_space_and_literal_parens(self):
+		"""The form actually emitted by Frappe: space encoded, parens literal.
+
+		This is the case from the Helpdesk docs that triggered the bug.
+		"""
+		content = "![](/files/image%20(14).png)"
+		result = render_markdown(content)
+		self.assertIn('<img src="/files/image%20%2814%29.png"', result)
+		self.assertNotIn(".png)", result)
+
+	def test_image_with_parens_and_alt_and_title(self):
+		content = '![logo](/files/image (24).png "App Logo")'
+		result = render_markdown(content)
+		self.assertIn('<img src="/files/image%20%2824%29.png"', result)
+		self.assertIn('alt="logo"', result)
+		self.assertIn('title="App Logo"', result)
+
+	def test_image_with_parens_inline_in_paragraph(self):
+		"""Image embedded in a sentence still renders as an inline image."""
+		content = "See ![](/files/image (14).png) for context."
+		result = render_markdown(content)
+		self.assertIn('<img src="/files/image%20%2814%29.png"', result)
+		self.assertNotIn(".png)", result)
+		self.assertIn("See ", result)
+		self.assertIn(" for context.", result)
+
+	def test_multiple_images_with_parens(self):
+		content = "![](/files/image (14).png)\n\n" "Some text.\n\n" "![](/files/image (15).png)"
+		result = render_markdown(content)
+		self.assertIn('<img src="/files/image%20%2814%29.png"', result)
+		self.assertIn('<img src="/files/image%20%2815%29.png"', result)
+
+
 class TestRawHTMLRendering(unittest.TestCase):
 	"""Tests for raw HTML rendering in markdown.
 


### PR DESCRIPTION
## Summary

The user-visible bug: Frappe uploads are named like `image (14).png`, so wiki markdown commonly contains `![](/files/image%20(14).png)` (encoded space, literal parens). After the v3 / TipTap migration, both renderers stopped handling those parens — the first `)` was treated as the markdown URL closer, so the image broke and `.png)` leaked out as text. Every image on the Frappe Helpdesk docs hit this.

This PR ships three commits, narrow → broader:

### 1. TipTap editor fix — `frontend/src/components/tiptap-extensions/image-extension.js`
The custom marked.js tokenizer captured URLs with `[^)"]+`, which stops at the first `)`. Widened the URL group to allow one level of balanced parens (matching CommonMark, which is what marked.js did before this tokenizer overrode it).

### 2. Public-page fix — `wiki/wiki/markdown.py` (Mistune workaround)
Mistune 3.2 has the same paren bug at the library level. Extended the existing image URL pre-encoder to also percent-encode `(` → `%28` and `)` → `%29` (already encoded literal spaces); widened `IMAGE_PATTERN` to match URLs with balanced parens so the pre-encoder can see them. Added 5 tests covering the paren cases.

### 3. Replace Mistune with markdown-it-py — `wiki/wiki/markdown.py`
Rather than keep nursing Mistune's parser quirks, swapped it for [markdown-it-py](https://github.com/executablebooks/markdown-it-py), the Python port of the JS markdown-it library. It's CommonMark-compliant, well-maintained, and handles balanced parens natively.

- **Dependency change:** `mistune>=3.0` → `markdown-it-py>=3.0`, `mdit-py-plugins>=0.4`
- **What was rewritten:** `WikiRenderer` (mistune.HTMLRenderer subclass) → render-rule overrides on the markdown-it-py renderer (`fence`/`code_block` for trailing-whitespace trim; `image` for video-block detection + script-tag stripping on alt/title). Heading slug + TOC extraction moved out of hidden renderer state into an explicit token walk before render. Plugins: `footnote_plugin`, `tasklists_plugin` (table + strikethrough are core).
- **What stayed identical:** callout preprocessor (`:::note` → placeholder → HTML), video preprocessor, image-URL space encoder, inline-code pipe sentinel for table rows (verified by repro that markdown-it-py's table plugin has the same bug as Mistune — it counts raw `|` per row and drops the block on mismatch).
- **Simplifications enabled by the swap:** paren encoding dropped — URLs render as `<img src="/files/image%20(14).png">`. The image URL encoder shrank back to a single `.replace(" ", "%20")`. `TestImageUrlParensEncoding` renamed → `TestImageUrlWithParens`, assertions flipped to the natural form.

Net diff in `markdown.py`: **−47 lines**. All 57 tests pass (52 existing + 5 paren cases).

## Test plan

- [ ] Open a wiki page whose markdown contains `![](/files/image%20(14).png)` (or any `image (N).png` Frappe upload) and confirm the image renders on the **public page**.
- [ ] Open the same page in the **editor** and confirm the image renders, alt/title round-trip, and the Stack Overflow caption pattern (`*caption*` on the next line) still works.
- [ ] Spot-check plain `![alt](/files/foo.png)` and `![alt](/files/foo.png "title")` (no parens) still render.
- [ ] Spot-check a real wiki page with tables (especially one with `|` inside inline code), callouts, code fences with language hints, task lists, footnotes, and h2/h3 headings (TOC anchors).
- [ ] Confirm video URLs (`*.mp4` etc.) still render as the video block.

> Reviewer note: the engine swap (commit 3) is opt-in scope. If you'd rather merge just commits 1–2 (the targeted fixes) and review the swap separately, say the word and I'll split it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Markdown image handling now correctly supports filenames with spaces and one level of parentheses (e.g., "image (24).png"), so such images render reliably.

* **New Features**
  * Markdown processing updated: callouts/asides and block-level video embeds are better recognized and rendered; heading anchors and table-of-contents extraction are improved.

* **Tests**
  * Added tests covering image URL encoding and rendering for filenames with parentheses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frappe/wiki/pull/635?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->