### PR TITLE
feat(editor): auto-convert uploaded images to WebP

### DIFF
--- a/e2e/tests/webp-conversion.spec.ts
+++ b/e2e/tests/webp-conversion.spec.ts
@@ -1,0 +1,212 @@
+import { randomUUID } from 'node:crypto';
+import { deflateSync } from 'node:zlib';
+import { type Page, expect, test } from '@playwright/test';
+import { deleteDoc, getList, updateDoc } from '../helpers/frappe';
+
+/**
+ * E2E coverage for automatic WebP image optimization.
+ *
+ * Spec: specs/automatic_webp_image_optimization.md
+ *
+ * When the `auto_convert_images_to_webp` Wiki Setting is on, images uploaded
+ * through the editor are converted to WebP server-side (via
+ * `wiki.api.upload_wiki_asset`) and embedded with the optimized `.webp` url.
+ * When off, the original format is kept.
+ */
+
+/**
+ * Build a valid RGB PNG entirely in Node, with a unique `tEXt` chunk so the
+ * bytes (and thus Frappe's content hash) differ on every call — even across
+ * separate test-process runs. Without this, identical bytes would trigger
+ * Frappe's content-hash file deduplication and make one upload reuse another's
+ * (possibly already-converted) file. Pillow ignores the tEXt chunk on decode,
+ * so the server-side WebP conversion still works.
+ */
+function crc32(buf: Buffer): number {
+	let c = ~0;
+	for (let i = 0; i < buf.length; i++) {
+		c ^= buf[i];
+		for (let k = 0; k < 8; k++) c = (c >>> 1) ^ (0xedb88320 & -(c & 1));
+	}
+	return ~c >>> 0;
+}
+
+function pngChunk(type: string, data: Buffer): Buffer {
+	const body = Buffer.concat([Buffer.from(type, 'ascii'), data]);
+	const len = Buffer.alloc(4);
+	len.writeUInt32BE(data.length, 0);
+	const crc = Buffer.alloc(4);
+	crc.writeUInt32BE(crc32(body), 0);
+	return Buffer.concat([len, body, crc]);
+}
+
+function makeUniquePng(size = 8): Buffer {
+	const sig = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+	const ihdr = Buffer.alloc(13);
+	ihdr.writeUInt32BE(size, 0);
+	ihdr.writeUInt32BE(size, 4);
+	ihdr[8] = 8; // bit depth
+	ihdr[9] = 2; // color type: RGB
+	const pixel = Buffer.from([40, 120, 220]);
+	const row = Buffer.concat([Buffer.from([0]), ...Array(size).fill(pixel)]);
+	const raw = Buffer.concat(Array(size).fill(row));
+	// tEXt chunk: keyword \0 text — carries a unique nonce.
+	const nonce = Buffer.from(`Comment\0${randomUUID()}`, 'latin1');
+	return Buffer.concat([
+		sig,
+		pngChunk('IHDR', ihdr),
+		pngChunk('tEXt', nonce),
+		pngChunk('IDAT', deflateSync(raw)),
+		pngChunk('IEND', Buffer.alloc(0)),
+	]);
+}
+
+interface FileDoc {
+	name: string;
+	file_name: string;
+	file_url: string;
+}
+
+async function setWebpConversion(
+	request: import('@playwright/test').APIRequestContext,
+	enabled: boolean,
+): Promise<void> {
+	await updateDoc(request, 'Wiki Settings', 'Wiki Settings', {
+		auto_convert_images_to_webp: enabled ? 1 : 0,
+	});
+}
+
+/**
+ * Navigate to the wiki SPA, open the first space, create a fresh page, and wait
+ * until the editor is mounted on its draft. Mirrors the setup used by other
+ * editor e2e tests (image-viewer.spec.ts) but stops at the editable draft.
+ */
+async function openNewPageInEditor(page: Page, title: string): Promise<void> {
+	await page.setViewportSize({ width: 1100, height: 900 });
+	await page.goto('/wiki');
+	await page.waitForLoadState('networkidle');
+
+	const spaceLink = page.locator('a[href*="/wiki/spaces/"]').first();
+	await expect(spaceLink).toBeVisible({ timeout: 5000 });
+	await spaceLink.click();
+	await page.waitForLoadState('networkidle');
+
+	const createFirstPage = page.locator('button:has-text("Create First Page")');
+	const newPageButton = page.locator('button[title="New Page"]');
+	if (await createFirstPage.isVisible({ timeout: 2000 }).catch(() => false)) {
+		await createFirstPage.click();
+	} else {
+		await newPageButton.click();
+	}
+
+	await page.getByLabel('Title').fill(title);
+	const createDialog = page.getByRole('dialog');
+	await createDialog.getByRole('button', { name: 'Save' }).click();
+	await expect(createDialog).toBeHidden();
+	await expect(page.locator('.dialog-overlay')).toBeHidden();
+	await page.waitForLoadState('networkidle');
+
+	const pageTitleInput = page.getByRole('textbox', { name: 'Page title' });
+	const openedCreatedPage = await pageTitleInput
+		.inputValue({ timeout: 2000 })
+		.then((value) => value === title)
+		.catch(() => false);
+	if (!openedCreatedPage) {
+		await page.locator('aside').getByText(title, { exact: true }).click();
+	}
+	await expect(pageTitleInput).toHaveValue(title, { timeout: 10000 });
+
+	const editor = page.locator('.ProseMirror, [contenteditable="true"]');
+	await expect(editor).toBeVisible({ timeout: 10000 });
+	await editor.click();
+}
+
+/**
+ * Upload an image into the open editor via the hidden slash-command file input,
+ * which routes through the same `insertAndUploadImage` path as paste/drop/toolbar.
+ */
+async function uploadImage(page: Page, fileName: string): Promise<void> {
+	await page.locator('input.hidden-file-input').setInputFiles({
+		name: fileName,
+		mimeType: 'image/png',
+		buffer: makeUniquePng(),
+	});
+}
+
+test.describe('Automatic WebP image optimization', () => {
+	// The setting is global; always restore it to the default (on) afterwards.
+	test.afterEach(async ({ request }) => {
+		await setWebpConversion(request, true);
+	});
+
+	// Best-effort: remove the File docs these tests uploaded so they don't
+	// accumulate on the site across runs.
+	test.afterAll(async ({ request }) => {
+		const files = await getList<FileDoc>(request, 'File', {
+			fields: ['name'],
+			filters: { file_name: ['like', 'e2e-webp-%'] },
+			limit: 200,
+		}).catch(() => [] as FileDoc[]);
+		for (const f of files) {
+			await deleteDoc(request, 'File', f.name).catch(() => {});
+		}
+	});
+
+	test('converts an uploaded PNG to WebP when the setting is enabled', async ({
+		page,
+		request,
+	}) => {
+		await setWebpConversion(request, true);
+
+		const stamp = Date.now();
+		const fileName = `e2e-webp-on-${stamp}.png`;
+		await openNewPageInEditor(page, `webp-on-${stamp}`);
+		await uploadImage(page, fileName);
+
+		// The node first shows a base64 preview (loading), then swaps to the
+		// converted /files/<name>.webp url once the upload resolves.
+		const img = page.locator('img.wiki-image').first();
+		await expect(img).toHaveAttribute('src', /\/files\/.*\.webp$/, {
+			timeout: 20000,
+		});
+
+		const src = await img.getAttribute('src');
+		expect(src).toContain(`e2e-webp-on-${stamp}`);
+		expect(src).not.toMatch(/data:/); // not still the preview
+		expect(src).not.toMatch(/\.png(\?|$)/);
+
+		// Backend: the File doc is webp and no original .png lingers.
+		const files = await getList<FileDoc>(request, 'File', {
+			fields: ['name', 'file_name', 'file_url'],
+			filters: { file_name: ['like', `e2e-webp-on-${stamp}%`] },
+			limit: 5,
+		});
+		expect(files.length).toBeGreaterThan(0);
+		for (const f of files) {
+			expect(f.file_url).toMatch(/\.webp$/);
+			expect(f.file_url).not.toMatch(/\.png$/);
+		}
+	});
+
+	test('keeps the original format when the setting is disabled', async ({
+		page,
+		request,
+	}) => {
+		await setWebpConversion(request, false);
+
+		const stamp = Date.now();
+		const fileName = `e2e-webp-off-${stamp}.png`;
+		await openNewPageInEditor(page, `webp-off-${stamp}`);
+		await uploadImage(page, fileName);
+
+		// With conversion off, the image stays a .png served from /files.
+		const img = page.locator('img.wiki-image').first();
+		await expect(img).toHaveAttribute('src', /\/files\/.*\.png$/, {
+			timeout: 20000,
+		});
+
+		const src = await img.getAttribute('src');
+		expect(src).toContain(`e2e-webp-off-${stamp}`);
+		expect(src).not.toMatch(/\.webp/);
+	});
+});

