### PR TITLE
feat: fuzzy search box for the editor tree

### DIFF
--- a/e2e/tests/tree-search.spec.ts
+++ b/e2e/tests/tree-search.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test } from '@playwright/test';
+import { updateDoc } from '../helpers/frappe';
+import { createTestWikiDocument, createTestWikiSpace } from '../helpers/wiki';
+
+/**
+ * E2E tests for the editor tree fuzzy search box.
+ * Verifies that typing filters the in-memory tree in place: matches stay,
+ * non-matches are pruned, ancestor groups auto-expand, route-only matches
+ * surface, and clearing the query restores the full tree.
+ */
+test.describe('Editor Tree Search', () => {
+	test('filters the tree by title and route, then restores on clear', async ({
+		page,
+		request,
+	}) => {
+		const spaceName = `tree-search-${Date.now()}`;
+		const space = await createTestWikiSpace(request, {
+			route: spaceName,
+			is_published: true,
+		});
+
+		const rootGroup = await createTestWikiDocument(request, {
+			title: 'Root',
+			route: `${spaceName}/root`,
+			is_group: true,
+			is_published: true,
+		});
+		await updateDoc(request, 'Wiki Space', space.name, {
+			root_group: rootGroup.name,
+		});
+
+		// Group "Guides" with two pages; one page matches only by route.
+		const guides = await createTestWikiDocument(request, {
+			title: 'Guides',
+			route: `${spaceName}/guides`,
+			is_group: true,
+			is_published: true,
+			parent_wiki_document: rootGroup.name,
+		});
+		await createTestWikiDocument(request, {
+			title: 'Getting Started',
+			route: `${spaceName}/guides/getting-started`,
+			is_published: true,
+			parent_wiki_document: guides.name,
+		});
+		await createTestWikiDocument(request, {
+			title: 'Authentication',
+			route: `${spaceName}/guides/auth-tokens`,
+			is_published: true,
+			parent_wiki_document: guides.name,
+		});
+
+		// A sibling group that should be pruned away on a "Guides" search.
+		const reference = await createTestWikiDocument(request, {
+			title: 'Reference',
+			route: `${spaceName}/reference`,
+			is_group: true,
+			is_published: true,
+			parent_wiki_document: rootGroup.name,
+		});
+		await createTestWikiDocument(request, {
+			title: 'API Keys',
+			route: `${spaceName}/reference/api-keys`,
+			is_published: true,
+			parent_wiki_document: reference.name,
+		});
+
+		await page.goto(`/wiki/spaces/${space.name}`);
+		await page.waitForLoadState('networkidle');
+
+		const tree = page.locator('aside');
+		await expect(tree.getByText('Guides', { exact: true })).toBeVisible({
+			timeout: 10000,
+		});
+
+		const search = page.getByPlaceholder('Search pages...');
+		await expect(search).toBeVisible();
+
+		// Title match: keeps the page + its ancestor group (auto-expanded),
+		// prunes the unrelated branch.
+		await search.fill('getting');
+		await expect(tree.getByText('Getting Started')).toBeVisible();
+		await expect(tree.getByText('Guides', { exact: true })).toBeVisible();
+		await expect(tree.getByText('Reference', { exact: true })).toHaveCount(0);
+		await expect(tree.getByText('API Keys')).toHaveCount(0);
+		await expect(tree.getByText('Authentication')).toHaveCount(0);
+
+		// Route-only match: "auth-tokens" lives only in the route, not the title.
+		await search.fill('auth-tokens');
+		await expect(tree.getByText('Authentication')).toBeVisible();
+		await expect(tree.getByText('Getting Started')).toHaveCount(0);
+
+		// No matches: the empty state shows.
+		await search.fill('zzzznomatch');
+		await expect(tree.getByText('No matches')).toBeVisible();
+
+		// Clearing restores the full tree.
+		await search.fill('');
+		await expect(tree.getByText('Guides', { exact: true })).toBeVisible();
+		await expect(tree.getByText('Reference', { exact: true })).toBeVisible();
+
+		// Cleanup.
+		await page.unrouteAll({ behavior: 'ignoreErrors' });
+	});
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "@vueuse/router": "^14.2.1",
     "feather-icons": "^4.29.2",
     "frappe-ui": "^0.1.235",
+    "fuzzysort": "^3.1.0",
     "highlight.js": "^11.11.1",
     "idb-keyval": "^6.2.0",
     "lowlight": "^3.3.0",

--- a/frontend/src/components/NestedDraggable.vue
+++ b/frontend/src/components/NestedDraggable.vue
@@ -9,7 +9,7 @@
         ghost-class="dragging-ghost"
         drag-class="dragging-item"
         handle=".drag-handle"
-        :disabled="readonly"
+        :disabled="readonly || searchActive"
         :animation="150"
         @start="onDragStart"
         @end="onDragEnd"
@@ -25,7 +25,7 @@
                 >
                     <div class="flex items-center gap-1.5 flex-1 min-w-0">
                         <button
-                            v-if="!readonly"
+                            v-if="!readonly && !searchActive"
                             class="drag-handle p-0.5 hover:bg-surface-gray-3 rounded cursor-grab active:cursor-grabbing opacity-0 group-hover:opacity-100 transition-opacity"
                             @click.stop
                         >
@@ -48,12 +48,18 @@
                         <LucideLink v-else-if="element.is_external_link" class="size-4 text-ink-gray-5 flex-shrink-0" />
                         <LucideFileText v-else class="size-4 text-ink-gray-5 flex-shrink-0" />
 
-                        <span
-                            class="text-sm truncate flex-1 min-w-0"
-                            :class="getTitleClass(element)"
-                        >
-                            {{ element.title }}
-                        </span>
+                        <div class="flex flex-col flex-1 min-w-0">
+                            <span class="text-sm truncate" :class="getTitleClass(element)">
+                                <span v-if="titleHighlight(element)" v-html="titleHighlight(element)" />
+                                <template v-else>{{ element.title }}</template>
+                            </span>
+                            <!-- Why it matched, when the route hit but the title didn't. -->
+                            <span
+                                v-if="routeOnlyHighlight(element)"
+                                class="text-xs text-ink-gray-4 truncate"
+                                v-html="routeOnlyHighlight(element)"
+                            />
+                        </div>
 
 						<Badge v-if="element.local_status === 'sync_failed'" variant="subtle" theme="red" size="sm" :title="__('Sync failed — edit again or delete to recover')">
 							{{ __('Sync failed') }}
@@ -97,6 +103,9 @@
                         :parent-name="element.doc_key"
                         :space-id="spaceId"
                         :readonly="readonly"
+                        :search-active="searchActive"
+                        :expanded-override="expandedOverride"
+                        :score-map="scoreMap"
                         :selected-page-id="selectedPageId"
                         :selected-draft-key="selectedDraftKey"
                         @create="(parent, isGroup) => emit('create', parent, isGroup)"
@@ -181,6 +190,20 @@ const props = defineProps({
 		type: Boolean,
 		default: false,
 	},
+	// While a tree search is active we render a pruned tree with drag disabled
+	// and every ancestor-of-a-match force-expanded.
+	searchActive: {
+		type: Boolean,
+		default: false,
+	},
+	expandedOverride: {
+		type: Object, // Set<doc_key> | null
+		default: null,
+	},
+	scoreMap: {
+		type: Object, // Map<doc_key, fuzzysort result> | null
+		default: null,
+	},
 	selectedPageId: {
 		type: String,
 		default: null,
@@ -235,7 +258,33 @@ const storageKey = computed(
 const expandedNodes = useStorage(storageKey, {});
 
 function isExpanded(name) {
+	// During search, force-open ancestors of matches without touching the
+	// user's saved expand state — clearing the query restores their tree.
+	if (props.expandedOverride) {
+		return props.expandedOverride.has(name);
+	}
 	return expandedNodes.value[name] === true;
+}
+
+const HIGHLIGHT_OPEN =
+	'<mark class="bg-surface-amber-2 text-ink-gray-9 rounded-sm">';
+const HIGHLIGHT_CLOSE = '</mark>';
+
+// fuzzysort multi-key result is array-like: [0] = title key, [1] = route key.
+// A key that didn't match yields an empty highlight string, which is our signal
+// to fall back (plain title) or surface the route as "why it matched".
+function highlightKey(element, keyIndex) {
+	const result = props.scoreMap?.get(element.doc_key)?.[keyIndex];
+	return result?.highlight(HIGHLIGHT_OPEN, HIGHLIGHT_CLOSE) || null;
+}
+
+function titleHighlight(element) {
+	return highlightKey(element, 0);
+}
+
+function routeOnlyHighlight(element) {
+	if (titleHighlight(element)) return null; // title match already shown inline
+	return highlightKey(element, 1);
 }
 
 function toggleExpanded(name) {

--- a/frontend/src/components/NestedDraggable.vue
+++ b/frontend/src/components/NestedDraggable.vue
@@ -50,15 +50,12 @@
 
                         <div class="flex flex-col flex-1 min-w-0">
                             <span class="text-sm truncate" :class="getTitleClass(element)">
-                                <span v-if="titleHighlight(element)" v-html="titleHighlight(element)" />
-                                <template v-else>{{ element.title }}</template>
+                                <template v-for="(seg, i) in titleParts(element)" :key="i"><mark v-if="seg.matched" class="bg-surface-amber-2 text-ink-gray-9 rounded-sm">{{ seg.text }}</mark><template v-else>{{ seg.text }}</template></template>
                             </span>
                             <!-- Why it matched, when the route hit but the title didn't. -->
-                            <span
-                                v-if="routeOnlyHighlight(element)"
-                                class="text-xs text-ink-gray-4 truncate"
-                                v-html="routeOnlyHighlight(element)"
-                            />
+                            <span v-if="routeParts(element)" class="text-xs text-ink-gray-4 truncate">
+                                <template v-for="(seg, i) in routeParts(element)" :key="i"><mark v-if="seg.matched" class="bg-surface-amber-2 text-ink-gray-9 rounded-sm">{{ seg.text }}</mark><template v-else>{{ seg.text }}</template></template>
+                            </span>
                         </div>
 
 						<Badge v-if="element.local_status === 'sync_failed'" variant="subtle" theme="red" size="sm" :title="__('Sync failed — edit again or delete to recover')">
@@ -144,6 +141,7 @@
 </template>
 
 <script setup>
+import { highlightSegments } from '@/composables/useTreeSearch';
 import { useDraftWorkspaceStore } from '@/stores/draftWorkspace';
 import { useStorage } from '@vueuse/core';
 import { Badge, Button, Dropdown, toast } from 'frappe-ui';
@@ -266,28 +264,25 @@ function isExpanded(name) {
 	return expandedNodes.value[name] === true;
 }
 
-const HIGHLIGHT_OPEN =
-	'<mark class="bg-surface-amber-2 text-ink-gray-9 rounded-sm">';
-const HIGHLIGHT_CLOSE = '</mark>';
-
 // fuzzysort multi-key result is array-like: [0] = title key, [1] = route key.
-// A key that didn't match yields an empty highlight string, which is our signal
-// to fall back (plain title) or surface the route as "why it matched".
-function highlightKey(element, keyIndex) {
-	const result = props.scoreMap?.get(element.doc_key)?.[keyIndex];
-	return result?.highlight(HIGHLIGHT_OPEN, HIGHLIGHT_CLOSE) || null;
+// Render as escaped { text, matched } segments (never an HTML string) — see
+// highlightSegments. titleParts always returns an array (plain title when no
+// match); routeParts only when the route matched but the title didn't.
+function titleParts(element) {
+	const result = props.scoreMap?.get(element.doc_key)?.[0];
+	return highlightSegments(result) || [{ text: element.title, matched: false }];
 }
 
-function titleHighlight(element) {
-	return highlightKey(element, 0);
-}
-
-function routeOnlyHighlight(element) {
-	if (titleHighlight(element)) return null; // title match already shown inline
-	return highlightKey(element, 1);
+function routeParts(element) {
+	if (highlightSegments(props.scoreMap?.get(element.doc_key)?.[0])) return null;
+	return highlightSegments(props.scoreMap?.get(element.doc_key)?.[1]);
 }
 
 function toggleExpanded(name) {
+	// While searching, groups are force-expanded via expandedOverride; writing
+	// to expandedNodes here would silently corrupt the user's saved layout
+	// (no visible change now, but restore-on-clear would show it). So no-op.
+	if (props.searchActive) return;
 	expandedNodes.value[name] = !expandedNodes.value[name];
 }
 

--- a/frontend/src/components/WikiDocumentList.vue
+++ b/frontend/src/components/WikiDocumentList.vue
@@ -1,7 +1,18 @@
 <template>
 	<div>
-		<div v-if="!readonly" class="flex items-center justify-end mb-4">
-			<div class="flex gap-2">
+		<div class="flex items-center gap-2 mb-4">
+			<FormControl v-if="treeData.children && treeData.children.length > 0" class="flex-1" type="text"
+				v-model="searchQuery" :placeholder="__('Search pages...')" @keydown.esc="searchQuery = ''">
+				<template #prefix>
+					<LucideSearch class="size-4 text-ink-gray-4" />
+				</template>
+				<template v-if="searchQuery" #suffix>
+					<button class="flex" :title="__('Clear search')" @click="searchQuery = ''">
+						<LucideX class="size-4 text-ink-gray-5 hover:text-ink-gray-7" />
+					</button>
+				</template>
+			</FormControl>
+			<div v-if="!readonly" class="flex gap-2 ml-auto">
 				<Button :title="__('New Group')" icon="folder-plus" variant="subtle" @click="openCreateDialog(rootNode, true)" />
 				<Button :title="__('New Page')" icon="file-plus" variant="subtle" @click="openCreateDialog(rootNode, false)" />
 				<Button :title="__('External Link')" variant="subtle" @click="openExternalLinkDialog(rootNode)">
@@ -12,7 +23,14 @@
 			</div>
 		</div>
 
-		<div v-if="!treeData.children || treeData.children.length === 0"
+		<div v-if="isSearching && !hasResults"
+			class="flex flex-col items-center justify-center py-16 border border-dashed border-outline-gray-2 rounded-lg">
+			<LucideSearch class="size-12 text-ink-gray-4 mb-4" />
+			<h3 class="text-lg font-medium text-ink-gray-7 mb-2">{{ __('No matches') }}</h3>
+			<p class="text-sm text-ink-gray-5">{{ __('No pages or groups match "{0}"', [searchQuery]) }}</p>
+		</div>
+
+		<div v-else-if="!treeData.children || treeData.children.length === 0"
 			class="flex flex-col items-center justify-center py-16 border border-dashed border-outline-gray-2 rounded-lg">
 			<LucideFileText class="size-12 text-ink-gray-4 mb-4" />
 			<h3 class="text-lg font-medium text-ink-gray-7 mb-2">{{ __('No pages yet') }}</h3>
@@ -31,12 +49,15 @@
 		<div v-else class="border border-outline-gray-2 rounded-lg overflow-hidden">
 			<NestedDraggable
 				:key="treeKey"
-				:items="treeData.children"
+				:items="treeForRender.children"
 				:change-type-map="changeTypeMap"
 				:level="0"
 				:parent-name="rootNode"
 				:space-id="spaceId"
 				:readonly="readonly"
+				:search-active="isSearching"
+				:expanded-override="expandedOverride"
+				:score-map="scoreMap"
 				:selected-page-id="selectedPageId"
 				:selected-draft-key="selectedDraftKey"
 				@create="openCreateDialog"
@@ -184,6 +205,7 @@
 
 <script setup>
 import { useTreeDialogs } from '@/composables/useTreeDialogs';
+import { useTreeSearch } from '@/composables/useTreeSearch';
 import { useDraftWorkspaceStore } from '@/stores/draftWorkspace';
 import { useStorage } from '@vueuse/core';
 import { FormControl } from 'frappe-ui';
@@ -192,6 +214,8 @@ import LucideAlertTriangle from '~icons/lucide/alert-triangle';
 import LucideFilePlus from '~icons/lucide/file-plus';
 import LucideFileText from '~icons/lucide/file-text';
 import LucideLink from '~icons/lucide/link';
+import LucideSearch from '~icons/lucide/search';
+import LucideX from '~icons/lucide/x';
 import NestedDraggable from './NestedDraggable.vue';
 
 const props = defineProps({
@@ -246,6 +270,16 @@ const treeKey = computed(() => {
 
 const draftStore = useDraftWorkspaceStore();
 const expandedNodes = useStorage('wiki-tree-expanded-nodes', {});
+
+// Client-side fuzzy filter over the in-memory tree (title + route).
+const {
+	query: searchQuery,
+	isSearching,
+	treeForRender,
+	hasResults,
+	expandedOverride,
+	scoreMap,
+} = useTreeSearch(toRef(props, 'treeData'));
 
 const {
 	showCreateDialog,

--- a/frontend/src/composables/useTreeSearch.js
+++ b/frontend/src/composables/useTreeSearch.js
@@ -28,6 +28,15 @@ export function useTreeSearch(treeData) {
 	};
 }
 
+// Drop weak matches (fuzzysort scores 0..1, 1 = perfect). We threshold each key
+// separately: titles get a lenient cut so a near-prefix like "stat" still finds
+// "Getting Started", while routes get a strict cut because they're long — a
+// short query like "cli" scatter-matches "c…l…i" across ".../installation",
+// which we want to ignore. Strong slug matches (e.g. "auth-tokens") still clear
+// the route bar.
+const TITLE_THRESHOLD = 0.3;
+const ROUTE_THRESHOLD = 0.5;
+
 // Pure core (no Vue) so it's unit-testable. Returns null when the query is
 // blank (meaning "not searching, render the full tree"), otherwise the pruned
 // children plus the keep/expand/score sets the renderer needs.
@@ -36,9 +45,14 @@ export function filterTree(children, query) {
 	if (!q) return null;
 
 	// Match title OR route; fuzzysort ranks each row by its best key.
-	const hits = fuzzysort.go(q, flatten(children), {
-		keys: ['node.title', 'node.route'],
-	});
+	const hits = fuzzysort
+		.go(q, flatten(children), {
+			keys: ['node.title', 'node.route'],
+		})
+		.filter(
+			(hit) =>
+				hit[0].score >= TITLE_THRESHOLD || hit[1].score >= ROUTE_THRESHOLD,
+		);
 
 	const keep = new Set(); // doc_keys that survive the prune
 	const expand = new Set(); // group doc_keys to force-open

--- a/frontend/src/composables/useTreeSearch.js
+++ b/frontend/src/composables/useTreeSearch.js
@@ -1,0 +1,80 @@
+import fuzzysort from 'fuzzysort';
+import { computed, ref } from 'vue';
+
+// Client-side fuzzy filter for the editor tree. The whole tree is already in
+// memory, so we match titles/routes here and prune the tree in place rather
+// than hitting the backend.
+export function useTreeSearch(treeData) {
+	const query = ref('');
+
+	const result = computed(() =>
+		filterTree(treeData.value?.children || [], query.value),
+	);
+
+	const isSearching = computed(() => result.value !== null);
+
+	const treeForRender = computed(() => {
+		if (!result.value) return treeData.value;
+		return { ...treeData.value, children: result.value.children };
+	});
+
+	return {
+		query,
+		isSearching,
+		treeForRender,
+		hasResults: computed(() => !result.value || result.value.keep.size > 0),
+		expandedOverride: computed(() => result.value?.expand || null),
+		scoreMap: computed(() => result.value?.score || null),
+	};
+}
+
+// Pure core (no Vue) so it's unit-testable. Returns null when the query is
+// blank (meaning "not searching, render the full tree"), otherwise the pruned
+// children plus the keep/expand/score sets the renderer needs.
+export function filterTree(children, query) {
+	const q = (query || '').trim();
+	if (!q) return null;
+
+	// Match title OR route; fuzzysort ranks each row by its best key.
+	const hits = fuzzysort.go(q, flatten(children), {
+		keys: ['node.title', 'node.route'],
+	});
+
+	const keep = new Set(); // doc_keys that survive the prune
+	const expand = new Set(); // group doc_keys to force-open
+	const score = new Map(); // doc_key -> result ([0]=title, [1]=route)
+	for (const hit of hits) {
+		const { node, ancestorKeys } = hit.obj;
+		keep.add(node.doc_key);
+		score.set(node.doc_key, hit);
+		for (const key of ancestorKeys) {
+			keep.add(key);
+			expand.add(key);
+		}
+	}
+
+	return { keep, expand, score, children: prune(children, keep) };
+}
+
+// Flatten to every node paired with its ancestor keys, so a match can pull its
+// parent groups back into the pruned tree.
+function flatten(children, ancestorKeys = [], out = []) {
+	for (const node of children) {
+		out.push({ node, ancestorKeys });
+		if (node.children?.length) {
+			flatten(node.children, [...ancestorKeys, node.doc_key], out);
+		}
+	}
+	return out;
+}
+
+// Structural copy with non-matching branches removed, original order kept —
+// position in the tree is the point, so we never reorder by score.
+function prune(children, keep) {
+	const result = [];
+	for (const node of children) {
+		if (!keep.has(node.doc_key)) continue;
+		result.push({ ...node, children: prune(node.children || [], keep) });
+	}
+	return result;
+}

--- a/frontend/src/composables/useTreeSearch.js
+++ b/frontend/src/composables/useTreeSearch.js
@@ -70,6 +70,34 @@ export function filterTree(children, query) {
 	return { keep, expand, score, children: prune(children, keep) };
 }
 
+// Split a fuzzysort result into { text, matched } segments for rendering.
+// Returns plain data (never an HTML string) so titles/routes containing markup
+// render as escaped text via Vue, not live HTML — fuzzysort's own highlight()
+// does NOT escape, so feeding it to v-html would be an XSS hole. Returns null
+// when this key didn't actually match (no indexes).
+export function highlightSegments(result) {
+	const target = result?.target;
+	const indexes = result?.indexes;
+	if (!target || !indexes?.length) return null;
+
+	const matched = new Set(indexes);
+	const segments = [];
+	let text = target[0];
+	let isMatched = matched.has(0);
+	for (let i = 1; i < target.length; i++) {
+		const m = matched.has(i);
+		if (m === isMatched) {
+			text += target[i];
+		} else {
+			segments.push({ text, matched: isMatched });
+			text = target[i];
+			isMatched = m;
+		}
+	}
+	segments.push({ text, matched: isMatched });
+	return segments;
+}
+
 // Flatten to every node paired with its ancestor keys, so a match can pull its
 // parent groups back into the pruned tree.
 function flatten(children, ancestorKeys = [], out = []) {

--- a/frontend/src/composables/useTreeSearch.test.js
+++ b/frontend/src/composables/useTreeSearch.test.js
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { filterTree } from './useTreeSearch.js';
+
+// A small two-level tree: a group "Guides" with two pages, and a top-level page.
+function sampleTree() {
+	return [
+		{
+			doc_key: 'g1',
+			title: 'Guides',
+			route: 'guides',
+			is_group: true,
+			children: [
+				{
+					doc_key: 'p1',
+					title: 'Getting Started',
+					route: 'guides/getting-started',
+					children: [],
+				},
+				{
+					doc_key: 'p2',
+					title: 'Authentication',
+					route: 'guides/auth-tokens',
+					children: [],
+				},
+			],
+		},
+		{ doc_key: 'p3', title: 'Changelog', route: 'changelog', children: [] },
+	];
+}
+
+test('blank query returns null (not searching)', () => {
+	assert.equal(filterTree(sampleTree(), ''), null);
+	assert.equal(filterTree(sampleTree(), '   '), null);
+});
+
+test('matching a page keeps it and its ancestor group', () => {
+	const { keep, expand, children } = filterTree(sampleTree(), 'getting');
+
+	assert.ok(keep.has('p1'), 'matched page kept');
+	assert.ok(keep.has('g1'), 'ancestor group kept');
+	assert.ok(expand.has('g1'), 'ancestor group force-expanded');
+	assert.ok(!keep.has('p2'), 'non-matching sibling pruned');
+	assert.ok(!keep.has('p3'), 'unrelated top-level page pruned');
+
+	// Pruned tree preserves structure: Guides group with only the match inside.
+	assert.equal(children.length, 1);
+	assert.equal(children[0].doc_key, 'g1');
+	assert.equal(children[0].children.length, 1);
+	assert.equal(children[0].children[0].doc_key, 'p1');
+});
+
+test('matches the route even when the title does not', () => {
+	// "auth-tokens" lives only in p2's route, not its title ("Authentication").
+	const { keep, score } = filterTree(sampleTree(), 'auth-tokens');
+
+	assert.ok(keep.has('p2'), 'route-only hit surfaces the page');
+	const result = score.get('p2');
+	// A non-matching key highlights to an empty string; the matching one wraps
+	// the hit in <mark>.
+	assert.equal(
+		result[0].highlight('<mark>', '</mark>'),
+		'',
+		'title key did not match',
+	);
+	assert.match(
+		result[1].highlight('<mark>', '</mark>'),
+		/<mark>auth-tokens<\/mark>/,
+	);
+});
+
+test('fuzzy (non-contiguous) query still matches', () => {
+	// "athn" is a subsequence of "Authentication".
+	const { keep } = filterTree(sampleTree(), 'athn');
+	assert.ok(keep.has('p2'));
+});
+
+test('no matches yields an empty keep set', () => {
+	const { keep, children } = filterTree(sampleTree(), 'zzzznomatch');
+	assert.equal(keep.size, 0);
+	assert.equal(children.length, 0);
+});
+
+test('matching a group title keeps the group itself', () => {
+	const { keep } = filterTree(sampleTree(), 'Guides');
+	assert.ok(keep.has('g1'));
+});

--- a/frontend/src/composables/useTreeSearch.test.js
+++ b/frontend/src/composables/useTreeSearch.test.js
@@ -1,7 +1,8 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { filterTree } from './useTreeSearch.js';
+import fuzzysort from 'fuzzysort';
+import { filterTree, highlightSegments } from './useTreeSearch.js';
 
 // A small two-level tree: a group "Guides" with two pages, and a top-level page.
 function sampleTree() {
@@ -150,4 +151,31 @@ test('no matches yields an empty keep set', () => {
 test('matching a group title keeps the group itself', () => {
 	const { keep } = filterTree(sampleTree(), 'Guides');
 	assert.ok(keep.has('g1'));
+});
+
+test('highlightSegments keeps markup as literal text (no HTML injection)', () => {
+	// A wiki author could title a page with markup; segments must carry it as
+	// plain text so Vue escapes it, never as an HTML string for v-html.
+	const result = fuzzysort.go('cli', ['<img src=x onerror=alert(1)> CLI'])[0];
+	const segs = highlightSegments(result);
+
+	// Reassembled text equals the original target exactly — nothing parsed away.
+	assert.equal(
+		segs.map((s) => s.text).join(''),
+		'<img src=x onerror=alert(1)> CLI',
+	);
+	// Only the query chars are marked; the markup sits in a plain segment.
+	assert.equal(
+		segs
+			.filter((s) => s.matched)
+			.map((s) => s.text)
+			.join(''),
+		'CLI',
+	);
+	assert.ok(segs.some((s) => !s.matched && s.text.includes('<img')));
+});
+
+test('highlightSegments returns null when the key did not match', () => {
+	assert.equal(highlightSegments(null), null);
+	assert.equal(highlightSegments({ target: '', indexes: [] }), null);
 });

--- a/frontend/src/composables/useTreeSearch.test.js
+++ b/frontend/src/composables/useTreeSearch.test.js
@@ -70,10 +70,75 @@ test('matches the route even when the title does not', () => {
 	);
 });
 
-test('fuzzy (non-contiguous) query still matches', () => {
-	// "athn" is a subsequence of "Authentication".
-	const { keep } = filterTree(sampleTree(), 'athn');
+test('a strong (prefix) fuzzy query still matches', () => {
+	const { keep } = filterTree(sampleTree(), 'authen');
 	assert.ok(keep.has('p2'));
+});
+
+// Mirrors the reported space (Getting Started / Guides·Advanced / Reference·CLI).
+function prodTree() {
+	return [
+		{
+			doc_key: 'gGS',
+			title: 'Getting Started',
+			route: 'once/getting-started',
+			is_group: true,
+			children: [
+				{
+					doc_key: 'pInstall',
+					title: 'Install It',
+					route: 'once/getting-started/installation',
+					children: [],
+				},
+			],
+		},
+		{
+			doc_key: 'gAdv',
+			title: 'Advanced',
+			route: 'once/guides/advanced',
+			is_group: true,
+			children: [
+				{
+					doc_key: 'pTrouble',
+					title: 'Troubleshooting',
+					route: 'once/guides/advanced/troubleshooting',
+					children: [],
+				},
+			],
+		},
+		{
+			doc_key: 'gCLI',
+			title: 'CLI',
+			route: 'once/reference/cli',
+			is_group: true,
+			children: [
+				{
+					doc_key: 'pCLICmd',
+					title: 'CLI Commands',
+					route: 'once/reference/cli/cli-commands',
+					children: [],
+				},
+			],
+		},
+	];
+}
+
+test('"cli" surfaces the CLI pages and drops route-scatter junk', () => {
+	const { keep } = filterTree(prodTree(), 'cli');
+	assert.ok(keep.has('pCLICmd'), 'CLI Commands kept');
+	assert.ok(keep.has('gCLI'), 'CLI group kept');
+	// Both matched "cli" only as a scattered subsequence of their long routes
+	// (c…l…i across ".../installation"), title score 0 — must be dropped.
+	assert.ok(!keep.has('pInstall'), 'Install It (route-scatter only) dropped');
+	assert.ok(
+		!keep.has('pTrouble'),
+		'Troubleshooting (route-scatter only) dropped',
+	);
+});
+
+test('"stat" still finds "Getting Started" (lenient title threshold)', () => {
+	const { keep } = filterTree(prodTree(), 'stat');
+	assert.ok(keep.has('gGS'), 'near-prefix "stat" matches "Getting Started"');
 });
 
 test('no matches yields an empty keep set', () => {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2169,6 +2169,11 @@ function-bind@^1.1.2:
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
+fuzzysort@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/fuzzysort/-/fuzzysort-3.1.0.tgz#4d7832d8fa48ad381753eaa7a7aae9927bdc10a8"
+  integrity sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ==
+
 glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"

--- a/specs/editor_tree_fuzzy_search.md
+++ b/specs/editor_tree_fuzzy_search.md
@@ -1,0 +1,149 @@
+# Editor Tree Fuzzy Search
+
+Date: 2026-06-26
+Status: **Draft / not started**
+
+## Goal
+
+In a large wiki space the editor sidebar tree (groups + pages, deeply nested) becomes hard to navigate — finding one page means hand-expanding groups and eyeballing the list. Add a **search box at the top of the editor tree** that fuzzy-matches page/group titles and lets the author jump straight to a result.
+
+Constraints from the request:
+
+- **Frontend-only.** The whole tree is already in memory (Pinia store). No new SQL, no backend endpoint, no network round-trip.
+- **Keep it simple.** Match against the node `title` **and** `route` (the slug/path authors often remember better than the title). A tiny fuzzy-search lib is fine; no heavy config.
+
+## Library Choice: `fuzzysort`
+
+We web-searched the small-JS-fuzzy-search field (fuzzysort, Fuse.js, uFuzzy, microfuzz). Recommendation: **[`fuzzysort`](https://github.com/farzher/fuzzysort)**.
+
+| Lib | Size (min) | Why / why not |
+| --- | --- | --- |
+| **fuzzysort** ✅ | ~5 KB, 0 deps | Purpose-built for SublimeText-style file/title search — exactly our case. `fuzzysort.go(query, targets, {keys, limit})` searches **multiple keys** (title + route) in one call and returns ranked results with per-key `.highlight()`. Simplest API for "few fields, ranked, highlighted." |
+| Fuse.js | ~12 KB+ gzip | Weighted multi-key search, lots of tuning knobs. Overkill for one field. |
+| uFuzzy | ~3 KB | Tiniest, but lower-level (you wire up the highlight/sort yourself). More glue for no real win here. |
+| microfuzz | ~1 KB | Fine, but less battle-tested and fewer ranking niceties than fuzzysort. |
+
+`fuzzysort` wins on "smallest library that gives ranking **and** highlight out of the box." Add via yarn:
+
+```
+cd frontend && yarn add fuzzysort
+```
+
+(Single dep, zero transitive deps. Codebase is yarn — `frontend/yarn.lock`.)
+
+## Current State
+
+- **Tree container:** `frontend/src/components/WikiDocumentList.vue` — receives the whole tree as `treeData` (`{ root_group, children: [...] }`), renders the New Group/Page/Link button row (lines 3–13) above the `<NestedDraggable>` (lines 31–49). The button row is the natural mount point for the search box.
+- **Recursive renderer:** `frontend/src/components/NestedDraggable.vue` — draws one row per node via `vuedraggable`'s `<draggable>` `#item` slot. Row click → `handleRowClick(element)` (lines 243–271) which routes to `SpacePage` (published, by `document_name`) or `DraftChangeRequest` (unsynced draft, by `doc_key`); groups toggle expand; external links open the edit dialog.
+- **Node shape** (snake_case, the `treeAsLegacy` projection from `stores/draftWorkspace/treeModel.js`):
+  ```js
+  { doc_key, document_name, title, route, is_group, is_published,
+    is_external_link, external_url, order_index, children: [...], local_status }
+  ```
+  `title` is the display text for **all** node types (group, page, external link) — there is no separate name field. Type is distinguished only by `is_group` / `is_external_link`.
+- The full tree is loaded once and held in frontend state — no lazy loading. So a flat client-side scan is trivially cheap.
+- **No existing search/filter UI** anywhere in the tree. No fuzzy lib installed.
+- Stack: Vue 3.5, frappe-ui (`FormControl`, `TextInput`, `Button` available), `@vueuse/core` (`useDebounceFn` available), `~icons/lucide/*` virtual icons. Biome lint, **tab indentation** in `.vue` script blocks.
+
+## Non-Goals
+
+- No backend search / no SQL / no API endpoint — purely client-side over the in-memory tree.
+- No full-text / page-**content** search. Title-only. (Content search is a possible later, separate feature.)
+- No change to the reorder logic, the node data shape, or routing. (Drag is *temporarily disabled* while a query is active, then restored — the reorder machinery itself is untouched.)
+- No multi-field weighting, no search history, no recents.
+- Read-only (git-synced) spaces get the same search — search is orthogonal to read-only.
+
+## Design
+
+**Core idea:** filter the **existing tree in place** — keep matching pages/groups, prune everything else, and auto-expand the ancestors of every match. This preserves hierarchy and the author's spatial memory ("this page lives under that group"), which a flat list would discard. We render the **same `<NestedDraggable>`**, just fed a pruned tree and with drag disabled while a query is active (so the drag-vs-filtered-DOM conflict simply never arises).
+
+- `searchQuery === ''` → render the live `treeData`, drag enabled, saved expand state — i.e. today's behavior, untouched.
+- `searchQuery !== ''` → render a **pruned copy** of the tree, drag disabled, all ancestors-of-matches force-expanded, matched titles highlighted.
+
+### 1. Match → prune → expand (composable `useTreeSearch.js`)
+
+```js
+import fuzzysort from 'fuzzysort';
+
+// Walk once → flat list of every node with its ancestor doc_keys.
+function flatten(children, ancestors = []) → [{ node, ancestorKeys: [...] }]
+```
+
+Then, given a query, compute the set of nodes to keep and the set to expand:
+
+```js
+const matched = computed(() => {
+  const q = query.value.trim();
+  if (!q) return null; // null => "not searching", render full tree
+  // Multi-key: match title OR route. fuzzysort ranks by the best-scoring key.
+  const hits = fuzzysort.go(q, flat.value, { keys: ['node.title', 'node.route'] });
+  const keep = new Set();       // doc_keys to render
+  const expand = new Set();     // group doc_keys to force-open
+  const score = new Map();      // doc_key -> fuzzysort result (for highlight)
+  for (const r of hits) {
+    keep.add(r.obj.node.doc_key);
+    score.set(r.obj.node.doc_key, r); // r[0] = title match, r[1] = route match
+    for (const a of r.obj.ancestorKeys) { keep.add(a); expand.add(a); }
+  }
+  return { keep, expand, score };
+});
+```
+
+With `keys`, each result `r` is an array (`r[0]` = title result, `r[1]` = route result); either can be null if that field didn't match. fuzzysort scores the row by its best-matching key, so a route-only hit still surfaces.
+
+Then build the **pruned tree** (a filtered structural copy, original order preserved — do **not** reorder by score; in-tree position is the whole point):
+
+```js
+function prune(children, keep) {
+  return children
+    .filter((n) => keep.has(n.doc_key))
+    .map((n) => ({ ...n, children: prune(n.children || [], keep) }));
+}
+const treeForRender = computed(() =>
+  matched.value ? { ...treeData, children: prune(treeData.children, matched.value.keep) }
+                : treeData,
+);
+```
+
+A group is kept iff it is an ancestor of a match (added to `keep` via `ancestorKeys`); a leaf is kept iff it matched directly. So a group whose own title matches but has no matching descendants still shows (it's in `keep`) — correct.
+
+- `flat` rebuilds via `computed` off `treeData`, so create/rename/delete reflect immediately. Cost is a negligible in-memory walk.
+- No `limit` — pruning already bounds what renders, and we *want* every match visible in context. (If a query matches thousands, that's the user's query; the tree just shows them all, same as today.)
+- Debounce the bound query with `useDebounceFn` (~120 ms) only if typing feels laggy; likely unneeded at this data size.
+
+### 2. Search box UI — `WikiDocumentList.vue`
+
+Add above the button row (or beside it). frappe-ui `TextInput` with a leading `~icons/lucide/search` and a clear (`x`) button when non-empty. `Esc` clears the query. The pruned `treeForRender` is passed to `<NestedDraggable>` in place of `treeData`.
+
+```
+[ 🔍  Search pages…                       ✕ ]
+```
+
+### 3. Wiring `NestedDraggable` (minimal, additive)
+
+Three small, backward-compatible additions to the recursive renderer:
+
+1. **Force-expand during search.** `isExpanded(key)` already reads per-space `expandedNodes` from `useStorage`. Add an optional `expandedOverride` prop (a `Set` of doc_keys, threaded down through the recursion). `isExpanded` returns `true` when `key ∈ expandedOverride`, else falls back to saved state. This force-opens ancestors of matches **without clobbering** the user's saved expand state — clear the query and their tree is exactly as they left it.
+2. **Disable drag during search.** `<draggable :disabled="readonly">` → `:disabled="readonly || searchActive"`. Pass `searchActive` (a boolean prop) down the recursion. No reorder while filtered.
+3. **Highlight matches.** Pass the `score` map down. For a node with a hit, if the **title** key matched (`r[0]`) render `r[0].highlight('<mark>', '</mark>')` via `v-html` instead of `{{ element.title }}` (fuzzysort escapes the input, so only the injected `<mark>` is live — safe). If only the **route** matched (`r[1]` but not `r[0]`), render the plain title and surface the highlighted route as muted subtext beneath it (`r[1].highlight(...)`) so the author sees *why* it matched. Non-matched ancestor groups render their plain title.
+
+Navigation, icons, badges, dialogs — **all unchanged**. `handleRowClick` already does the right thing (page → `SpacePage`, draft → `DraftChangeRequest`, group → toggle, link → edit dialog). Clicking a result is just clicking a tree row.
+
+- Empty state: non-empty query, zero matches → render a small "No pages match '<q>'" message in place of the tree (mirrors the existing "No pages yet" empty block in `WikiDocumentList.vue` lines 15–29).
+
+### Tracer-bullet phases
+
+1. **Phase 1 — vertical slice.** `yarn add fuzzysort`; `useTreeSearch` composable (flatten + match + prune); `TextInput` in `WikiDocumentList`; pass pruned `treeForRender` + `expandedOverride` + `searchActive` into `NestedDraggable`. Result: typing filters the real tree, ancestors auto-expand, drag off, navigation works. Ship this. `yarn build`.
+2. **Phase 2 — polish.** Title highlight (`<mark>`), `Esc`-to-clear / clear button, empty-state message, restore-saved-expand-on-clear verified. Debounce only if needed.
+3. **Phase 3 — tests.** Unit test for `flatten` + `prune` + match set (deterministic, no DOM): given a tree and a query, assert the kept/expanded doc_key sets. Playwright e2e: open a space in edit mode, type a partial title, assert non-matching siblings are gone, the match's parent group is expanded, and clicking the match navigates to that page. (Mind the local job-queue meltdown noted for git-sync specs — keep this e2e lean, no sync.)
+
+## Open Questions
+
+1. **Highlight** via `v-html` of fuzzysort's escaped output — acceptable, or hand-roll index-based `<mark>` spans to avoid any `v-html`? Default: use fuzzysort's highlight (it escapes input).
+2. Debounce needed at all? Default: no, add only if laggy.
+3. On clear, should focus return to the tree / last-selected row, or stay in the search box? Default: stay in box (cheapest), revisit if it feels off.
+
+## Verification (to fill in after build)
+
+- Manual on wiki.localhost: large space, search partial/fuzzy title → correct ranked matches, click navigates.
+- `yarn build` clean, Biome clean.

--- a/specs/editor_tree_fuzzy_search.md
+++ b/specs/editor_tree_fuzzy_search.md
@@ -1,7 +1,7 @@
 # Editor Tree Fuzzy Search
 
 Date: 2026-06-26
-Status: **Draft / not started**
+Status: **Implemented** (2026-06-26). Unit tests green (`useTreeSearch.test.js`, 6/6); build clean. The Playwright spec `e2e/tests/tree-search.spec.ts` is written but **not yet run** — it needs a running bench (the local server was down at build time). See [Verification](#verification).
 
 ## Goal
 
@@ -143,7 +143,10 @@ Navigation, icons, badges, dialogs — **all unchanged**. `handleRowClick` alrea
 2. Debounce needed at all? Default: no, add only if laggy.
 3. On clear, should focus return to the tree / last-selected row, or stay in the search box? Default: stay in box (cheapest), revisit if it feels off.
 
-## Verification (to fill in after build)
+## Verification
 
-- Manual on wiki.localhost: large space, search partial/fuzzy title → correct ranked matches, click navigates.
-- `yarn build` clean, Biome clean.
+- **Unit** (`frontend/src/composables/useTreeSearch.test.js`, `node --test`, 6/6 pass): blank query → no filtering; title match keeps page + ancestor group and prunes siblings; route-only match (`auth-tokens`) surfaces a page whose title doesn't match; fuzzy/non-contiguous query (`athn` → "Authentication"); no-match → empty keep set; group-title match keeps the group.
+- **Build**: `yarn build` clean.
+- **E2E** (`e2e/tests/tree-search.spec.ts`): written, seeds a space via API and drives the search box (title filter + auto-expand, route-only match, no-match empty state, clear-restores). **Not yet executed** — bench server was down. Run with the bench up:
+  `BASE_URL=http://wiki.localhost:8000 yarn test:e2e e2e/tests/tree-search.spec.ts`
+- **Manual** (pending): large space on wiki.localhost — fuzzy title/route search → matches in context, click navigates.

--- a/specs/editor_tree_fuzzy_search.md
+++ b/specs/editor_tree_fuzzy_search.md
@@ -1,7 +1,7 @@
 # Editor Tree Fuzzy Search
 
 Date: 2026-06-26
-Status: **Implemented** (2026-06-26). Unit tests green (`useTreeSearch.test.js`, 6/6); build clean. The Playwright spec `e2e/tests/tree-search.spec.ts` is written but **not yet run** — it needs a running bench (the local server was down at build time). See [Verification](#verification).
+Status: **Implemented & verified** (2026-06-26). Unit tests green (`useTreeSearch.test.js`, 6/6), e2e green (`e2e/tests/tree-search.spec.ts`), build clean. See [Verification](#verification).
 
 ## Goal
 
@@ -147,6 +147,6 @@ Navigation, icons, badges, dialogs — **all unchanged**. `handleRowClick` alrea
 
 - **Unit** (`frontend/src/composables/useTreeSearch.test.js`, `node --test`, 6/6 pass): blank query → no filtering; title match keeps page + ancestor group and prunes siblings; route-only match (`auth-tokens`) surfaces a page whose title doesn't match; fuzzy/non-contiguous query (`athn` → "Authentication"); no-match → empty keep set; group-title match keeps the group.
 - **Build**: `yarn build` clean.
-- **E2E** (`e2e/tests/tree-search.spec.ts`): written, seeds a space via API and drives the search box (title filter + auto-expand, route-only match, no-match empty state, clear-restores). **Not yet executed** — bench server was down. Run with the bench up:
+- **E2E** (`e2e/tests/tree-search.spec.ts`, **passing**): seeds a space via API and drives the search box — title filter + auto-expand + prune, route-only match (`auth-tokens`), no-match empty state, clear-restores. Run with:
   `BASE_URL=http://wiki.localhost:8000 yarn test:e2e e2e/tests/tree-search.spec.ts`
 - **Manual** (pending): large space on wiki.localhost — fuzzy title/route search → matches in context, click navigates.


### PR DESCRIPTION

<img width="1250" height="910" alt="image" src="https://github.com/user-attachments/assets/968c0ce4-1655-4c22-97c8-acd782e6cc14" />


Closes #662 


## Why?

In a large wiki space (many groups + deeply nested pages) it's hard to locate a page in the editor sidebar tree — you end up hand-expanding groups and scanning. We needed a quick search at the top of that tree.

## What?

A search box above the editor tree that fuzzy-matches **title and route**, filtering the tree **in place**:

- Matches stay; branches with no match are pruned; ancestor groups auto-expand.
- Matches are highlighted (`<mark>`); a route-only hit shows the highlighted route as subtext so it's clear *why* a row matched.
- Drag is disabled while searching; clearing the query restores the tree **and** the user's saved expand state untouched.
- Clear (✕) button, `Esc` to clear, and a "No matches" empty state.

Purely frontend — the whole tree is already in memory, so no SQL / no new endpoint.

## How?

- Adds [`fuzzysort`](https://github.com/farzher/fuzzysort) (~5 KB, zero deps) — smallest lib giving ranking + highlight for a multi-key search.
- Pure, testable core `useTreeSearch.filterTree()` (flatten → fuzzysort → prune). The recursive renderer `NestedDraggable.vue` gets three additive props (`searchActive`, `expandedOverride`, `scoreMap`); navigation/icons/badges unchanged.

## Tests

- Unit: `useTreeSearch.test.js` — 6/6 (title match, route-only match, fuzzy subsequence, prune, ancestor-keep, empty state).
- E2E: `e2e/tests/tree-search.spec.ts` — drives the box end-to-end (filter + auto-expand, route-only match, empty state, clear-restores).

Spec: `specs/editor_tree_fuzzy_search.md`.