### PR TITLE
fix(editor): parse markdown image URLs containing spaces

### DIFF
--- a/frontend/src/components/tiptap-extensions/image-extension.js
+++ b/frontend/src/components/tiptap-extensions/image-extension.js
@@ -4,7 +4,12 @@ import ImageNodeView from './ImageNodeView.vue';
 import { isVideoUrl } from './video-block.js';
 
 // Markdown image regex: ![alt](src "title")
-const inputRegex = /(?:^|\s)(!\[(.+|:?)]\((\S+)(?:(?:\s+)["'](\S+)["'])?\))$/;
+// The src allows spaces and one level of balanced parens so Frappe filenames
+// like `/files/CleanShot 2026-05-27 at 00.06.09@2x.png` or `/files/image (24).png`
+// round-trip correctly. The src group is non-greedy so the optional title
+// (quoted, whitespace-separated) is still split off rather than swallowed.
+const inputRegex =
+	/(?:^|\s)(!\[([^\]]*)]\(((?:[^()"]|\([^()"]*\))+?)(?:\s+["']([^"']+)["'])?\))$/;
 
 /**
  * Custom Image extension with caption support
@@ -31,10 +36,13 @@ const imageCaptionTokenizer = {
 
 	tokenize(src, tokens, lexer) {
 		// Match: ![alt](src) or ![alt](src "title") optionally followed by \n*caption*
-		// URL allows one level of balanced parens so Frappe filenames like
-		// `/files/image (24).png` survive (otherwise the inner `)` closes the markdown).
+		// The URL allows spaces and one level of balanced parens so Frappe
+		// filenames like `/files/CleanShot 2026-05-27 at 00.06.09@2x.png` or
+		// `/files/image (24).png` survive (otherwise spaces / inner `)` break it).
+		// The URL group is non-greedy so a trailing quoted title is still split
+		// off instead of being absorbed into the src.
 		const imagePattern =
-			/^!\[([^\]]*)\]\(((?:[^()"\s]|\([^()"]*\))+)(?:\s+"([^"]*)")?\)/;
+			/^!\[([^\]]*)\]\(((?:[^()"]|\([^()"]*\))+?)(?:\s+"([^"]*)")?\)/;
 		const captionPattern = /^\n\*([^*]+)\*/;
 
 		const imageMatch = imagePattern.exec(src);
@@ -42,7 +50,8 @@ const imageCaptionTokenizer = {
 			return undefined;
 		}
 
-		const [imageRaw, alt, href, title] = imageMatch;
+		const [imageRaw, alt, hrefRaw, title] = imageMatch;
+		const href = (hrefRaw || '').trim();
 		if (isVideoUrl(href)) {
 			return undefined;
 		}


### PR DESCRIPTION
## Problem

Uploaded images whose filenames contain spaces render as **literal markdown text** after a save/reload cycle, e.g.:

```
![](/files/CleanShot 2026-05-27 at 00.06.09@2x.png)
```

### Why

It's a round-trip bug:

1. Frappe preserves the original filename on upload, so `file_url` can contain spaces.
2. In-session the image renders fine (it's an image node).
3. On save the editor serializes it to `![](...)`.
4. On reload, the `@tiptap/markdown` tokenizer tries to re-parse it — but both the marked tokenizer regex (`[^()"\s]`) and the input-rule regex (`\S+`) **excluded whitespace** from the URL, so the match failed and the line fell back to literal text.

(`@` / `:` were never the problem — only spaces.)

## Fix

Allow spaces in the image URL in both regexes in `image-extension.js`, while keeping the existing balanced-paren support so `/files/image (24).png` still works. The URL group is non-greedy so a trailing quoted title is still split off rather than absorbed, and the parsed href is trimmed to drop any stray trailing space before the closing `)`.

Verified the updated patterns against: plain URLs, spaces, `@`, balanced parens, and quoted titles — all parse correctly and round-trip.

## Scope

Frontend editor only. Public/server-side markdown rendering already handles these URLs, so no backend change is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)