### PR TITLE
feat: per-space Accept Contributions toggle

### DIFF
--- a/e2e/tests/accept-contributions.spec.ts
+++ b/e2e/tests/accept-contributions.spec.ts
@@ -1,0 +1,133 @@
+import { expect, test } from '@playwright/test';
+import { createDoc, getDoc } from '../helpers/frappe';
+import {
+	type WikiSpace,
+	cleanupWikiSpacesByRoute,
+	createTestWikiDocument,
+	generateWikiTitle,
+} from '../helpers/wiki';
+
+/**
+ * Per-space "Accept Contributions" toggle — reader-side behavior.
+ *
+ * The public reader shows an Edit (split) button that lets readers raise change
+ * requests. When a space turns contributions off, read-only viewers should no
+ * longer see Edit — Copy (as Markdown) becomes the primary action and the other
+ * actions (Download, Open in ChatGPT/Claude) stay. Users with write/merge
+ * access (managers) always keep the Edit button.
+ *
+ * We seed a publicly readable space (Guest Read role) + a published page via the
+ * API, then read it in a fresh Guest browser context (no stored auth) to
+ * exercise the read-only path. Manager behavior is checked with the stored
+ * (Administrator) auth state.
+ */
+test.describe('Accept Contributions toggle (reader)', () => {
+	let route: string;
+
+	test.afterEach(async ({ request }) => {
+		if (route) await cleanupWikiSpacesByRoute(request, route);
+		route = '';
+	});
+
+	async function seedPublicPage(
+		request: Parameters<typeof createDoc>[0],
+		allowContributions: boolean,
+	): Promise<string> {
+		route = `accept-contrib-${Date.now()}`;
+		const space = await createDoc<WikiSpace & { root_group: string }>(
+			request,
+			'Wiki Space',
+			{
+				route,
+				space_name: route,
+				is_published: true,
+				allow_contributions: allowContributions ? 1 : 0,
+				// Guest Read makes the space publicly readable (anonymous reader path).
+				roles: [{ role: 'Guest', permission_level: 'Read' }],
+			},
+		);
+
+		const doc = await createTestWikiDocument(request, {
+			title: generateWikiTitle('Accept Contrib'),
+			content: '# Heading\n\nReader body content.',
+			wiki_space: space.name,
+			parent_wiki_document: space.root_group,
+			is_published: true,
+		});
+
+		// The controller computes the final stored route; read it back.
+		const stored = await getDoc<{ route: string }>(
+			request,
+			'Wiki Document',
+			doc.name,
+		);
+		return `/${stored.route}`;
+	}
+
+	test('shows Edit to a public reader when contributions are on', async ({
+		request,
+		browser,
+		baseURL,
+	}) => {
+		const url = await seedPublicPage(request, true);
+
+		// Explicitly logged-out context (the project default carries the admin
+		// auth state) pointed at the same server.
+		const guest = await browser.newContext({
+			baseURL,
+			storageState: { cookies: [], origins: [] },
+		});
+		const guestPage = await guest.newPage();
+		await guestPage.setViewportSize({ width: 1100, height: 900 });
+		await guestPage.goto(url);
+		await guestPage.waitForLoadState('networkidle');
+
+		// Desktop Edit link (last() = desktop block, which is the visible one).
+		await expect(guestPage.locator('a.wiki-edit-link').last()).toBeVisible({
+			timeout: 10000,
+		});
+
+		await guest.close();
+	});
+
+	test('hides Edit (Copy becomes primary) when contributions are off; other actions remain', async ({
+		page,
+		request,
+		browser,
+		baseURL,
+	}) => {
+		const url = await seedPublicPage(request, false);
+
+		// --- Read-only viewer (Guest) ---
+		const guest = await browser.newContext({
+			baseURL,
+			storageState: { cookies: [], origins: [] },
+		});
+		const guestPage = await guest.newPage();
+		await guestPage.setViewportSize({ width: 1100, height: 900 });
+		await guestPage.goto(url);
+		await guestPage.waitForLoadState('networkidle');
+
+		// No Edit affordance anywhere on the page.
+		await expect(guestPage.locator('a.wiki-edit-link')).toHaveCount(0);
+
+		// Copy is the primary action instead.
+		await expect(
+			guestPage.getByRole('button', { name: 'Copy', exact: true }).last(),
+		).toBeVisible({ timeout: 10000 });
+
+		// The other actions are still present (in the dropdown menu).
+		await expect(guestPage.getByText('Open in ChatGPT').last()).toBeAttached();
+		await expect(guestPage.getByText('Open in Claude').last()).toBeAttached();
+
+		await guest.close();
+
+		// --- Manager (stored Administrator auth) still sees Edit ---
+		await page.setViewportSize({ width: 1100, height: 900 });
+		await page.goto(url);
+		await page.waitForLoadState('networkidle');
+		await expect(page.locator('a.wiki-edit-link').last()).toBeVisible({
+			timeout: 10000,
+		});
+	});
+});

--- a/frontend/src/components/SpaceSettings/PermissionsPanel.vue
+++ b/frontend/src/components/SpaceSettings/PermissionsPanel.vue
@@ -116,6 +116,25 @@
 			{{ __('Only space admins can change access control.') }}
 		</p>
 
+		<!-- Accept contributions -->
+		<div
+			class="flex items-center justify-between rounded-lg border border-outline-gray-2 bg-surface-gray-1 p-3"
+		>
+			<div class="mr-4 flex-1">
+				<p class="text-sm font-medium text-ink-gray-9">
+					{{ __('Accept Contributions') }}
+				</p>
+				<p class="mt-0.5 text-xs text-ink-gray-5">
+					{{ __('Let readers propose edits via change requests. Users with write access can always edit.') }}
+				</p>
+			</div>
+			<Switch
+				v-model="allowContributions"
+				:disabled="!canManageAccess || savingContributions"
+				@update:modelValue="updateContributions"
+			/>
+		</div>
+
 		<!-- Primary Save, below the message, aligned right -->
 		<div v-if="canManageAccess" class="flex justify-end">
 			<Button
