### PR TITLE
perf: index Wiki Revision Item on (revision, doc_key)

### DIFF
--- a/wiki/frappe_wiki/doctype/wiki_revision_item/wiki_revision_item.json
+++ b/wiki/frappe_wiki/doctype/wiki_revision_item/wiki_revision_item.json
@@ -102,7 +102,7 @@
 		}
 	],
 	"links": [],
-	"modified": "2026-02-17 11:54:37.644118",
+	"modified": "2026-06-21 00:00:00.000000",
 	"modified_by": "Administrator",
 	"module": "Frappe Wiki",
 	"name": "Wiki Revision Item",

--- a/wiki/frappe_wiki/doctype/wiki_revision_item/wiki_revision_item.py
+++ b/wiki/frappe_wiki/doctype/wiki_revision_item/wiki_revision_item.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026, Frappe and contributors
 # For license information, please see license.txt
 
+import frappe
 from frappe.model.document import Document
 
 
@@ -28,3 +29,9 @@ class WikiRevisionItem(Document):
 	# end: auto-generated types
 
 	pass
+
+
+def on_doctype_update():
+	# Page lookups filter on (revision, doc_key); without this index the query
+	# full-scans the table, which is slow once revisions accumulate (1M+ rows on docs.frappe.io).
+	frappe.db.add_index("Wiki Revision Item", ["revision", "doc_key"])


### PR DESCRIPTION
## Problem

`get_cr_page` (and other lookups) filter `Wiki Revision Item` by `(revision, doc_key)`, but the table has no index on those columns. Every lookup full-scans the table. On docs.frappe.io the table has **1.1M+ rows (~370MB)**, so the change-request page API took **2s+**.

`EXPLAIN` on prod:
```
type: ALL   key: NULL   rows: 1101691   Extra: Using where
```

## Solution

Add an `on_doctype_update` hook that creates a composite index on `(revision, doc_key)`, and bump the doctype's `modified` timestamp so the hook runs on `bench migrate`.

After:
```
type: ref   key: revision_doc_key_index   rows: 1
```

Verified locally: `add_index` creates `revision_doc_key_index` and the planner switches from a full scan to a single-row `ref` lookup. The hook is idempotent, so it's a no-op where the index already exists (e.g. prod, where it was added manually).