### PR TITLE
feat(sidebar): show logged-in user's name in sidebar header

### DIFF
--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -1,14 +1,7 @@
 <template>
 <Sidebar
 	v-model:collapsed="isSidebarCollapsed"
-	:header="{
-		title: __('Frappe Wiki'),
-		logo: '/assets/wiki/images/wiki-logo.png',
-		menuItems: [
-			{ label: __('Toggle Theme'), icon: themeIcon, onClick: toggleTheme },
-			{ label: __('Log out'), icon: LucideLogOut, onClick: logout },
-		],
-	}"
+	:header="header"
 	:sections="sections"
 />
 </template>
@@ -25,10 +18,12 @@ import LucideRocket from "~icons/lucide/rocket";
 import LucideGitBranch from "~icons/lucide/git-branch";
 import LucideLogOut from "~icons/lucide/log-out";
 import { useSessionStore } from "@/stores/session";
+import { useUserStore } from "@/stores/user";
 
 const route = useRoute();
 const router = useRouter();
 const sessionStore = useSessionStore();
+const userStore = useUserStore();
 
 const userTheme = useStorage("wiki-theme", "dark");
 
@@ -37,6 +32,16 @@ const themeIcon = computed(() => {
 });
 
 const isSidebarCollapsed  = useStorage("is-sidebar-collapsed", false);
+
+const header = computed(() => ({
+	title: __("Frappe Wiki"),
+	subtitle: userStore.data?.full_name,
+	logo: "/assets/wiki/images/wiki-logo.png",
+	menuItems: [
+		{ label: __("Toggle Theme"), icon: themeIcon, onClick: toggleTheme },
+		{ label: __("Log out"), icon: LucideLogOut, onClick: logout },
+	],
+}));
 
 const navItems = [
 	{ label: __("Spaces"), icon: LucideRocket, to: { name: "SpaceList" } },


### PR DESCRIPTION

<img width="628" height="862" alt="image" src="https://github.com/user-attachments/assets/a6c24708-5705-43a3-9deb-3d36d394ed17" />



## Why?

The sidebar header showed only the app name, with no indication of who is logged in. The LMS sidebar already surfaces the logged-in user's name in this spot, so we want parity in Wiki.

## What?

Show the logged-in user's full name as the subtitle in the sidebar header, right below "Frappe Wiki".

## How?

frappe-ui's `SidebarHeader` already supports a `subtitle` prop rendered below the title. The header object in `Sidebar.vue` is now a computed that sets `subtitle: userStore.data?.full_name`, so the name fills in reactively once the user resource loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)