@@ -137,6 +156,7 @@ import {
 	Button,
 	FormControl,
 	Select,
+	Switch,
 	createListResource,
 	createResource,
 	toast,
@@ -159,6 +179,10 @@ const emit = defineEmits(['update:dirty']);
 const roleRows = ref([]);
 const savedRoles = ref([]);
 const savingRoles = ref(false);
+
+// Legacy spaces (created before this toggle) have a null column; treat as on.
+const allowContributions = ref(true);
+const savingContributions = ref(false);
 
 // Inline (non-teleported) role picker state — see template note.
 const roleQuery = ref('');
@@ -188,6 +212,10 @@ watch(
 		if (doc) {
 			roleRows.value = snapshot(doc.roles || []);
 			savedRoles.value = snapshot(doc.roles || []);
+			allowContributions.value =
+				doc.allow_contributions == null
+					? true
+					: Boolean(doc.allow_contributions);
 			spaceCapabilities.submit({ space: props.spaceId });
 		}
 	},
@@ -272,6 +300,32 @@ function removeRole(idx) {
 const updateRolesResource = createResource({
 	url: 'wiki.api.wiki_space.update_space_roles',
 });
+
+const contributionsResource = createResource({
+	url: 'wiki.api.wiki_space.set_space_contributions',
+});
+
+async function updateContributions(value) {
+	savingContributions.value = true;
+	try {
+		await contributionsResource.submit({
+			space_id: props.spaceId,
+			allow: value ? 1 : 0,
+		});
+		toast.success(
+			value
+				? __('Contributions enabled')
+				: __('Contributions disabled'),
+		);
+	} catch (error) {
+		allowContributions.value = !value;
+		toast.error(
+			error.messages?.[0] || __('Failed to update contributions setting'),
+		);
+	} finally {
+		savingContributions.value = false;
+	}
+}
 
 async function saveRoles() {
 	savingRoles.value = true;

--- a/frontend/src/components/SpaceSettings/PermissionsPanel.vue
+++ b/frontend/src/components/SpaceSettings/PermissionsPanel.vue
@@ -127,10 +127,13 @@
 				<p class="mt-0.5 text-xs text-ink-gray-5">
 					{{ __('Let readers propose edits via change requests. Users with write access can always edit.') }}
 				</p>
+				<p v-if="isGitSynced" class="mt-0.5 text-xs text-ink-gray-5">
+					{{ __('Synced spaces are read-only, so contributions are always off.') }}
+				</p>
 			</div>
 			<Switch
 				v-model="allowContributions"
-				:disabled="!canManageAccess || savingContributions"
+				:disabled="!canManageAccess || savingContributions || isGitSynced"
 				@update:modelValue="updateContributions"
 			/>
 		</div>
@@ -183,6 +186,8 @@ const savingRoles = ref(false);
 // Legacy spaces (created before this toggle) have a null column; treat as on.
 const allowContributions = ref(true);
 const savingContributions = ref(false);
+// Git-synced spaces are read-only; the toggle is moot and the server rejects it.
+const isGitSynced = computed(() => Boolean(props.space.doc?.git_synced));
 
 // Inline (non-teleported) role picker state — see template note.
 const roleQuery = ref('');

--- a/specs/frontend_global_wiki_settings.md
+++ b/specs/frontend_global_wiki_settings.md
@@ -1,0 +1,170 @@
+# Global Wiki Settings in the Frontend
+
+Date: 2026-06-29
+Status: **Planned**
+
+## Goal
+
+Today the only way to change global **Wiki Settings** is to leave the Wiki SPA and
+go into the Frappe Desk (`/app/wiki-settings`). We already have a polished
+**per-space** settings experience in the frontend (the gear → `SpaceSettings`
+dialog). This brings the **global** `Wiki Settings` Single DocType into the
+frontend the same way — a modal `Dialog` opened from the sidebar menu — so an
+admin never has to touch the Desk.
+
+**Scope (confirmed):**
+- Migrate the *existing* `Wiki Settings` fields only — no new appearance/design
+  fields (logos/favicon/navbar stay per-space, by design).
+- GitHub App tab **included**, with write-only handling for its Password secrets.
+- Presentation: a modal `Dialog`, mirroring the existing Space Settings UX.
+
+We mirror the app's own established pattern (`SpaceSettings.vue`) rather than
+importing the CRM/LMS settings shell, for visual + code consistency.
+
+## Existing pattern we reuse
+
+- Shell: `frontend/src/components/SpaceSettings/SpaceSettings.vue` — `Dialog` body,
+  left rail of tab `Button`s + a right panel switched by `v-if`.
+- Per-field toggle save: `GeneralPanel.vue` uses
+  `props.space.setValue.submit({ field: value })` and reverts the local ref on
+  error. Copied exactly.
+- Data resource: `createDocumentResource({ doctype, name, auto: true })` for a
+  Single (see `SpaceDetails.vue:291`).
+- Admin gate: `useUserStore().isWikiManager` (`frontend/src/stores/user.js:20`).
+- Sidebar menu: `Sidebar.vue` `header.menuItems` (today Toggle Theme / Log out);
+  mobile equivalent in `MobileTopNav.vue`.
+
+## Fields to surface
+
+`Wiki Settings` (`wiki/wiki/doctype/wiki_settings/wiki_settings.json`), grouped by
+its existing Tab Breaks:
+
+- **General:** `default_wiki_space` (Autocomplete, options via `get_all_spaces`),
+  `enable_table_of_contents` (Check), `auto_convert_images_to_webp` (Check)
+- **Feedback:** `enable_feedback` (Check), `feedback_submission_limit`
+  (Int, depends on `enable_feedback`), `ask_for_contact_details` (Check)
+- **Header / Robots:** `head_html` (Code/HTML), `javascript` (Code/JS)
+- **GitHub App:** `github_app_id`, `github_app_client_id`,
+  `github_app_public_link` (Data — round-trip normally) +
+  `github_app_client_secret`, `github_app_private_key`, `github_webhook_secret`
+  (**Password — do NOT round-trip via the doc API**)
+
+## Implementation (tracer-bullet phases)
+
+### Phase 1 — Backend: permissions + GitHub secret API
+
+1. **Permission alignment.** Frontend gate is `isWikiManager`
+   (`Wiki Manager` / `System Manager`), but the DocType currently grants
+   read/write only to `System Manager` + `Wiki Approver`. Add a **`Wiki Manager`
+   read+write perm row** to `wiki_settings.json` so the gated UI can save.
+2. **GitHub secret presence + write-only API** in `wiki/api/github.py` (next to
+   the existing whitelisted helpers ~line 488), since Password fields never come
+   back from a normal doc read:
+   - `get_app_config()` → `{ app_id, client_id, public_link, has_client_secret,
+     has_private_key, has_webhook_secret }`. Gate on
+     `has_permission("Wiki Settings", "read")`. Booleans only — never return
+     secret values.
+   - `save_app_credentials(client_secret?, private_key?, webhook_secret?)` →
+     write-only; only overwrites a secret when a non-empty value is passed
+     (blank = leave as-is). Gate on `has_permission("Wiki Settings", "write")`.
+     Reuse the save shape of `store_app_credentials` (github.py:461).
+3. **Redirect the manifest flow back to the SPA.** `manifest_redirect.py`
+   currently bounces to `/app/wiki-settings?github_app_created=1` (Desk). Change
+   it to `/wiki?github_app_created=1` so the one-click "Create GitHub App" flow
+   returns to the SPA; the frontend reads that param to re-open the dialog on the
+   GitHub tab.
+
+### Phase 2 — Frontend shell + General panel (end-to-end tracer bullet)
+
+New folder `frontend/src/components/WikiSettings/`:
+- `WikiSettings.vue` — shell cloned from `SpaceSettings.vue`: left-rail tab
+  `Button`s (General / Feedback / Header & Robots / GitHub App) + right panel
+  switch. Owns one shared
+  `createDocumentResource({ doctype: 'Wiki Settings', name: 'Wiki Settings', auto: true })`,
+  passed to panels as a `settings` prop (mirrors how `space` is passed).
+- `GeneralPanel.vue` — `Switch` rows for `enable_table_of_contents` /
+  `auto_convert_images_to_webp` saved via `settings.setValue.submit(...)` with
+  revert-on-error. `default_wiki_space` via `Autocomplete`/`Select`, options from
+  `createResource({ url: 'wiki.wiki.doctype.wiki_settings.wiki_settings.get_all_spaces' })`.
+
+Entry point (wired in this phase so the bullet is testable):
+- Small `useWikiSettings` composable (or a ref in `MainLayout.vue`) holding
+  `showWikiSettings` — like CRM's global `showSettings`.
+- Mount `<Dialog><WikiSettings/></Dialog>` once in `MainLayout.vue` (desktop +
+  mobile).
+- Add a **Settings** item to `Sidebar.vue` `header.menuItems`, shown only when
+  `userStore.isWikiManager`, `onClick` → `showWikiSettings = true`. Mirror in
+  `MobileTopNav.vue`.
+- Handle `?github_app_created=1` on mount → open dialog to the GitHub tab.
+
+After Phase 2: an admin opens Settings, flips a General toggle, and it persists.
+
+### Phase 3 — Feedback + Header/Robots panels
+
+- `FeedbackPanel.vue` — `enable_feedback` / `ask_for_contact_details` switches;
+  `feedback_submission_limit` as `FormControl type="number"` shown only when
+  `enable_feedback` (matches the DocType `depends_on`).
+- `CodePanel.vue` (Header & Robots) — `head_html` + `javascript` as monospace
+  `FormControl type="textarea"` with an explicit **Save** button using
+  `settings.save.submit()` and an "Unsaved changes" `Badge` from
+  `settings.isDirty`. *(Plain textarea for the bullet; CodeMirror later.)*
+
+### Phase 4 — GitHub App panel
+
+`GitHubAppPanel.vue`:
+- Data fields (`github_app_id`, `github_app_client_id`, `github_app_public_link`)
+  bound to the shared `settings` resource.
+- Secrets: load presence via `get_app_config`; render each as "•••• configured" /
+  "Not set" with an edit field; write via `save_app_credentials`. Never display
+  stored secret values.
+- **Create GitHub App** button → `window.open('/github/new_app', '_blank')` (same
+  as the Desk client script `wiki_settings.js:8`). On return via the redirect
+  param, reload the resource + `get_app_config`.
+- Optional: surface connection state via `wiki.api.github.is_connected`.
+
+### Phase 5 — Tests & build
+
+- **Python unit** (`test_wiki_settings.py`): `get_app_config` presence booleans &
+  no secret leakage; `save_app_credentials` writes only non-empty values and is
+  permission-gated; a `Wiki Manager` can read/write after the perm row is added.
+  Temp-revert to confirm the test fails without the fix (CLAUDE.md regression
+  rule).
+- **E2E (Playwright)**: as a Wiki Manager, open the dialog from the menu, toggle a
+  General setting, reload, assert persisted; assert a non-manager doesn't see the
+  Settings item.
+- `yarn build` in `frontend/` after frontend edits; `bench --site wiki.localhost
+  migrate` for the JSON perm change.
+
+## Files to create / modify
+
+**Create**
+- `frontend/src/components/WikiSettings/WikiSettings.vue`
+- `frontend/src/components/WikiSettings/GeneralPanel.vue`
+- `frontend/src/components/WikiSettings/FeedbackPanel.vue`
+- `frontend/src/components/WikiSettings/CodePanel.vue`
+- `frontend/src/components/WikiSettings/GitHubAppPanel.vue`
+- `frontend/src/composables/useWikiSettings.js` (global open state) — optional
+
+**Modify**
+- `wiki/wiki/doctype/wiki_settings/wiki_settings.json` (add `Wiki Manager` perm)
+- `wiki/api/github.py` (`get_app_config`, `save_app_credentials`)
+- `wiki/www/github/manifest_redirect.py` (redirect → SPA)
+- `frontend/src/layouts/MainLayout.vue` (mount dialog)
+- `frontend/src/components/Sidebar.vue` + `MobileTopNav.vue` (menu entry, gated)
+- `wiki/wiki/doctype/wiki_settings/test_wiki_settings.py` (+ new e2e spec)
+
+## Verification
+
+1. `bench --site wiki.localhost migrate`; `yarn build` in `frontend/`.
+2. As Administrator at `wiki.localhost/wiki` → Sidebar menu → **Settings**; dialog
+   opens with all four tabs.
+3. Toggle "Enable Table of Contents", reload, re-open — persisted. Confirm in Desk
+   (`/app/wiki-settings`) to prove single-source.
+4. Feedback tab: enabling feedback reveals the submission-limit field; save and
+   verify the widget appears on a public page.
+5. Header/Robots: set `head_html`, save (dirty badge clears), confirm it lands in
+   a rendered public wiki page `<head>`.
+6. GitHub App: secrets show as "configured" without revealing values; "Create
+   GitHub App" opens the manifest flow and returns to the SPA settings dialog.
+7. As a non-manager → Settings item absent.
+8. `test_wiki_settings` and the Playwright spec both green.

--- a/specs/space_accept_contributions_toggle.md
+++ b/specs/space_accept_contributions_toggle.md
@@ -59,9 +59,9 @@ requires read access (Guests can't actually raise CRs on open spaces, as today).
 - `permissions.py`:
   - `_space_accepts_contributions(space)` — reads the flag; **None/missing ⇒ True**
     (backward compatible).
-  - `can_contribute_space(space, user)` — `can_read_space` and
+  - `can_contribute_to_space(space, user)` — `can_read_space` and
     (`can_write_space` or `_space_accepts_contributions`).
-  - `wiki_cr_has_permission`: route **write** ptypes through `can_contribute_space`
+  - `wiki_cr_has_permission`: route **write** ptypes through `can_contribute_to_space`
     (single choke point covering `cr.insert()` and all CR page mutations); reads
     stay on `can_read_space`.
 - `wiki_change_request.py`: in `create_change_request` and
@@ -89,7 +89,7 @@ requires read access (Guests can't actually raise CRs on open spaces, as today).
   `set_space_contributions`. Coerce null → on for legacy rows.
 
 ### Phase 6 — Tests
-- `test_permissions.py`: `can_contribute_space` matrix (manager / write-tier /
+- `test_permissions.py`: `can_contribute_to_space` matrix (manager / write-tier /
   read-tier × toggle on/off) and that CR creation is blocked for a read-tier user
   when the toggle is off but allowed for a write-tier user.
 

--- a/specs/space_accept_contributions_toggle.md
+++ b/specs/space_accept_contributions_toggle.md
@@ -1,0 +1,94 @@
+# Per-Space "Accept Contributions" Toggle
+
+Date: 2026-06-29
+Status: **Planned**
+
+## Goal
+
+Let admins turn off contributions (Change Requests) for a Wiki Space. When off, the
+**Edit** button is hidden from read-only viewers in the public reader and the
+backend refuses to create Change Requests for them. Users with **Write/merge
+access** (Wiki Managers, Write-tier space roles, System Manager) can always edit,
+regardless of the toggle. The toggle is **on by default** (backward compatible).
+
+The reader's other actions (Copy as Markdown, Download PDF, Open in ChatGPT/Claude)
+stay available to everyone. When the Edit button is hidden, **Copy** becomes the
+primary action button in the page header.
+
+## Semantics
+
+- `Wiki Space.allow_contributions` (Check, default **1**).
+- **Can contribute** (raise / edit a Change Request) iff:
+  - user can *write* the space (manager / Write-tier) — always; **OR**
+  - the space accepts contributions **and** the user can *read* the space.
+- **Show Edit button** in the reader iff: space accepts contributions **OR** user can
+  write the space. (Anonymous Guests still see Edit on a contributions-on space and
+  get the existing login redirect — unchanged.)
+
+Note the asymmetry: the reader's *show-edit* predicate uses `accepts OR can_write`
+(so anonymous discovery is preserved), while the *can-contribute* gate additionally
+requires read access (Guests can't actually raise CRs on open spaces, as today).
+
+## Current State
+
+- `permissions.py` has `can_read_space` / `can_write_space` and the
+  `has_permission` / `permission_query_conditions` hooks. Read = view + raise CRs;
+  Write = additionally merge.
+- The reader (`templates/wiki/document.html` + `macros/buttons.html`) always renders
+  the `[✏ Edit ▾]` split button (except orphan/chromeless docs). No per-user gate.
+- CR creation: `create_change_request` / `get_or_create_draft_change_request`
+  (`wiki_change_request.py`) gate on `can_read_space`.
+- `wiki.api.get_space_capabilities` returns `{can_read, can_write}` for the SPA.
+- SPA settings: `SpaceSettings.vue` → `PermissionsPanel.vue` (access-control roles,
+  saved via the `update_space_roles` whitelisted method, write-gated).
+
+## Plan (tracer bullet: schema → backend gate → reader → API → settings UI → tests)
+
+### Phase 1 — Schema
+- Add `allow_contributions` (Check, default `1`) to `Wiki Space` in the Access
+  Control tab, after `roles`. Label "Accept Contributions", with a description.
+- Migration patch `set_allow_contributions_default` to backfill existing spaces to
+  `1` (registered in `patches.txt`).
+
+### Phase 2 — Backend permission gate
+- `permissions.py`:
+  - `_space_accepts_contributions(space)` — reads the flag; **None/missing ⇒ True**
+    (backward compatible).
+  - `can_contribute_space(space, user)` — `can_read_space` and
+    (`can_write_space` or `_space_accepts_contributions`).
+  - `wiki_cr_has_permission`: route **write** ptypes through `can_contribute_space`
+    (single choke point covering `cr.insert()` and all CR page mutations); reads
+    stay on `can_read_space`.
+- `wiki_change_request.py`: in `create_change_request` and
+  `get_or_create_draft_change_request`, keep the read check, then add a contribution
+  check that throws a clear "not accepting contributions" PermissionError for
+  read-only users when the toggle is off.
+
+### Phase 3 — Reader (server-rendered)
+- `wiki_document.py` `get_web_context`: add `can_edit = accepts OR can_write_space`
+  (False for orphan/chromeless docs).
+- `macros/buttons.html`: `page_actions_dropdown(show_edit=True)` — when `show_edit`,
+  render the Edit `<a class="wiki-edit-link">` primary as today; otherwise render a
+  **Copy** primary `<button>` (clipboard/check state, no `wiki-edit-link` class).
+- `document.html`: pass `show_edit=can_edit` (mobile + desktop) and only include the
+  redundant "Copy page" dropdown item when `can_edit` (Copy is primary otherwise).
+
+### Phase 4 — Capabilities API
+- `get_space_capabilities`: add `can_contribute` to the returned dict.
+
+### Phase 5 — Settings UI (Permissions panel)
+- `api/wiki_space.py`: `set_space_contributions(space_id, allow)` — write-gated
+  (`check_permission("write")`), sets the flag.
+- `PermissionsPanel.vue`: an "Accept contributions" Switch below the roles table.
+  Editable for `canManageAccess` (write), read-only otherwise. Saves immediately via
+  `set_space_contributions`. Coerce null → on for legacy rows.
+
+### Phase 6 — Tests
+- `test_permissions.py`: `can_contribute_space` matrix (manager / write-tier /
+  read-tier × toggle on/off) and that CR creation is blocked for a read-tier user
+  when the toggle is off but allowed for a write-tier user.
+
+## Out of scope (for now)
+- Deep SPA editor read-only UX when a read-tier user reaches `/wiki/...` directly:
+  backend already throws and the reader hides the entry point. Capability
+  (`can_contribute`) is exposed for a future SPA polish.

--- a/specs/space_accept_contributions_toggle.md
+++ b/specs/space_accept_contributions_toggle.md
@@ -1,7 +1,12 @@
 # Per-Space "Accept Contributions" Toggle
 
 Date: 2026-06-29
-Status: **Planned**
+Status: **Implemented & verified** on wiki.localhost (2026-06-29). All 6 phases
+landed; `wiki.test_permissions` (34 tests) and
+`wiki.frappe_wiki.doctype.wiki_change_request.test_wiki_change_request` (85
+tests) pass. The reader `can_edit` flip was verified for Guest vs manager with
+the toggle on/off; the new enforcement tests were confirmed to fail on a
+temp-reverted toggle before restoring.
 
 ## Goal
 

--- a/wiki/api/__init__.py
+++ b/wiki/api/__init__.py
@@ -10,14 +10,16 @@ CONVERTIBLE_IMAGE_EXTENSIONS = (".png", ".jpeg", ".jpg")
 def get_space_capabilities(space: str) -> dict:
 	"""Return the current user's read/write capabilities for a Wiki Space.
 
-	Used by the SPA to show/hide the Merge action. Enforcement always remains
-	server-side in the permission hooks and Change Request controller.
+	Used by the SPA to show/hide the Merge and contribute actions. Enforcement
+	always remains server-side in the permission hooks and Change Request
+	controller.
 	"""
-	from wiki.permissions import can_read_space, can_write_space
+	from wiki.permissions import can_contribute_space, can_read_space, can_write_space
 
 	return {
 		"can_read": can_read_space(space),
 		"can_write": can_write_space(space),
+		"can_contribute": can_contribute_space(space),
 	}
 
 

--- a/wiki/api/__init__.py
+++ b/wiki/api/__init__.py
@@ -14,12 +14,12 @@ def get_space_capabilities(space: str) -> dict:
 	always remains server-side in the permission hooks and Change Request
 	controller.
 	"""
-	from wiki.permissions import can_contribute_space, can_read_space, can_write_space
+	from wiki.permissions import can_contribute_to_space, can_read_space, can_write_space
 
 	return {
 		"can_read": can_read_space(space),
 		"can_write": can_write_space(space),
-		"can_contribute": can_contribute_space(space),
+		"can_contribute": can_contribute_to_space(space),
 	}
 
 

--- a/wiki/api/wiki_space.py
+++ b/wiki/api/wiki_space.py
@@ -38,6 +38,23 @@ def update_space_roles(space_id: str, roles: list | str) -> list[dict]:
 
 
 @frappe.whitelist()
+def set_space_contributions(space_id: str, allow: int | str | bool) -> bool:
+	"""Toggle whether a Wiki Space accepts contributions (Change Requests).
+
+	Restricted to users who can write the space (managers, or Write-tier users of
+	a configured space), mirroring access-control changes.
+	"""
+	allow = frappe.parse_json(allow) if isinstance(allow, str) else allow
+	value = 1 if allow else 0
+
+	space = frappe.get_doc("Wiki Space", space_id)
+	space.check_permission("write")
+	space.allow_contributions = value
+	space.save()
+	return bool(value)
+
+
+@frappe.whitelist()
 def get_wiki_tree(space_id: str) -> dict:
 	"""Get the tree structure of Wiki Documents for a given Wiki Space."""
 	space = frappe.get_cached_doc("Wiki Space", space_id)

--- a/wiki/api/wiki_space.py
+++ b/wiki/api/wiki_space.py
@@ -42,13 +42,17 @@ def set_space_contributions(space_id: str, allow: int | str | bool) -> bool:
 	"""Toggle whether a Wiki Space accepts contributions (Change Requests).
 
 	Restricted to users who can write the space (managers, or Write-tier users of
-	a configured space), mirroring access-control changes.
+	a configured space), mirroring access-control changes. Rejected on git-synced
+	spaces, which are read-only — contributions can't happen there regardless.
 	"""
+	from wiki.permissions import assert_space_writable
+
 	allow = frappe.parse_json(allow) if isinstance(allow, str) else allow
 	value = 1 if allow else 0
 
 	space = frappe.get_doc("Wiki Space", space_id)
 	space.check_permission("write")
+	assert_space_writable(space)
 	space.allow_contributions = value
 	space.save()
 	return bool(value)

--- a/wiki/frappe_wiki/doctype/wiki_change_request/wiki_change_request.py
+++ b/wiki/frappe_wiki/doctype/wiki_change_request/wiki_change_request.py
@@ -88,9 +88,9 @@ def _assert_space_accepts_contributions(wiki_space: str, user: str | None = None
 	Write-tier users (and managers) may always contribute. The caller has already
 	verified read access.
 	"""
-	from wiki.permissions import can_contribute_space
+	from wiki.permissions import can_contribute_to_space
 
-	if not can_contribute_space(wiki_space, user):
+	if not can_contribute_to_space(wiki_space, user):
 		frappe.throw(
 			_("This wiki space is not accepting contributions."),
 			frappe.PermissionError,

--- a/wiki/frappe_wiki/doctype/wiki_change_request/wiki_change_request.py
+++ b/wiki/frappe_wiki/doctype/wiki_change_request/wiki_change_request.py
@@ -82,6 +82,21 @@ def _can_merge(wiki_space: str | None, user: str | None = None) -> bool:
 	return can_write_space(wiki_space, user)
 
 
+def _assert_space_accepts_contributions(wiki_space: str, user: str | None = None) -> None:
+	"""Block a Read-tier user from raising CRs when the space has them turned off.
+
+	Write-tier users (and managers) may always contribute. The caller has already
+	verified read access.
+	"""
+	from wiki.permissions import can_contribute_space
+
+	if not can_contribute_space(wiki_space, user):
+		frappe.throw(
+			_("This wiki space is not accepting contributions."),
+			frappe.PermissionError,
+		)
+
+
 # Statuses in which the CR head revision may still be mutated by its author.
 _EDITABLE_STATUSES = {"Draft", "Changes Requested"}
 
@@ -464,6 +479,7 @@ def get_or_create_draft_change_request(wiki_space: str, title: str | None = None
 	if not can_read_space(wiki_space):
 		frappe.throw(_("You do not have access to this wiki space."), frappe.PermissionError)
 
+	_assert_space_accepts_contributions(wiki_space)
 	assert_space_writable(wiki_space)
 
 	cr = _find_existing_draft(wiki_space)
@@ -726,6 +742,7 @@ def create_change_request(wiki_space: str, title: str, description: str | None =
 	if not can_read_space(wiki_space):
 		frappe.throw(_("You do not have access to this wiki space."), frappe.PermissionError)
 
+	_assert_space_accepts_contributions(wiki_space)
 	assert_space_writable(wiki_space)
 
 	space = frappe.get_doc("Wiki Space", wiki_space)

--- a/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
@@ -235,6 +235,19 @@ class WikiDocument(NestedSet):
 			return ""
 		return f"/wiki/spaces/{wiki_space.name}/page/{self.name}"
 
+	def _can_show_edit(self, wiki_space_doc, user=None) -> bool:
+		"""Whether to render the reader's Edit button for the current user.
+
+		Shown when the space accepts contributions (anyone, including anonymous
+		visitors who then hit the login redirect — unchanged) or when the user has
+		write/merge access (managers always see Edit even with contributions off).
+		"""
+		from wiki.permissions import can_write_space
+
+		if wiki_space_doc.allow_contributions:
+			return True
+		return can_write_space(wiki_space_doc.name, user)
+
 	def check_space_access(self, ptype="read", user=None):
 		"""Gate content access by the owning Wiki Space's role configuration.
 
@@ -362,6 +375,7 @@ class WikiDocument(NestedSet):
 			"last_updated": pretty_date(self.modified),
 			"last_updated_on": self.get_formatted("modified"),
 			"hide_chrome": not wiki_space,
+			"can_edit": False,
 		}
 
 		if not wiki_space:
@@ -373,6 +387,7 @@ class WikiDocument(NestedSet):
 		context.update(
 			{
 				"wiki_space": wiki_space_doc,
+				"can_edit": self._can_show_edit(wiki_space_doc),
 				"wiki_spaces_for_switcher": frappe.get_all(
 					"Wiki Space",
 					fields=["name", "space_name", "route", "light_mode_logo", "app_switcher_logo"],

--- a/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
@@ -242,9 +242,11 @@ class WikiDocument(NestedSet):
 		visitors who then hit the login redirect — unchanged) or when the user has
 		write/merge access (managers always see Edit even with contributions off).
 		"""
-		from wiki.permissions import can_write_space
+		from wiki.permissions import _space_accepts_contributions, can_write_space
 
-		if wiki_space_doc.allow_contributions:
+		# Mirror the backend's contribution gate exactly (it treats a missing/NULL
+		# flag as enabled) so the button and the CR endpoints never disagree.
+		if _space_accepts_contributions(wiki_space_doc):
 			return True
 		return can_write_space(wiki_space_doc.name, user)
 

--- a/wiki/patches.txt
+++ b/wiki/patches.txt
@@ -20,3 +20,4 @@ execute:frappe.db.set_single_value('Wiki Settings', 'auto_convert_images_to_webp
 wiki.wiki.doctype.wiki_space.patches.backfill_space_access
 wiki.wiki.doctype.wiki_space.patches.seed_space_roles_from_published
 wiki.frappe_wiki.doctype.wiki_change_request.patches.drop_reviewer_participant_tables
+wiki.wiki.doctype.wiki_space.patches.set_allow_contributions_default

--- a/wiki/permissions.py
+++ b/wiki/permissions.py
@@ -127,7 +127,7 @@ def _space_accepts_contributions(space) -> bool:
 	return value is None or bool(value)
 
 
-def can_contribute_space(space, user=None) -> bool:
+def can_contribute_to_space(space, user=None) -> bool:
 	"""Whether the user may propose changes (raise/edit Change Requests).
 
 	Write-tier users (and managers) can always contribute. Read-tier users can
@@ -249,5 +249,5 @@ def wiki_cr_has_permission(doc, ptype, user=None):
 	# bypass that). Merging is gated separately by can_write_space in the CR
 	# controller.
 	if ptype in WRITE_PTYPES:
-		return can_contribute_space(space, user)
+		return can_contribute_to_space(space, user)
 	return can_read_space(space, user)

--- a/wiki/permissions.py
+++ b/wiki/permissions.py
@@ -114,6 +114,33 @@ def can_write_space(space, user=None) -> bool:
 	return any(role in user_roles for role, level in levels.items() if level == "Write")
 
 
+def _space_accepts_contributions(space) -> bool:
+	"""Whether a space lets Read-tier users propose changes (raise CRs).
+
+	Missing/NULL is treated as enabled so spaces created before this toggle (and
+	rows not yet backfilled) keep accepting contributions.
+	"""
+	name = _resolve_space_name(space)
+	if not name:
+		return True
+	value = frappe.get_cached_value("Wiki Space", name, "allow_contributions")
+	return value is None or bool(value)
+
+
+def can_contribute_space(space, user=None) -> bool:
+	"""Whether the user may propose changes (raise/edit Change Requests).
+
+	Write-tier users (and managers) can always contribute. Read-tier users can
+	contribute only while the space accepts contributions.
+	"""
+	user = user or frappe.session.user
+	if not can_read_space(space, user):
+		return False
+	if can_write_space(space, user):
+		return True
+	return _space_accepts_contributions(space)
+
+
 def _accessible_space_names(user=None) -> set:
 	"""Spaces a user may read: open spaces (no role rows) plus restricted spaces
 	with a role row whose role the user holds. Guests get only the latter."""
@@ -217,6 +244,10 @@ def wiki_cr_has_permission(doc, ptype, user=None):
 			return _is_manager(user)
 		return True
 
-	# Reading a CR and editing/saving it (proposing changes) both require space
-	# Read. Merging is gated separately by can_write_space in the CR controller.
+	# Reading a CR requires space Read. Editing/saving it (proposing changes)
+	# additionally requires the space to accept contributions (Write-tier users
+	# bypass that). Merging is gated separately by can_write_space in the CR
+	# controller.
+	if ptype in WRITE_PTYPES:
+		return can_contribute_space(space, user)
 	return can_read_space(space, user)

--- a/wiki/templates/wiki/document.html
+++ b/wiki/templates/wiki/document.html
@@ -49,9 +49,11 @@
             {% else %}
             <!-- Mobile: Edit above title -->
             <div class="flex justify-start mb-4 sm:hidden">
-                {{ page_actions_dropdown(edit_href=doc.get_edit_link(), edit_text="Edit") }}
+                {{ page_actions_dropdown(edit_href=doc.get_edit_link(), edit_text="Edit", show_edit=can_edit) }}
                     {{ download_action_item() }}
+                    {% if can_edit %}
                     {{ page_action_item(text="Copy page", description="Copy page as Markdown for LLMs", icon="clipboard", click="copyMarkdown(); open = false") }}
+                    {% endif %}
                     {{ page_action_item(text="Open in ChatGPT", description="Ask ChatGPT about this page", icon="openai", href_expr="getAIUrl('openai')", target="_blank") }}
                     {{ page_action_item(text="Open in Claude", description="Ask Claude about this page", icon="claude", href_expr="getAIUrl('claude')", target="_blank") }}
                 {{ dropdown_end() }}
@@ -61,9 +63,11 @@
 
                 <!-- Desktop: Edit beside title -->
                 <div class="hidden sm:block">
-                    {{ page_actions_dropdown(edit_href=doc.get_edit_link(), edit_text="Edit") }}
+                    {{ page_actions_dropdown(edit_href=doc.get_edit_link(), edit_text="Edit", show_edit=can_edit) }}
                         {{ download_action_item() }}
+                        {% if can_edit %}
                         {{ page_action_item(text="Copy page", description="Copy page as Markdown for LLMs", icon="clipboard", click="copyMarkdown(); open = false") }}
+                        {% endif %}
                         {{ page_action_item(text="Open in ChatGPT", description="Ask ChatGPT about this page", icon="openai", href_expr="getAIUrl('openai')", target="_blank") }}
                         {{ page_action_item(text="Open in Claude", description="Ask Claude about this page", icon="claude", href_expr="getAIUrl('claude')", target="_blank") }}
                     {{ dropdown_end() }}

--- a/wiki/templates/wiki/macros/buttons.html
+++ b/wiki/templates/wiki/macros/buttons.html
@@ -127,16 +127,30 @@
        {{ page_action_item(text="Copy page", description="Copy page as Markdown for LLMs", icon="clipboard", click="copyMarkdown()") }}
    {{ dropdown_end() }}
 #}
-{% macro page_actions_dropdown(edit_href="", edit_text="Edit") %}
+{% macro page_actions_dropdown(edit_href="", edit_text="Edit", show_edit=True) %}
     <div class="relative inline-flex" x-data="{ open: false }" @click.outside="open = false">
         <!-- Split button group -->
         <div class="inline-flex rounded-lg border border-[var(--outline-gray-2)] overflow-hidden">
+            {% if show_edit %}
             <!-- Edit button (navigates to edit page) -->
             <a href="{{ edit_href }}"
                class="wiki-edit-link inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-[var(--ink-gray-7)] bg-[var(--surface-white)] hover:bg-[var(--surface-gray-1)] transition-colors duration-200">
                 {{ render_icon("edit", "w-4 h-4") }}
                 <span>{{ edit_text }}</span>
             </a>
+            {% else %}
+            <!-- Contributions off: Copy as Markdown is the primary action -->
+            <button @click="copyMarkdown()"
+                    class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-[var(--ink-gray-7)] bg-[var(--surface-white)] hover:bg-[var(--surface-gray-1)] transition-colors duration-200 cursor-pointer">
+                <template x-if="!copied">
+                    {{ render_icon("clipboard", "w-4 h-4") }}
+                </template>
+                <template x-if="copied">
+                    {{ render_icon("check", "w-4 h-4 text-green-600") }}
+                </template>
+                <span x-text="copied ? 'Copied!' : 'Copy'"></span>
+            </button>
+            {% endif %}
             <!-- Dropdown toggle button -->
             <button @click="open = !open"
                     class="inline-flex items-center px-2 py-1.5 text-[var(--ink-gray-5)] bg-[var(--surface-white)] hover:bg-[var(--surface-gray-1)] border-l border-[var(--outline-gray-2)] transition-colors duration-200 cursor-pointer">

--- a/wiki/test_permissions.py
+++ b/wiki/test_permissions.py
@@ -337,3 +337,28 @@ class TestSpaceRolesAPI(IntegrationTestCase):
 		)
 		rows = get_space_roles(self.space)
 		self.assertEqual([r["role"] for r in rows], [READER_ROLE])
+
+	def test_set_space_contributions_updates_flag_for_manager(self):
+		from wiki.api.wiki_space import set_space_contributions
+
+		frappe.set_user(self.manager)
+		set_space_contributions(self.space, 0)
+		self.assertEqual(frappe.db.get_value("Wiki Space", self.space, "allow_contributions"), 0)
+		set_space_contributions(self.space, 1)
+		self.assertEqual(frappe.db.get_value("Wiki Space", self.space, "allow_contributions"), 1)
+
+	def test_set_space_contributions_denied_for_read_tier_user(self):
+		from wiki.api.wiki_space import set_space_contributions
+
+		frappe.set_user(self.reader)
+		with self.assertRaises(frappe.PermissionError):
+			set_space_contributions(self.space, 0)
+
+	def test_set_space_contributions_blocked_on_git_synced_space(self):
+		from wiki.api.wiki_space import set_space_contributions
+
+		frappe.db.set_value("Wiki Space", self.space, "git_synced", 1)
+		frappe.clear_document_cache("Wiki Space", self.space)
+		frappe.set_user(self.manager)
+		with self.assertRaises(frappe.PermissionError):
+			set_space_contributions(self.space, 0)

--- a/wiki/test_permissions.py
+++ b/wiki/test_permissions.py
@@ -14,12 +14,18 @@ from frappe.tests import IntegrationTestCase
 from wiki.permissions import (
 	_accessible_space_names,
 	_is_manager,
+	can_contribute_space,
 	can_read_space,
 	can_write_space,
 	wiki_cr_has_permission,
 	wiki_document_has_permission,
 	wiki_space_has_permission,
 )
+
+
+def _set_contributions(space: str, allow: bool) -> None:
+	frappe.db.set_value("Wiki Space", space, "allow_contributions", 1 if allow else 0)
+
 
 READER_ROLE = "_Test WSAC Reader"
 WRITER_ROLE = "_Test WSAC Writer"
@@ -221,11 +227,55 @@ class TestWikiSpacePermissions(IntegrationTestCase):
 
 	def test_cr_has_permission_is_governed_by_space_read(self):
 		doc = frappe.get_doc({"doctype": "Wiki Change Request", "wiki_space": self.restricted})
-		# Reading and editing (proposing) a CR both require space Read; merge is
+		# Reading a CR requires space Read; editing (proposing) additionally
+		# requires the space to accept contributions (on by default). Merge is
 		# gated separately in the controller.
 		self.assertTrue(wiki_cr_has_permission(doc, "read", self.reader))
 		self.assertTrue(wiki_cr_has_permission(doc, "write", self.reader))
 		self.assertFalse(wiki_cr_has_permission(doc, "read", self.outsider))
+
+	# --- can_contribute_space (Accept Contributions toggle) -------------
+
+	def test_contributions_on_lets_reader_contribute(self):
+		_set_contributions(self.restricted, True)
+		self.assertTrue(can_contribute_space(self.restricted, self.reader))
+
+	def test_contributions_off_blocks_reader(self):
+		_set_contributions(self.restricted, False)
+		self.assertFalse(can_contribute_space(self.restricted, self.reader))
+
+	def test_contributions_off_still_allows_writer_and_manager(self):
+		_set_contributions(self.restricted, False)
+		self.assertTrue(can_contribute_space(self.restricted, self.writer))
+		self.assertTrue(can_contribute_space(self.restricted, self.manager))
+
+	def test_contributions_never_grant_access_without_read(self):
+		_set_contributions(self.restricted, True)
+		self.assertFalse(can_contribute_space(self.restricted, self.outsider))
+
+	def test_new_space_defaults_to_accepting(self):
+		# The doctype default keeps contributions on unless explicitly disabled.
+		self.assertEqual(frappe.db.get_value("Wiki Space", self.restricted, "allow_contributions"), 1)
+		self.assertTrue(can_contribute_space(self.restricted, self.reader))
+
+	def test_cr_write_blocked_for_reader_when_contributions_off(self):
+		_set_contributions(self.restricted, False)
+		doc = frappe.get_doc({"doctype": "Wiki Change Request", "wiki_space": self.restricted})
+		# Reads still allowed; writes (proposing) blocked for Read-tier, allowed
+		# for Write-tier even with contributions off.
+		self.assertTrue(wiki_cr_has_permission(doc, "read", self.reader))
+		self.assertFalse(wiki_cr_has_permission(doc, "write", self.reader))
+		self.assertTrue(wiki_cr_has_permission(doc, "write", self.writer))
+
+	def test_create_change_request_blocked_for_reader_when_off(self):
+		from wiki.frappe_wiki.doctype.wiki_change_request.wiki_change_request import (
+			create_change_request,
+		)
+
+		_set_contributions(self.restricted, False)
+		frappe.set_user(self.reader)
+		with self.assertRaises(frappe.PermissionError):
+			create_change_request(self.restricted, "Reader proposal")
 
 
 class TestSpaceRolesAPI(IntegrationTestCase):

--- a/wiki/test_permissions.py
+++ b/wiki/test_permissions.py
@@ -14,7 +14,7 @@ from frappe.tests import IntegrationTestCase
 from wiki.permissions import (
 	_accessible_space_names,
 	_is_manager,
-	can_contribute_space,
+	can_contribute_to_space,
 	can_read_space,
 	can_write_space,
 	wiki_cr_has_permission,
@@ -234,29 +234,29 @@ class TestWikiSpacePermissions(IntegrationTestCase):
 		self.assertTrue(wiki_cr_has_permission(doc, "write", self.reader))
 		self.assertFalse(wiki_cr_has_permission(doc, "read", self.outsider))
 
-	# --- can_contribute_space (Accept Contributions toggle) -------------
+	# --- can_contribute_to_space (Accept Contributions toggle) -------------
 
 	def test_contributions_on_lets_reader_contribute(self):
 		_set_contributions(self.restricted, True)
-		self.assertTrue(can_contribute_space(self.restricted, self.reader))
+		self.assertTrue(can_contribute_to_space(self.restricted, self.reader))
 
 	def test_contributions_off_blocks_reader(self):
 		_set_contributions(self.restricted, False)
-		self.assertFalse(can_contribute_space(self.restricted, self.reader))
+		self.assertFalse(can_contribute_to_space(self.restricted, self.reader))
 
 	def test_contributions_off_still_allows_writer_and_manager(self):
 		_set_contributions(self.restricted, False)
-		self.assertTrue(can_contribute_space(self.restricted, self.writer))
-		self.assertTrue(can_contribute_space(self.restricted, self.manager))
+		self.assertTrue(can_contribute_to_space(self.restricted, self.writer))
+		self.assertTrue(can_contribute_to_space(self.restricted, self.manager))
 
 	def test_contributions_never_grant_access_without_read(self):
 		_set_contributions(self.restricted, True)
-		self.assertFalse(can_contribute_space(self.restricted, self.outsider))
+		self.assertFalse(can_contribute_to_space(self.restricted, self.outsider))
 
 	def test_new_space_defaults_to_accepting(self):
 		# The doctype default keeps contributions on unless explicitly disabled.
 		self.assertEqual(frappe.db.get_value("Wiki Space", self.restricted, "allow_contributions"), 1)
-		self.assertTrue(can_contribute_space(self.restricted, self.reader))
+		self.assertTrue(can_contribute_to_space(self.restricted, self.reader))
 
 	def test_cr_write_blocked_for_reader_when_contributions_off(self):
 		_set_contributions(self.restricted, False)

--- a/wiki/wiki/doctype/wiki_space/patches/set_allow_contributions_default.py
+++ b/wiki/wiki/doctype/wiki_space/patches/set_allow_contributions_default.py
@@ -15,10 +15,9 @@ def execute():
 	if not frappe.db.has_column("Wiki Space", "allow_contributions"):
 		return
 
-	frappe.db.sql(
-		"""
-		update `tabWiki Space`
-		set allow_contributions = 1
-		where allow_contributions is null
-		"""
-	)
+	wiki_space = frappe.qb.DocType("Wiki Space")
+	(
+		frappe.qb.update(wiki_space)
+		.set(wiki_space.allow_contributions, 1)
+		.where(wiki_space.allow_contributions.isnull())
+	).run()

--- a/wiki/wiki/doctype/wiki_space/patches/set_allow_contributions_default.py
+++ b/wiki/wiki/doctype/wiki_space/patches/set_allow_contributions_default.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+
+"""Backfill ``allow_contributions`` to 1 on existing Wiki Spaces.
+
+The field defaults to 1 for new spaces, but a newly added column leaves existing
+rows NULL. Contributions were always allowed before this toggle existed, so set
+every existing space to accept contributions to preserve behavior.
+"""
+
+import frappe
+
+
+def execute():
+	if not frappe.db.has_column("Wiki Space", "allow_contributions"):
+		return
+
+	frappe.db.sql(
+		"""
+		update `tabWiki Space`
+		set allow_contributions = 1
+		where allow_contributions is null
+		"""
+	)

--- a/wiki/wiki/doctype/wiki_space/wiki_space.json
+++ b/wiki/wiki/doctype/wiki_space/wiki_space.json
@@ -29,6 +29,8 @@
   "access_control_tab",
   "access_control_section",
   "roles",
+  "contributions_section",
+  "allow_contributions",
   "version_3_tab",
   "root_group",
   "main_revision",
@@ -134,6 +136,18 @@
    "fieldtype": "Table",
    "label": "Roles",
    "options": "Wiki Space Role"
+  },
+  {
+   "fieldname": "contributions_section",
+   "fieldtype": "Section Break",
+   "label": "Contributions"
+  },
+  {
+   "default": "1",
+   "description": "Allow readers to propose edits via Change Requests. Users with write/merge access can always edit, even when this is off.",
+   "fieldname": "allow_contributions",
+   "fieldtype": "Check",
+   "label": "Accept Contributions"
   },
   {
    "fieldname": "version_3_tab",


### PR DESCRIPTION

<img width="2252" height="1038" alt="image" src="https://github.com/user-attachments/assets/2aa6d606-9834-49b5-a9db-3e3079a194ac" />


Closes https://github.com/frappe/wiki/issues/669


## Why?

The Edit button (which lets readers raise change requests) was always shown. Space owners need a way to turn contributions off — making a space read-only for the public while keeping it editable for people with write/merge access.

## What?

Adds a per-space **Accept Contributions** toggle (Permissions settings), **on by default** so existing behavior is unchanged.

- **On:** readers see Edit and can raise change requests (as today).
- **Off:** read-only viewers no longer see Edit; **Copy (as Markdown)** becomes the primary action and Download / Open in ChatGPT / Open in Claude stay available.
- Wiki Managers / System Managers / Write-tier space roles **always** see Edit and can edit, regardless of the toggle.

## How?

- New `Wiki Space.allow_contributions` (Check, default 1) + a backfill patch for existing spaces.
- `permissions.py`: `can_contribute_space` = read access AND (write access OR space accepts contributions). The Change Request `has_permission` hook routes *write* ptypes through it (single choke point), and `create_change_request` / `get_or_create_draft_change_request` reject read-only users with a clear message when off.
- Reader: `get_web_context` exposes `can_edit = accepts OR can_write`, so anonymous discovery + the existing login redirect are preserved when on. The button macro renders Copy-as-primary when Edit is hidden.
- SPA: `get_space_capabilities` returns `can_contribute`; a write-gated `set_space_contributions` endpoint backs the new switch in the Permissions panel.

## Tests

- `wiki.test_permissions` — added the `can_contribute_space` matrix, CR write-hook gating, and `create_change_request` rejection for read-tier when off.
- `e2e/tests/accept-contributions.spec.ts` — reader Edit visibility on/off as a logged-out viewer, Copy-as-primary + retained actions, and managers still seeing Edit.

Both verified to fail on a temp-reverted toggle before restoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)