### PR TITLE
fix(e2e): avoid strict-mode violation in sidebar editor test

### DIFF
--- a/e2e/tests/wiki.spec.ts
+++ b/e2e/tests/wiki.spec.ts
@@ -146,7 +146,7 @@ test.describe('Wiki Editor', () => {
 			'button:has-text("Create First Page")',
 		);
 		const newPageButton = page.locator('button[title="New Page"]');
-		await expect(createFirstPage.or(newPageButton)).toBeVisible({
+		await expect(createFirstPage.or(newPageButton).first()).toBeVisible({
 			timeout: 10000,
 		});
 


### PR DESCRIPTION
## Problem

The `should open wiki editor when clicking page in sidebar` Playwright test fails intermittently on `develop` with a strict-mode violation:

```
Error: strict mode violation: locator('button:has-text("Create First Page")').or(locator('button[title="New Page"]')) resolved to 2 elements
```

When the selected space has no pages, the sidebar renders **both** the empty-state `Create First Page` button **and** the header `New Page` icon button. `createFirstPage.or(newPageButton)` then resolves to two elements, which Playwright rejects under strict mode.

## Fix

Add `.first()` to the assertion, matching the pattern already used in the sibling test a few lines above. The subsequent logic already disambiguates which button to click, so this only affects the initial visibility wait.

Failing run: https://github.com/frappe/wiki/actions/runs/26833306765/job/79120335207

🤖 Generated with [Claude Code](https://claude.com/claude-code)