### PR TITLE
feat(editor): dynamic browser tab titles

### DIFF
--- a/frontend/src/components/DraftContributionPanel.vue
+++ b/frontend/src/components/DraftContributionPanel.vue
@@ -125,7 +125,9 @@ import {
 	Dropdown,
 	FormControl,
 	LoadingIndicator,
+	getCachedDocumentResource,
 	toast,
+	usePageMeta,
 } from 'frappe-ui';
 import { computed, onMounted, ref, watch } from 'vue';
 import { useRouter } from 'vue-router';
@@ -165,6 +167,17 @@ const loadFailed = ref(false);
 // Guards against a slow response for a page we've already navigated away
 // from overwriting the page the user is now looking at.
 let loadToken = 0;
+
+// Browser tab title: "{draft page} | {space}". Returning undefined while the
+// draft is still loading keeps the previous title instead of flashing a blank one.
+usePageMeta(() => {
+	const title = crPage.value?.title;
+	if (!title) return;
+	const space = props.spaceId
+		? getCachedDocumentResource('Wiki Space', props.spaceId)
+		: null;
+	return { title: [title, space?.doc?.space_name].filter(Boolean).join(' | ') };
+});
 
 // Read the page through the workspace store. Tmp pages live entirely on the
 // client; the store returns them from pagesByKey without hitting the

--- a/frontend/src/components/SpaceWelcome.vue
+++ b/frontend/src/components/SpaceWelcome.vue
@@ -11,5 +11,17 @@
 </template>
 
 <script setup>
+import { getCachedDocumentResource, usePageMeta } from 'frappe-ui';
+import { useRoute } from 'vue-router';
 import LucideFileText from '~icons/lucide/file-text';
+
+const route = useRoute();
+
+// SpaceDetails (the parent layout) creates the Wiki Space document resource,
+// so this is always a cache read — never a fetch.
+usePageMeta(() => {
+	const space = getCachedDocumentResource('Wiki Space', route.params.spaceId);
+	if (!space?.doc) return;
+	return { title: `${space.doc.space_name} | Frappe Wiki` };
+});
 </script>

--- a/frontend/src/components/WikiDocumentPanel.vue
+++ b/frontend/src/components/WikiDocumentPanel.vue
@@ -144,7 +144,9 @@ import {
 	Dropdown,
 	FormControl,
 	createDocumentResource,
+	getCachedDocumentResource,
 	toast,
+	usePageMeta,
 } from 'frappe-ui';
 import { computed, ref, shallowRef, watch } from 'vue';
 import LucideExternalLink from '~icons/lucide/external-link';
@@ -310,6 +312,17 @@ const displayPublished = computed(() => {
 
 const displayRoute = computed(() => {
 	return activePage.value?.route || currentCrPage.value?.route || wikiDoc.value.doc?.route || '';
+});
+
+// Browser tab title: "{page} | {space}". Returning undefined while the doc
+// is still loading keeps the previous title instead of flashing a blank one.
+usePageMeta(() => {
+	const title = displayTitle.value;
+	if (!title) return;
+	const space = props.spaceId
+		? getCachedDocumentResource('Wiki Space', props.spaceId)
+		: null;
+	return { title: [title, space?.doc?.space_name].filter(Boolean).join(' | ') };
 });
 
 watch(

--- a/frontend/src/pages/ContributionReview.vue
+++ b/frontend/src/pages/ContributionReview.vue
@@ -276,7 +276,7 @@
 <script setup>
 import { ref, computed, reactive } from 'vue';
 import { useRouter } from 'vue-router';
-import { createDocumentResource, createResource, Button, Badge, Dialog, FormControl, LoadingIndicator, toast } from 'frappe-ui';
+import { createDocumentResource, createResource, Button, Badge, Dialog, FormControl, LoadingIndicator, toast, usePageMeta } from 'frappe-ui';
 import { useUserStore } from '@/stores/user';
 
 const router = useRouter();
@@ -317,6 +317,11 @@ const changeRequest = createDocumentResource({
 	doctype: 'Wiki Change Request',
 	name: props.changeRequestId,
 	auto: true,
+});
+
+usePageMeta(() => {
+	if (!changeRequest.doc) return;
+	return { title: `${changeRequest.doc.title} | Frappe Wiki` };
 });
 
 const changes = createResource({

--- a/frontend/src/pages/Contributions.vue
+++ b/frontend/src/pages/Contributions.vue
@@ -90,8 +90,10 @@
 <script setup>
 import { computed } from 'vue';
 import { useRouteQuery } from '@vueuse/router';
-import { ListView, Badge, Tabs, Button, LoadingIndicator, createListResource } from 'frappe-ui';
+import { ListView, Badge, Tabs, Button, LoadingIndicator, createListResource, usePageMeta } from 'frappe-ui';
 import { useUserStore } from '@/stores/user';
+
+usePageMeta(() => ({ title: `${__('Change Requests')} | Frappe Wiki` }));
 
 const tabQuery = useRouteQuery('tab', 'my');
 const userStore = useUserStore();

--- a/frontend/src/pages/Spaces.vue
+++ b/frontend/src/pages/Spaces.vue
@@ -4,4 +4,7 @@
 
 <script setup>
 import SpaceList from '@/components/SpaceList.vue';
+import { usePageMeta } from 'frappe-ui';
+
+usePageMeta(() => ({ title: `${__('Spaces')} | Frappe Wiki` }));
 </script>


### PR DESCRIPTION
### Current state

The browser tab always says "Frappe Wiki", no matter where you are in the app. With several wiki tabs open there's no way to tell them apart, and browser history/bookmarks are equally unhelpful.

### After this change

The tab title reflects what's actually open, and updates live (e.g. when you rename a page):

| Where you are | Tab title |
|---|---|
| Spaces list | `Spaces \| Frappe Wiki` |
| Space welcome | `{space} \| Frappe Wiki` |
| Page / draft editor | `{page} \| {space}` |
| Change requests list | `Change Requests \| Frappe Wiki` |
| Change request review | `{CR title} \| Frappe Wiki` |

Uses frappe-ui's `usePageMeta` — the plugin was already registered in `main.js`, just never used. While data is loading the previous title is kept, so nothing flashes blank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)