--- a/frontend/src/components/WikiEditor.vue
+++ b/frontend/src/components/WikiEditor.vue
@@ -127,6 +127,10 @@ async function uploadFile(file) {
 		const isImage = file.type.includes('image');
 		const result = await fileUploader.upload(file, {
 			private: false,
+			// Hit our handler directly (not via upload_file's `method` delegation,
+			// which would recurse). It converts PNG/JPEG to WebP when the Wiki
+			// Setting is enabled, returning the optimized file_url.
+			upload_endpoint: '/api/method/wiki.api.upload_wiki_asset',
 		});
 
 		toast.success(`${isImage ? 'Image' : 'File'} uploaded successfully`);
@@ -134,6 +138,75 @@ async function uploadFile(file) {
 	} catch (error) {
 		toast.error('Failed to upload file');
 		throw error;
+	}
+}
+
+/**
+ * Read a file into a base64 data URL for an instant local preview.
+ */
+function fileToBase64(file) {
+	return new Promise((resolve, reject) => {
+		const reader = new FileReader();
+		reader.onload = () => resolve(reader.result);
+		reader.onerror = reject;
+		reader.readAsDataURL(file);
+	});
+}
+
+/**
+ * Patch the attributes of the in-flight image node identified by uploadId.
+ */
+function updateImageNode(uploadId, attrs) {
+	const ed = editor.value;
+	if (!ed) return;
+	const { state, view } = ed;
+	let target = null;
+	state.doc.descendants((node, pos) => {
+		if (node.type.name === 'image' && node.attrs.uploadId === uploadId) {
+			target = { node, pos };
+			return false;
+		}
+	});
+	if (!target) return;
+	const tr = state.tr.setNodeMarkup(target.pos, undefined, {
+		...target.node.attrs,
+		...attrs,
+	});
+	view.dispatch(tr);
+}
+
+/**
+ * Insert an image immediately with a local preview + loading overlay, upload
+ * it in the background, then swap in the final URL (or surface an error).
+ */
+async function insertAndUploadImage(file) {
+	const ed = editor.value;
+	if (!ed) return;
+
+	const uploadId = `upload-${Date.now()}-${Math.random()
+		.toString(36)
+		.slice(2, 9)}`;
+
+	let preview = '';
+	try {
+		preview = await fileToBase64(file);
+	} catch {
+		preview = '';
+	}
+
+	ed.chain()
+		.focus()
+		.setImage({ src: preview, uploadId, loading: true })
+		.run();
+
+	try {
+		const url = await uploadFile(file);
+		updateImageNode(uploadId, { src: url, loading: false, error: null });
+	} catch (error) {
+		updateImageNode(uploadId, {
+			loading: false,
+			error: error?.message || 'Failed to upload image',
+		});
 	}
 }
 
