### PR TITLE
fix(reader): stop clipping descenders in sidebar space title

### DIFF
--- a/wiki/templates/wiki/includes/sidebar.html
+++ b/wiki/templates/wiki/includes/sidebar.html
@@ -22,7 +22,7 @@
             <img class="h-8 max-w-16 flex-shrink-0" src="{{ wiki_space.app_switcher_logo }}"/>
             {% endif %}
             <div class="flex flex-1 flex-col text-left ml-2 truncate">
-                <div class="text-base font-medium leading-none text-[var(--ink-gray-9)] truncate">{{ wiki_space.space_name or _("Wiki") }}</div>
+                <div class="text-base font-medium leading-tight text-[var(--ink-gray-9)] truncate">{{ wiki_space.space_name or _("Wiki") }}</div>
             </div>
             <div class="ml-2">
                 <svg class="size-4 text-[var(--ink-gray-5)] transition-transform duration-200" :class="{ 'rotate-180': spaceSwitcherOpen }" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -59,7 +59,7 @@
             <img class="h-8 max-w-16 flex-shrink-0" src="{{ wiki_space.app_switcher_logo }}"/>
             {% endif %}
             <div class="flex flex-1 flex-col text-left ml-2 truncate">
-                <div class="text-base font-medium leading-none text-[var(--ink-gray-9)] truncate">{{ wiki_space.space_name or _("Wiki") }}</div>
+                <div class="text-base font-medium leading-tight text-[var(--ink-gray-9)] truncate">{{ wiki_space.space_name or _("Wiki") }}</div>
             </div>
         </div>
         {% endif %}


### PR DESCRIPTION

<img width="1580" height="782" alt="image" src="https://github.com/user-attachments/assets/fa7fe98e-5902-48f1-b8f3-a32357148f22" />


Closes #672 


## Problem

In the published wiki reader, the sidebar space title clipped the bottom of letters with descenders — the "g" in a name like "Legal" was visibly cut off (#672).

## Solution

The title combined `leading-none` (line-height: 1) with `truncate` (which sets `overflow: hidden`). A line box collapsed to exactly the font size leaves no room below the baseline, so descenders get clipped. Switched to `leading-tight` so the line box has room for descenders while the title still truncates on overflow.

Fixes #672

🤖 Generated with [Claude Code](https://claude.com/claude-code)