@@ -149,11 +222,7 @@ function handlePaste(_view, event) {
 			event.preventDefault();
 			const file = item.getAsFile();
 			if (file) {
-				uploadFile(file).then((url) => {
-					if (editor.value) {
-						editor.value.chain().focus().setImage({ src: url }).run();
-					}
-				});
+				insertAndUploadImage(file);
 			}
 			return true;
 		}
@@ -192,11 +261,7 @@ function handleDrop(_view, event) {
 		const isVideo = file.type.includes('video');
 
 		if (isImage) {
-			uploadFile(file).then((url) => {
-				if (editor.value) {
-					editor.value.chain().focus().setImage({ src: url }).run();
-				}
-			});
+			insertAndUploadImage(file);
 		} else if (isVideo && editor.value) {
 			editor.value.commands.uploadVideo(file);
 		}
@@ -209,14 +274,7 @@ function handleDrop(_view, event) {
  * Handle image upload from toolbar
  */
 async function handleImageUpload(file) {
-	try {
-		const url = await uploadFile(file);
-		if (editor.value) {
-			editor.value.chain().focus().setImage({ src: url }).run();
-		}
-	} catch (error) {
-		console.error('Failed to upload image:', error);
-	}
+	await insertAndUploadImage(file);
 }
 
 /**

--- a/frontend/src/components/tiptap-extensions/ImageNodeView.vue
+++ b/frontend/src/components/tiptap-extensions/ImageNodeView.vue
@@ -1,17 +1,28 @@
 <template>
     <NodeViewWrapper class="wiki-image-wrapper" :class="{ 'is-selected': selected }">
         <div class="wiki-image-container">
-            <img
-                :src="node.attrs.src"
-                :alt="node.attrs.alt || ''"
-                :title="node.attrs.title || ''"
-                :width="node.attrs.width || undefined"
-                :height="node.attrs.height || undefined"
-                class="wiki-image"
-                @click="selectNode"
-            />
+            <div class="wiki-image-frame">
+                <img
+                    :src="node.attrs.src"
+                    :alt="node.attrs.alt || ''"
+                    :title="node.attrs.title || ''"
+                    :width="node.attrs.width || undefined"
+                    :height="node.attrs.height || undefined"
+                    class="wiki-image"
+                    :class="{ 'is-loading': node.attrs.loading }"
+                    @click="selectNode"
+                />
+                <!-- Upload / optimization progress overlay -->
+                <div v-if="node.attrs.loading" class="wiki-image-loading-overlay">
+                    <span class="wiki-image-spinner" />
+                    <span class="wiki-image-loading-text">Uploading…</span>
+                </div>
+            </div>
+            <div v-if="node.attrs.error" class="wiki-image-error">
+                Upload failed: {{ node.attrs.error }}
+            </div>
             <input
-                v-if="editor.isEditable || node.attrs.caption"
+                v-if="(editor.isEditable || node.attrs.caption) && !node.attrs.error"
                 ref="captionInput"
                 v-model="caption"
                 type="text"
@@ -122,12 +133,59 @@ function handleKeydown(event) {
     margin: 0;
 }
 
+.wiki-image-frame {
+    position: relative;
+    display: inline-flex;
+    max-width: 100%;
+}
+
 .wiki-image {
     max-width: 100%;
     height: auto;
     border-radius: 0.375rem;
     cursor: pointer;
     margin: 0;
+}
+
+.wiki-image.is-loading {
+    filter: brightness(0.7);
+}
+
+.wiki-image-loading-overlay {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    border-radius: 0.375rem;
+    background: rgba(17, 17, 17, 0.35);
+    color: #fff;
+    font-size: 0.8125rem;
+}
+
+.wiki-image-spinner {
+    width: 1.25rem;
+    height: 1.25rem;
+    border: 2px solid rgba(255, 255, 255, 0.4);
+    border-top-color: #fff;
+    border-radius: 50%;
+    animation: wiki-image-spin 0.7s linear infinite;
+}
+
+@keyframes wiki-image-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.wiki-image-error {
+    width: 100%;
+    text-align: center;
+    font-size: 0.8125rem;
+    color: var(--ink-red-5, #dc2626);
+    padding: 0.5rem 0;
 }
 
 .wiki-image-caption-input {

--- a/frontend/src/components/tiptap-extensions/image-extension.js
+++ b/frontend/src/components/tiptap-extensions/image-extension.js
@@ -112,6 +112,21 @@ export const WikiImage = Node.create({
 			height: {
 				default: null,
 			},
+			// Transient editor-only state for the upload/optimization lifecycle.
+			// `rendered: false` keeps these out of the serialized HTML, and
+			// renderMarkdown ignores them, so they never persist to content.
+			loading: {
+				default: false,
+				rendered: false,
+			},
+			uploadId: {
+				default: null,
+				rendered: false,
+			},
+			error: {
+				default: null,
+				rendered: false,
+			},
 		};
 	},
 
@@ -150,6 +165,13 @@ export const WikiImage = Node.create({
 	// ![alt](src "title")
 	// *caption*
 	renderMarkdown: (node) => {
+		// Skip images still uploading/optimizing — their `src` is a transient
+		// base64 preview that must never be written to saved content. Once the
+		// upload resolves, `loading` clears and the node re-serializes normally.
+		if (node.attrs?.loading) {
+			return '';
+		}
+
 		const src = node.attrs?.src ?? '';
 		const alt = node.attrs?.alt ?? '';
 		const title = node.attrs?.title ?? '';

--- a/wiki/api/__init__.py
+++ b/wiki/api/__init__.py
@@ -1,5 +1,9 @@
+import os
+
 import frappe
 from frappe.translate import get_all_translations
+
+CONVERTIBLE_IMAGE_EXTENSIONS = (".png", ".jpeg", ".jpg")
 
 
 @frappe.whitelist()
@@ -32,3 +36,65 @@ def get_translations():
 		language = frappe.db.get_single_value("System Settings", "language")
 
 	return get_all_translations(language)
+
+
+def _to_webp(path_or_url: str) -> str:
+	"""Swap any file extension for `.webp` (works for both fs paths and URLs)."""
+	return os.path.splitext(path_or_url)[0] + ".webp"
+
+
+def convert_file_to_webp(file_doc) -> str:
+	"""Convert a local PNG/JPEG File doc to WebP in place.
+
+	Replaces the file on disk, deletes the original, and updates the doc's
+	file_url. Returns the new (or unchanged, if not convertible) file_url.
+	"""
+	from frappe.core.doctype.file.file import get_local_image
+	from frappe.core.doctype.file.utils import delete_file
+
+	if not file_doc:
+		return ""
+
+	file_url = file_doc.file_url or ""
+	# Only act on local site files of a convertible raster format.
+	if not file_url.startswith("/files") or not file_url.lower().endswith(CONVERTIBLE_IMAGE_EXTENSIONS):
+		return file_url
+
+	try:
+		image, _, _ = get_local_image(file_url)
+		image.save(_to_webp(file_doc.get_full_path()), "WEBP")
+	except Exception:
+		# Corrupt or unsupported image — keep the original upload rather than
+		# failing the whole request and losing the author's image.
+		frappe.log_error(title="Wiki WebP conversion failed")
+		return file_url
+
+	# delete_file resolves public/private from the URL's leading segment, so it
+	# must be given the /files/... url — not the absolute filesystem path.
+	delete_file(file_url)
+
+	file_doc.file_url = _to_webp(file_url)
+	if file_doc.file_name:
+		file_doc.file_name = _to_webp(file_doc.file_name)
+	file_doc.save()
+	return file_doc.file_url
+
+
+@frappe.whitelist()
+def upload_wiki_asset():
+	"""Upload handler for wiki editor assets.
+
+	Wraps Frappe's standard file upload. When the `auto_convert_images_to_webp`
+	Wiki Setting is enabled, uploaded PNG/JPEG images are converted to WebP
+	before the File doc is returned, so the editor receives the optimized URL.
+	"""
+	from frappe.handler import upload_file
+
+	file_doc = upload_file()
+	if (
+		file_doc
+		and (file_doc.file_url or "").lower().endswith(CONVERTIBLE_IMAGE_EXTENSIONS)
+		and frappe.get_cached_value("Wiki Settings", "Wiki Settings", "auto_convert_images_to_webp")
+	):
+		convert_file_to_webp(file_doc)
+	return file_doc

--- a/wiki/patches.txt
+++ b/wiki/patches.txt
@@ -16,3 +16,4 @@ wiki.wiki.doctype.wiki_space.patches.v3.assign_wiki_user_to_active_users
 wiki.wiki.doctype.wiki_space.patches.v3.migrate_orphan_pages_to_wiki_document
 wiki.frappe_wiki.doctype.wiki_revision.patches.convert_open_crs_to_overlay
 wiki.frappe_wiki.doctype.wiki_content_blob.patches.unescape_iframe_embeds
+execute:frappe.db.set_single_value('Wiki Settings', 'auto_convert_images_to_webp', 1) #2026-06-10

--- a/wiki/wiki/doctype/wiki_settings/wiki_settings.json
+++ b/wiki/wiki/doctype/wiki_settings/wiki_settings.json
@@ -10,6 +10,7 @@
   "default_wiki_space",
   "table_of_contents_section",
   "enable_table_of_contents",
+  "auto_convert_images_to_webp",
   "feedback_tab",
   "feedback_section",
   "enable_feedback",
@@ -57,6 +58,13 @@
    "fieldname": "enable_table_of_contents",
    "fieldtype": "Check",
    "label": "Enable Table of Contents"
+  },
+  {
+   "default": "1",
+   "description": "Automatically convert uploaded PNG/JPEG images to WebP to reduce page size.",
+   "fieldname": "auto_convert_images_to_webp",
+   "fieldtype": "Check",
+   "label": "Convert Uploaded Images to WebP"
   },
   {
    "fieldname": "feedback_section",


### PR DESCRIPTION
Adds a Wiki Setting (**on by default**) that converts PNG/JPEG images uploaded in the editor to WebP, reducing page weight.

- Toggle `auto_convert_images_to_webp` in Wiki Settings; a patch enables it for existing sites.
- Editor uploads route through `wiki.api.upload_wiki_asset`, which converts via Pillow. Non-images and undecodable files pass through unchanged (the original is kept).
- Uploads show an inline preview + loading state and swap to the optimized URL on success.

e2e test (`webp-conversion.spec.ts`) covers both the on and off paths.