### PR TITLE
feat(settings): manage global Wiki Settings from the frontend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,10 @@ Use Tracer bullets comes from the Pragmatic Programmer. When building systems, y
 * Commit the spec before the development commits
 * Use comments only when necessary to explain "why?" not "how?", how must be clear from the code itself
 
+## Frontend / Backend Sync
+
+* Whenever a new field is added to a backend DocType that is surfaced in the frontend (e.g. settings panels), it must also be handled in the corresponding frontend component so the two stay in sync. This is a convention/reminder only — there is no automatic syncing mechanism; the frontend enumerates fields explicitly.
+
 ## Regression tests
 
 * When we fix a bug, add at the very least a Unit test, and verify before/after by temp revert of fix to make sure the test tests what is intended

--- a/e2e/tests/wiki-settings.spec.ts
+++ b/e2e/tests/wiki-settings.spec.ts
@@ -38,7 +38,7 @@ test.describe('Global Wiki Settings', () => {
 			'General',
 			'Feedback',
 			'Header & Robots',
-			'GitHub App',
+			'GitHub Sync',
 		]) {
 			await expect(
 				dialog.getByRole('button', { name: tab, exact: true }),

--- a/e2e/tests/wiki-settings.spec.ts
+++ b/e2e/tests/wiki-settings.spec.ts
@@ -1,0 +1,88 @@
+import { expect, test } from '@playwright/test';
+import { getDoc, updateDoc } from '../helpers/frappe';
+
+/**
+ * Global Wiki Settings dialog (admin-only, front-end).
+ *
+ * The site-wide Wiki Settings singleton used to be editable only from the Desk.
+ * It now opens as a dialog inside the SPA for Wiki Managers. We open it via the
+ * GitHub-App return param (?github_app_created=1) — deterministic, and it also
+ * exercises that redirect handler — then verify the tabs render and that a
+ * General toggle round-trips to the backend.
+ *
+ * The stored auth state is Administrator (System Manager → Wiki Manager), so the
+ * dialog and its trigger are available.
+ */
+test.describe('Global Wiki Settings', () => {
+	test('admin opens settings and a General toggle persists', async ({
+		page,
+		request,
+	}) => {
+		const original = await getDoc<{ enable_table_of_contents: number }>(
+			request,
+			'Wiki Settings',
+			'Wiki Settings',
+		);
+		const before = Boolean(original.enable_table_of_contents);
+
+		await page.setViewportSize({ width: 1100, height: 900 });
+		await page.goto('/wiki?github_app_created=1');
+		await page.waitForLoadState('networkidle');
+
+		const dialog = page.getByRole('dialog');
+		await expect(dialog).toBeVisible({ timeout: 10000 });
+		await expect(dialog.getByText('Wiki Settings')).toBeVisible();
+
+		// All four tabs are present.
+		for (const tab of [
+			'General',
+			'Feedback',
+			'Header & Robots',
+			'GitHub App',
+		]) {
+			await expect(
+				dialog.getByRole('button', { name: tab, exact: true }),
+			).toBeVisible();
+		}
+
+		// Toggle "Enable Table of Contents" on the General tab.
+		await dialog.getByRole('button', { name: 'General', exact: true }).click();
+		const tocSwitch = dialog.getByRole('switch').first();
+		await expect(tocSwitch).toBeVisible();
+		await tocSwitch.click();
+		await expect(tocSwitch).toHaveAttribute('aria-checked', String(!before));
+
+		// It persisted to the backend singleton.
+		await expect
+			.poll(async () => {
+				const doc = await getDoc<{ enable_table_of_contents: number }>(
+					request,
+					'Wiki Settings',
+					'Wiki Settings',
+				);
+				return Boolean(doc.enable_table_of_contents);
+			})
+			.toBe(!before);
+
+		// Restore the original value so the run is idempotent.
+		await updateDoc(request, 'Wiki Settings', 'Wiki Settings', {
+			enable_table_of_contents: before ? 1 : 0,
+		});
+	});
+
+	test('admin opens settings from the sidebar menu', async ({ page }) => {
+		await page.setViewportSize({ width: 1100, height: 900 });
+		await page.goto('/wiki');
+		await page.waitForLoadState('networkidle');
+
+		// The sidebar header is a dropdown trigger labelled with the app title.
+		await page.getByRole('button', { name: 'Frappe Wiki' }).click();
+		await page.getByRole('menuitem', { name: 'Settings' }).click();
+
+		const dialog = page.getByRole('dialog');
+		await expect(dialog).toBeVisible({ timeout: 10000 });
+		await expect(
+			dialog.getByRole('button', { name: 'General', exact: true }),
+		).toBeVisible();
+	});
+});

--- a/frontend/src/components/MobileTopNav.vue
+++ b/frontend/src/components/MobileTopNav.vue
@@ -40,12 +40,16 @@ import { computed, onMounted } from 'vue';
 import { useRouter } from 'vue-router';
 import LucideMenu from '~icons/lucide/menu';
 import { useSessionStore } from '@/stores/session';
+import { useUserStore } from '@/stores/user';
 import { useMobile } from '../composables/useMobile';
 import { useTheme } from '../composables/useTheme';
+import { useWikiSettings } from '../composables/useWikiSettings';
 
 const { mobileHasLeadingControl } = useMobile();
 const router = useRouter();
 const sessionStore = useSessionStore();
+const userStore = useUserStore();
+const { open: openWikiSettings } = useWikiSettings();
 const { userTheme, toggleTheme, initTheme } = useTheme();
 
 // On mobile the desktop Sidebar never mounts, so apply the saved theme here —
@@ -67,6 +71,15 @@ const appMenuOptions = computed(() => [
 		icon: 'git-branch',
 		onClick: () => router.push({ name: 'ChangeRequests' }),
 	},
+	...(userStore.isWikiManager
+		? [
+				{
+					label: __('Settings'),
+					icon: 'settings',
+					onClick: () => openWikiSettings(),
+				},
+			]
+		: []),
 	{
 		label: __('Toggle Theme'),
 		icon: userTheme.value === 'dark' ? 'sun' : 'moon',

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -15,14 +15,17 @@ import { useStorage } from "@vueuse/core";
 import LucideRocket from "~icons/lucide/rocket";
 import LucideGitBranch from "~icons/lucide/git-branch";
 import LucideLogOut from "~icons/lucide/log-out";
+import LucideSettings from "~icons/lucide/settings";
 import { useSessionStore } from "@/stores/session";
 import { useUserStore } from "@/stores/user";
 import { useTheme } from "../composables/useTheme";
+import { useWikiSettings } from "../composables/useWikiSettings";
 
 const route = useRoute();
 const router = useRouter();
 const sessionStore = useSessionStore();
 const userStore = useUserStore();
+const { open: openWikiSettings } = useWikiSettings();
 
 const { themeIcon, toggleTheme, initTheme } = useTheme();
 
@@ -33,6 +36,9 @@ const header = computed(() => ({
 	subtitle: userStore.data?.full_name,
 	logo: "/assets/wiki/images/wiki-logo.png",
 	menuItems: [
+		...(userStore.isWikiManager
+			? [{ label: __("Settings"), icon: LucideSettings, onClick: () => openWikiSettings() }]
+			: []),
 		{ label: __("Toggle Theme"), icon: themeIcon, onClick: toggleTheme },
 		{ label: __("Log out"), icon: LucideLogOut, onClick: logout },
 	],

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -39,7 +39,7 @@ const header = computed(() => ({
 		...(userStore.isWikiManager
 			? [{ label: __("Settings"), icon: LucideSettings, onClick: () => openWikiSettings() }]
 			: []),
-		{ label: __("Toggle Theme"), icon: themeIcon, onClick: toggleTheme },
+		{ label: __("Toggle Theme"), icon: themeIcon.value, onClick: toggleTheme },
 		{ label: __("Log out"), icon: LucideLogOut, onClick: logout },
 	],
 }));

--- a/frontend/src/components/WikiSettings/CodePanel.vue
+++ b/frontend/src/components/WikiSettings/CodePanel.vue
@@ -1,0 +1,94 @@
+<template>
+	<div class="flex flex-col gap-4">
+		<div class="flex flex-col gap-1.5">
+			<label class="text-sm font-medium text-ink-gray-9">
+				{{ __('<head> HTML') }}
+			</label>
+			<p class="text-xs text-ink-gray-5">
+				{{ __('Injected into the <head> of all public wiki pages') }}
+			</p>
+			<textarea
+				v-model="headHtml"
+				rows="6"
+				spellcheck="false"
+				class="w-full rounded-lg border border-outline-gray-2 bg-surface-gray-1 p-3 font-mono text-xs text-ink-gray-9 focus:border-outline-gray-3 focus:outline-none"
+			/>
+		</div>
+
+		<div class="flex flex-col gap-1.5">
+			<label class="text-sm font-medium text-ink-gray-9">
+				{{ __('JavaScript') }}
+			</label>
+			<p class="text-xs text-ink-gray-5">
+				{{ __('Custom JavaScript included on all public wiki pages') }}
+			</p>
+			<textarea
+				v-model="javascript"
+				rows="6"
+				spellcheck="false"
+				class="w-full rounded-lg border border-outline-gray-2 bg-surface-gray-1 p-3 font-mono text-xs text-ink-gray-9 focus:border-outline-gray-3 focus:outline-none"
+			/>
+		</div>
+
+		<div class="flex items-center justify-end gap-2">
+			<Badge v-if="isDirty" theme="orange" size="sm">
+				{{ __('Unsaved changes') }}
+			</Badge>
+			<Button
+				variant="solid"
+				:loading="saving"
+				:disabled="!isDirty"
+				@click="save"
+			>
+				{{ __('Save') }}
+			</Button>
+		</div>
+	</div>
+</template>
+
+<script setup>
+import { Badge, Button } from 'frappe-ui';
+import { computed, ref, watch } from 'vue';
+
+const props = defineProps({
+	settings: {
+		type: Object,
+		required: true,
+	},
+});
+
+const headHtml = ref('');
+const javascript = ref('');
+const saving = ref(false);
+
+watch(
+	() => props.settings.doc,
+	(doc) => {
+		if (doc) {
+			headHtml.value = doc.head_html || '';
+			javascript.value = doc.javascript || '';
+		}
+	},
+	{ immediate: true },
+);
+
+const isDirty = computed(
+	() =>
+		headHtml.value !== (props.settings.doc?.head_html || '') ||
+		javascript.value !== (props.settings.doc?.javascript || ''),
+);
+
+async function save() {
+	saving.value = true;
+	try {
+		await props.settings.setValue.submit({
+			head_html: headHtml.value,
+			javascript: javascript.value,
+		});
+	} catch (error) {
+		console.error('Failed to save header/robots settings:', error);
+	} finally {
+		saving.value = false;
+	}
+}
+</script>

--- a/frontend/src/components/WikiSettings/CodePanel.vue
+++ b/frontend/src/components/WikiSettings/CodePanel.vue
@@ -9,22 +9,7 @@
 			</p>
 			<textarea
 				v-model="headHtml"
-				rows="6"
-				spellcheck="false"
-				class="w-full rounded-lg border border-outline-gray-2 bg-surface-gray-1 p-3 font-mono text-xs text-ink-gray-9 focus:border-outline-gray-3 focus:outline-none"
-			/>
-		</div>
-
-		<div class="flex flex-col gap-1.5">
-			<label class="text-sm font-medium text-ink-gray-9">
-				{{ __('JavaScript') }}
-			</label>
-			<p class="text-xs text-ink-gray-5">
-				{{ __('Custom JavaScript included on all public wiki pages') }}
-			</p>
-			<textarea
-				v-model="javascript"
-				rows="6"
+				rows="8"
 				spellcheck="false"
 				class="w-full rounded-lg border border-outline-gray-2 bg-surface-gray-1 p-3 font-mono text-xs text-ink-gray-9 focus:border-outline-gray-3 focus:outline-none"
 			/>
@@ -58,7 +43,6 @@ const props = defineProps({
 });
 
 const headHtml = ref('');
-const javascript = ref('');
 const saving = ref(false);
 
 watch(
@@ -66,27 +50,21 @@ watch(
 	(doc) => {
 		if (doc) {
 			headHtml.value = doc.head_html || '';
-			javascript.value = doc.javascript || '';
 		}
 	},
 	{ immediate: true },
 );
 
 const isDirty = computed(
-	() =>
-		headHtml.value !== (props.settings.doc?.head_html || '') ||
-		javascript.value !== (props.settings.doc?.javascript || ''),
+	() => headHtml.value !== (props.settings.doc?.head_html || ''),
 );
 
 async function save() {
 	saving.value = true;
 	try {
-		await props.settings.setValue.submit({
-			head_html: headHtml.value,
-			javascript: javascript.value,
-		});
+		await props.settings.setValue.submit({ head_html: headHtml.value });
 	} catch (error) {
-		console.error('Failed to save header/robots settings:', error);
+		console.error('Failed to save header HTML:', error);
 	} finally {
 		saving.value = false;
 	}

--- a/frontend/src/components/WikiSettings/FeedbackPanel.vue
+++ b/frontend/src/components/WikiSettings/FeedbackPanel.vue
@@ -9,15 +9,6 @@
 			"
 		/>
 
-		<SettingToggle
-			:settings="settings"
-			fieldname="ask_for_contact_details"
-			:title="__('Ask for Contact Details')"
-			:description="
-				__('Ask visitors for their email when submitting feedback')
-			"
-		/>
-
 		<div
 			v-if="settings.doc?.enable_feedback"
 			class="flex items-center justify-between rounded-lg border border-outline-gray-2 bg-surface-gray-1 p-3"

--- a/frontend/src/components/WikiSettings/FeedbackPanel.vue
+++ b/frontend/src/components/WikiSettings/FeedbackPanel.vue
@@ -1,0 +1,83 @@
+<template>
+	<div class="flex flex-col gap-4">
+		<SettingToggle
+			:settings="settings"
+			fieldname="enable_feedback"
+			:title="__('Enable Feedback')"
+			:description="
+				__('Show a feedback widget on every wiki page to collect ratings and comments')
+			"
+		/>
+
+		<SettingToggle
+			:settings="settings"
+			fieldname="ask_for_contact_details"
+			:title="__('Ask for Contact Details')"
+			:description="
+				__('Ask visitors for their email when submitting feedback')
+			"
+		/>
+
+		<div
+			v-if="settings.doc?.enable_feedback"
+			class="flex items-center justify-between rounded-lg border border-outline-gray-2 bg-surface-gray-1 p-3"
+		>
+			<div class="mr-4 flex-1">
+				<p class="text-sm font-medium text-ink-gray-9">
+					{{ __('Feedback Submission Limit') }}
+				</p>
+				<p class="mt-0.5 text-xs text-ink-gray-5">
+					{{ __('Hourly rate limit on feedback submissions') }}
+				</p>
+			</div>
+			<FormControl
+				type="number"
+				class="w-24"
+				:min="0"
+				:modelValue="submissionLimit"
+				:disabled="updating"
+				@update:modelValue="submissionLimit = $event"
+				@change="updateLimit"
+			/>
+		</div>
+	</div>
+</template>
+
+<script setup>
+import { FormControl } from 'frappe-ui';
+import { ref, watch } from 'vue';
+import SettingToggle from './SettingToggle.vue';
+
+const props = defineProps({
+	settings: {
+		type: Object,
+		required: true,
+	},
+});
+
+const submissionLimit = ref(0);
+const updating = ref(false);
+
+watch(
+	() => props.settings.doc?.feedback_submission_limit,
+	(v) => {
+		submissionLimit.value = v ?? 0;
+	},
+	{ immediate: true },
+);
+
+async function updateLimit() {
+	const val = Math.max(0, parseInt(submissionLimit.value, 10) || 0);
+	submissionLimit.value = val;
+	if (val === props.settings.doc?.feedback_submission_limit) return;
+	updating.value = true;
+	try {
+		await props.settings.setValue.submit({ feedback_submission_limit: val });
+	} catch (error) {
+		console.error('Failed to update feedback submission limit:', error);
+		submissionLimit.value = props.settings.doc?.feedback_submission_limit ?? 0;
+	} finally {
+		updating.value = false;
+	}
+}
+</script>

--- a/frontend/src/components/WikiSettings/GeneralPanel.vue
+++ b/frontend/src/components/WikiSettings/GeneralPanel.vue
@@ -10,7 +10,7 @@
 		<SettingToggle
 			:settings="settings"
 			fieldname="auto_convert_images_to_webp"
-			:title="__('Convert Uploaded Images to WebP')"
+			:title="__('Auto Convert Image to WebP')"
 			:description="
 				__('Automatically convert uploaded PNG/JPEG images to WebP to reduce page size')
 			"

--- a/frontend/src/components/WikiSettings/GeneralPanel.vue
+++ b/frontend/src/components/WikiSettings/GeneralPanel.vue
@@ -1,23 +1,5 @@
 <template>
 	<div class="flex flex-col gap-4">
-		<div
-			class="rounded-lg border border-outline-gray-2 bg-surface-gray-1 p-3"
-		>
-			<p class="text-sm font-medium text-ink-gray-9">
-				{{ __('Default Wiki Space') }}
-			</p>
-			<p class="mt-0.5 text-xs text-ink-gray-5">
-				{{ __('The space visitors land on when they open the wiki root') }}
-			</p>
-			<Autocomplete
-				class="mt-2"
-				:options="spaceOptions"
-				:modelValue="selectedSpace"
-				:placeholder="__('Select a space')"
-				@update:modelValue="updateDefaultSpace"
-			/>
-		</div>
-
 		<SettingToggle
 			:settings="settings"
 			fieldname="enable_table_of_contents"
@@ -37,34 +19,12 @@
 </template>
 
 <script setup>
-import { Autocomplete, createResource } from 'frappe-ui';
-import { computed } from 'vue';
 import SettingToggle from './SettingToggle.vue';
 
-const props = defineProps({
+defineProps({
 	settings: {
 		type: Object,
 		required: true,
 	},
 });
-
-const spacesResource = createResource({
-	url: 'wiki.wiki.doctype.wiki_settings.wiki_settings.get_all_spaces',
-	auto: true,
-});
-
-const spaceOptions = computed(() =>
-	(spacesResource.data || []).map((route) => ({ label: route, value: route })),
-);
-
-const selectedSpace = computed(() => {
-	const value = props.settings.doc?.default_wiki_space;
-	return value ? { label: value, value } : null;
-});
-
-async function updateDefaultSpace(option) {
-	await props.settings.setValue.submit({
-		default_wiki_space: option?.value || '',
-	});
-}
 </script>

--- a/frontend/src/components/WikiSettings/GeneralPanel.vue
+++ b/frontend/src/components/WikiSettings/GeneralPanel.vue
@@ -1,0 +1,70 @@
+<template>
+	<div class="flex flex-col gap-4">
+		<div
+			class="rounded-lg border border-outline-gray-2 bg-surface-gray-1 p-3"
+		>
+			<p class="text-sm font-medium text-ink-gray-9">
+				{{ __('Default Wiki Space') }}
+			</p>
+			<p class="mt-0.5 text-xs text-ink-gray-5">
+				{{ __('The space visitors land on when they open the wiki root') }}
+			</p>
+			<Autocomplete
+				class="mt-2"
+				:options="spaceOptions"
+				:modelValue="selectedSpace"
+				:placeholder="__('Select a space')"
+				@update:modelValue="updateDefaultSpace"
+			/>
+		</div>
+
+		<SettingToggle
+			:settings="settings"
+			fieldname="enable_table_of_contents"
+			:title="__('Enable Table of Contents')"
+			:description="__('Show an auto-generated table of contents on wiki pages')"
+		/>
+
+		<SettingToggle
+			:settings="settings"
+			fieldname="auto_convert_images_to_webp"
+			:title="__('Convert Uploaded Images to WebP')"
+			:description="
+				__('Automatically convert uploaded PNG/JPEG images to WebP to reduce page size')
+			"
+		/>
+	</div>
+</template>
+
+<script setup>
+import { Autocomplete, createResource } from 'frappe-ui';
+import { computed } from 'vue';
+import SettingToggle from './SettingToggle.vue';
+
+const props = defineProps({
+	settings: {
+		type: Object,
+		required: true,
+	},
+});
+
+const spacesResource = createResource({
+	url: 'wiki.wiki.doctype.wiki_settings.wiki_settings.get_all_spaces',
+	auto: true,
+});
+
+const spaceOptions = computed(() =>
+	(spacesResource.data || []).map((route) => ({ label: route, value: route })),
+);
+
+const selectedSpace = computed(() => {
+	const value = props.settings.doc?.default_wiki_space;
+	return value ? { label: value, value } : null;
+});
+
+async function updateDefaultSpace(option) {
+	await props.settings.setValue.submit({
+		default_wiki_space: option?.value || '',
+	});
+}
+</script>

--- a/frontend/src/components/WikiSettings/GitHubAppPanel.vue
+++ b/frontend/src/components/WikiSettings/GitHubAppPanel.vue
@@ -1,7 +1,10 @@
 <template>
 	<div class="flex flex-col gap-5">
-		<!-- Intro + one-click create -->
-		<div class="rounded-lg border border-outline-gray-2 bg-surface-gray-1 p-3">
+		<!-- Intro + one-click create — only while the App isn't configured yet. -->
+		<div
+			v-if="!isConfigured"
+			class="rounded-lg border border-outline-gray-2 bg-surface-gray-1 p-3"
+		>
 			<p class="text-sm font-medium text-ink-gray-9">{{ __('GitHub Sync') }}</p>
 			<p class="mt-0.5 text-xs text-ink-gray-5">
 				{{
@@ -158,6 +161,15 @@ const clientSecret = ref('');
 const webhookSecret = ref('');
 const privateKey = ref('');
 const savingSecrets = ref(false);
+
+// "Create GitHub App" creates a brand-new App, so only offer it before one is
+// set up — once an App ID + Client ID are stored, creating another would orphan
+// the existing one.
+const isConfigured = computed(() =>
+	Boolean(
+		props.settings.doc?.github_app_id && props.settings.doc?.github_app_client_id,
+	),
+);
 
 const hasClientSecret = computed(() => Boolean(appConfig.data?.has_client_secret));
 const hasWebhookSecret = computed(() => Boolean(appConfig.data?.has_webhook_secret));

--- a/frontend/src/components/WikiSettings/GitHubAppPanel.vue
+++ b/frontend/src/components/WikiSettings/GitHubAppPanel.vue
@@ -2,7 +2,7 @@
 	<div class="flex flex-col gap-5">
 		<!-- Intro + one-click create -->
 		<div class="rounded-lg border border-outline-gray-2 bg-surface-gray-1 p-3">
-			<p class="text-sm font-medium text-ink-gray-9">{{ __('GitHub App') }}</p>
+			<p class="text-sm font-medium text-ink-gray-9">{{ __('GitHub Sync') }}</p>
 			<p class="mt-0.5 text-xs text-ink-gray-5">
 				{{
 					__('Configure a GitHub App so Wiki Spaces can sync from GitHub repositories, including private ones. Access tokens are minted on demand from the App private key — no per-space secrets are stored.')

--- a/frontend/src/components/WikiSettings/GitHubAppPanel.vue
+++ b/frontend/src/components/WikiSettings/GitHubAppPanel.vue
@@ -1,0 +1,237 @@
+<template>
+	<div class="flex flex-col gap-5">
+		<!-- Intro + one-click create -->
+		<div class="rounded-lg border border-outline-gray-2 bg-surface-gray-1 p-3">
+			<p class="text-sm font-medium text-ink-gray-9">{{ __('GitHub App') }}</p>
+			<p class="mt-0.5 text-xs text-ink-gray-5">
+				{{
+					__('Configure a GitHub App so Wiki Spaces can sync from GitHub repositories, including private ones. Access tokens are minted on demand from the App private key — no per-space secrets are stored.')
+				}}
+			</p>
+			<Button
+				class="mt-3"
+				variant="solid"
+				icon-left="github"
+				@click="createApp"
+			>
+				{{ __('Create GitHub App') }}
+			</Button>
+		</div>
+
+		<!-- Manual configuration (non-secret Data fields) -->
+		<div class="flex flex-col gap-3">
+			<p class="text-sm font-medium text-ink-gray-9">
+				{{ __('App Configuration') }}
+			</p>
+			<FormControl v-model="appId" type="text" :label="__('App ID')" />
+			<FormControl
+				v-model="clientId"
+				type="text"
+				:label="__('Client ID')"
+			/>
+			<FormControl
+				v-model="publicLink"
+				type="text"
+				:label="__('App Public Link')"
+				:description="
+					__('Public installation link, e.g. https://github.com/apps/your-app/installations/new')
+				"
+			/>
+			<div class="flex items-center justify-end gap-2">
+				<Badge v-if="configDirty" theme="orange" size="sm">
+					{{ __('Unsaved changes') }}
+				</Badge>
+				<Button
+					variant="solid"
+					:loading="savingConfig"
+					:disabled="!configDirty"
+					@click="saveConfig"
+				>
+					{{ __('Save') }}
+				</Button>
+			</div>
+		</div>
+
+		<!-- Secrets (write-only) -->
+		<div class="flex flex-col gap-3">
+			<p class="text-sm font-medium text-ink-gray-9">{{ __('Secrets') }}</p>
+			<p class="-mt-2 text-xs text-ink-gray-5">
+				{{ __('Stored secrets are never shown. Leave a field blank to keep its current value.') }}
+			</p>
+
+			<div class="flex flex-col gap-1.5">
+				<div class="flex items-center gap-2">
+					<label class="text-sm font-medium text-ink-gray-9">
+						{{ __('Client Secret') }}
+					</label>
+					<Badge :theme="hasClientSecret ? 'green' : 'gray'" size="sm">
+						{{ hasClientSecret ? __('Configured') : __('Not set') }}
+					</Badge>
+				</div>
+				<FormControl
+					v-model="clientSecret"
+					type="password"
+					:placeholder="hasClientSecret ? '••••••••' : __('Enter client secret')"
+				/>
+			</div>
+
+			<div class="flex flex-col gap-1.5">
+				<div class="flex items-center gap-2">
+					<label class="text-sm font-medium text-ink-gray-9">
+						{{ __('Webhook Secret') }}
+					</label>
+					<Badge :theme="hasWebhookSecret ? 'green' : 'gray'" size="sm">
+						{{ hasWebhookSecret ? __('Configured') : __('Not set') }}
+					</Badge>
+				</div>
+				<FormControl
+					v-model="webhookSecret"
+					type="password"
+					:placeholder="hasWebhookSecret ? '••••••••' : __('Enter webhook secret')"
+				/>
+			</div>
+
+			<div class="flex flex-col gap-1.5">
+				<div class="flex items-center gap-2">
+					<label class="text-sm font-medium text-ink-gray-9">
+						{{ __('Private Key') }}
+					</label>
+					<Badge :theme="hasPrivateKey ? 'green' : 'gray'" size="sm">
+						{{ hasPrivateKey ? __('Configured') : __('Not set') }}
+					</Badge>
+				</div>
+				<p class="text-xs text-ink-gray-5">
+					{{ __('PEM-encoded private key generated for the GitHub App') }}
+				</p>
+				<textarea
+					v-model="privateKey"
+					rows="5"
+					spellcheck="false"
+					:placeholder="
+						hasPrivateKey ? __('Configured — paste a new key to replace') : __('Paste PEM private key')
+					"
+					class="w-full rounded-lg border border-outline-gray-2 bg-surface-gray-1 p-3 font-mono text-xs text-ink-gray-9 focus:border-outline-gray-3 focus:outline-none"
+				/>
+			</div>
+
+			<div class="flex items-center justify-end">
+				<Button
+					variant="solid"
+					:loading="savingSecrets"
+					:disabled="!secretsDirty"
+					@click="saveSecrets"
+				>
+					{{ __('Save Secrets') }}
+				</Button>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script setup>
+import { Badge, Button, FormControl, createResource, toast } from 'frappe-ui';
+import { computed, ref, watch } from 'vue';
+
+const props = defineProps({
+	settings: {
+		type: Object,
+		required: true,
+	},
+});
+
+// Password fields don't round-trip through the doc API, so presence comes from
+// a dedicated endpoint that returns booleans only (never the secret values).
+const appConfig = createResource({
+	url: 'wiki.api.github.get_app_config',
+	auto: true,
+});
+const saveCredentials = createResource({
+	url: 'wiki.api.github.save_app_credentials',
+});
+
+const appId = ref('');
+const clientId = ref('');
+const publicLink = ref('');
+const savingConfig = ref(false);
+
+const clientSecret = ref('');
+const webhookSecret = ref('');
+const privateKey = ref('');
+const savingSecrets = ref(false);
+
+const hasClientSecret = computed(() => Boolean(appConfig.data?.has_client_secret));
+const hasWebhookSecret = computed(() => Boolean(appConfig.data?.has_webhook_secret));
+const hasPrivateKey = computed(() => Boolean(appConfig.data?.has_private_key));
+
+watch(
+	() => props.settings.doc,
+	(doc) => {
+		if (doc) {
+			appId.value = doc.github_app_id || '';
+			clientId.value = doc.github_app_client_id || '';
+			publicLink.value = doc.github_app_public_link || '';
+		}
+	},
+	{ immediate: true },
+);
+
+const configDirty = computed(
+	() =>
+		appId.value !== (props.settings.doc?.github_app_id || '') ||
+		clientId.value !== (props.settings.doc?.github_app_client_id || '') ||
+		publicLink.value !== (props.settings.doc?.github_app_public_link || ''),
+);
+
+const secretsDirty = computed(
+	() =>
+		Boolean(clientSecret.value) ||
+		Boolean(webhookSecret.value) ||
+		Boolean(privateKey.value),
+);
+
+function createApp() {
+	// Same-window so the manifest flow's redirect back to /wiki?github_app_created=1
+	// re-opens this dialog on the GitHub tab (handled in MainLayout).
+	window.location.href = '/github/new_app';
+}
+
+async function saveConfig() {
+	savingConfig.value = true;
+	try {
+		await props.settings.setValue.submit({
+			github_app_id: appId.value,
+			github_app_client_id: clientId.value,
+			github_app_public_link: publicLink.value,
+		});
+		toast.success(__('Configuration saved'));
+	} catch (error) {
+		console.error('Failed to save GitHub App configuration:', error);
+		toast.error(__('Failed to save configuration'));
+	} finally {
+		savingConfig.value = false;
+	}
+}
+
+async function saveSecrets() {
+	const payload = {};
+	if (clientSecret.value) payload.client_secret = clientSecret.value;
+	if (webhookSecret.value) payload.webhook_secret = webhookSecret.value;
+	if (privateKey.value) payload.private_key = privateKey.value;
+	if (!Object.keys(payload).length) return;
+
+	savingSecrets.value = true;
+	try {
+		await saveCredentials.submit(payload);
+		clientSecret.value = '';
+		webhookSecret.value = '';
+		privateKey.value = '';
+		await appConfig.reload();
+		toast.success(__('Secrets updated'));
+	} catch (error) {
+		console.error('Failed to save GitHub App secrets:', error);
+		toast.error(__('Failed to save secrets'));
+	} finally {
+		savingSecrets.value = false;
+	}
+}
+</script>

--- a/frontend/src/components/WikiSettings/SettingToggle.vue
+++ b/frontend/src/components/WikiSettings/SettingToggle.vue
@@ -1,0 +1,60 @@
+<template>
+	<div
+		class="flex items-center justify-between rounded-lg border border-outline-gray-2 bg-surface-gray-1 p-3"
+	>
+		<div class="mr-4 flex-1">
+			<p class="text-sm font-medium text-ink-gray-9">{{ title }}</p>
+			<p v-if="description" class="mt-0.5 text-xs text-ink-gray-5">
+				{{ description }}
+			</p>
+		</div>
+		<Switch v-model="value" :disabled="updating" @update:modelValue="update" />
+	</div>
+</template>
+
+<script setup>
+import { Switch } from 'frappe-ui';
+import { ref, watch } from 'vue';
+
+const props = defineProps({
+	settings: {
+		type: Object,
+		required: true,
+	},
+	fieldname: {
+		type: String,
+		required: true,
+	},
+	title: {
+		type: String,
+		required: true,
+	},
+	description: {
+		type: String,
+		default: '',
+	},
+});
+
+const value = ref(false);
+const updating = ref(false);
+
+watch(
+	() => props.settings.doc?.[props.fieldname],
+	(v) => {
+		value.value = Boolean(v);
+	},
+	{ immediate: true },
+);
+
+async function update(val) {
+	updating.value = true;
+	try {
+		await props.settings.setValue.submit({ [props.fieldname]: val ? 1 : 0 });
+	} catch (error) {
+		console.error(`Failed to update ${props.fieldname}:`, error);
+		value.value = !val;
+	} finally {
+		updating.value = false;
+	}
+}
+</script>

--- a/frontend/src/components/WikiSettings/WikiSettings.vue
+++ b/frontend/src/components/WikiSettings/WikiSettings.vue
@@ -44,6 +44,14 @@
 						v-if="selectedTab === 'general'"
 						:settings="settings"
 					/>
+					<FeedbackPanel
+						v-else-if="selectedTab === 'feedback'"
+						:settings="settings"
+					/>
+					<CodePanel
+						v-else-if="selectedTab === 'code'"
+						:settings="settings"
+					/>
 				</template>
 			</div>
 		</div>
@@ -53,6 +61,8 @@
 <script setup>
 import { Button, LoadingIndicator, createDocumentResource } from 'frappe-ui';
 import { computed, ref } from 'vue';
+import CodePanel from './CodePanel.vue';
+import FeedbackPanel from './FeedbackPanel.vue';
 import GeneralPanel from './GeneralPanel.vue';
 
 const props = defineProps({
@@ -72,7 +82,11 @@ const settings = createDocumentResource({
 	auto: true,
 });
 
-const tabs = [{ label: __('General'), value: 'general', icon: 'settings' }];
+const tabs = [
+	{ label: __('General'), value: 'general', icon: 'settings' },
+	{ label: __('Feedback'), value: 'feedback', icon: 'message-square' },
+	{ label: __('Header & Robots'), value: 'code', icon: 'code' },
+];
 
 const selectedTab = ref(
 	tabs.some((tab) => tab.value === props.initialTab)

--- a/frontend/src/components/WikiSettings/WikiSettings.vue
+++ b/frontend/src/components/WikiSettings/WikiSettings.vue
@@ -1,0 +1,85 @@
+<template>
+	<div class="flex h-[80vh] max-h-[680px] overflow-hidden">
+		<!-- Vertical navigation -->
+		<div
+			class="flex w-52 shrink-0 flex-col gap-4 border-r border-outline-gray-2 bg-surface-gray-1 p-3"
+		>
+			<span class="px-2 pt-1 text-lg font-semibold text-ink-gray-9">
+				{{ __('Wiki Settings') }}
+			</span>
+			<div class="flex flex-col gap-1">
+				<Button
+					v-for="tab in tabs"
+					:key="tab.value"
+					:variant="selectedTab === tab.value ? 'subtle' : 'ghost'"
+					:icon-left="tab.icon"
+					class="!justify-start"
+					:class="{ '!bg-surface-gray-3': selectedTab === tab.value }"
+					@click="selectedTab = tab.value"
+				>
+					{{ tab.label }}
+				</Button>
+			</div>
+		</div>
+
+		<!-- Active panel -->
+		<div class="flex flex-1 flex-col overflow-hidden bg-surface-white">
+			<div
+				class="flex items-center justify-between border-b border-outline-gray-2 px-6 py-4"
+			>
+				<h2 class="text-xl font-semibold text-ink-gray-9">
+					{{ activeTab?.label }}
+				</h2>
+				<Button variant="ghost" icon="x" @click="$emit('close')" />
+			</div>
+			<div class="flex-1 overflow-y-auto p-6">
+				<div
+					v-if="!settings.doc"
+					class="flex h-full items-center justify-center"
+				>
+					<LoadingIndicator class="size-5 text-ink-gray-5" />
+				</div>
+				<template v-else>
+					<GeneralPanel
+						v-if="selectedTab === 'general'"
+						:settings="settings"
+					/>
+				</template>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script setup>
+import { Button, LoadingIndicator, createDocumentResource } from 'frappe-ui';
+import { computed, ref } from 'vue';
+import GeneralPanel from './GeneralPanel.vue';
+
+const props = defineProps({
+	initialTab: {
+		type: String,
+		default: 'general',
+	},
+});
+
+defineEmits(['close']);
+
+// Single doctype: fetched fresh each time the dialog opens (the component
+// remounts), so the panels always reflect the latest saved values.
+const settings = createDocumentResource({
+	doctype: 'Wiki Settings',
+	name: 'Wiki Settings',
+	auto: true,
+});
+
+const tabs = [{ label: __('General'), value: 'general', icon: 'settings' }];
+
+const selectedTab = ref(
+	tabs.some((tab) => tab.value === props.initialTab)
+		? props.initialTab
+		: 'general',
+);
+const activeTab = computed(() =>
+	tabs.find((tab) => tab.value === selectedTab.value),
+);
+</script>

--- a/frontend/src/components/WikiSettings/WikiSettings.vue
+++ b/frontend/src/components/WikiSettings/WikiSettings.vue
@@ -52,6 +52,10 @@
 						v-else-if="selectedTab === 'code'"
 						:settings="settings"
 					/>
+					<GitHubAppPanel
+						v-else-if="selectedTab === 'github'"
+						:settings="settings"
+					/>
 				</template>
 			</div>
 		</div>
@@ -64,6 +68,7 @@ import { computed, ref } from 'vue';
 import CodePanel from './CodePanel.vue';
 import FeedbackPanel from './FeedbackPanel.vue';
 import GeneralPanel from './GeneralPanel.vue';
+import GitHubAppPanel from './GitHubAppPanel.vue';
 
 const props = defineProps({
 	initialTab: {
@@ -86,6 +91,7 @@ const tabs = [
 	{ label: __('General'), value: 'general', icon: 'settings' },
 	{ label: __('Feedback'), value: 'feedback', icon: 'message-square' },
 	{ label: __('Header & Robots'), value: 'code', icon: 'code' },
+	{ label: __('GitHub App'), value: 'github', icon: 'github' },
 ];
 
 const selectedTab = ref(

--- a/frontend/src/components/WikiSettings/WikiSettings.vue
+++ b/frontend/src/components/WikiSettings/WikiSettings.vue
@@ -91,7 +91,7 @@ const tabs = [
 	{ label: __('General'), value: 'general', icon: 'settings' },
 	{ label: __('Feedback'), value: 'feedback', icon: 'message-square' },
 	{ label: __('Header & Robots'), value: 'code', icon: 'code' },
-	{ label: __('GitHub App'), value: 'github', icon: 'github' },
+	{ label: __('GitHub Sync'), value: 'github', icon: 'github' },
 ];
 
 const selectedTab = ref(

--- a/frontend/src/composables/useWikiSettings.js
+++ b/frontend/src/composables/useWikiSettings.js
@@ -1,0 +1,20 @@
+import { ref } from 'vue';
+
+// Global open-state for the site-wide Wiki Settings dialog, so any component
+// (sidebar menu, mobile nav, the GitHub-App return redirect) can open it and
+// deep-link to a specific tab. Mirrors CRM's global `showSettings` flag.
+const showWikiSettings = ref(false);
+const initialTab = ref('general');
+
+export function useWikiSettings() {
+	function open(tab = 'general') {
+		initialTab.value = tab;
+		showWikiSettings.value = true;
+	}
+
+	function close() {
+		showWikiSettings.value = false;
+	}
+
+	return { showWikiSettings, initialTab, open, close };
+}

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -57,7 +57,7 @@
 
 <script setup>
 import { Dialog } from 'frappe-ui';
-import { computed, onMounted } from 'vue';
+import { computed, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import Sidebar from '../components/Sidebar.vue';
 import MobileTopNav from '../components/MobileTopNav.vue';
@@ -76,13 +76,18 @@ const isLoading = computed(() => userStore.isLoading);
 const hasAccess = computed(() => userStore.canAccessWiki);
 
 // The GitHub-App manifest flow redirects back here with ?github_app_created=1.
-// Re-open the settings dialog on the GitHub tab and strip the query param.
-onMounted(() => {
-	if (route.query.github_app_created) {
+// Re-open the settings dialog on the GitHub tab and strip the query param. This
+// watches (rather than runs once on mount) because the app mounts before the
+// router resolves the initial route, so the query isn't populated yet at mount.
+watch(
+	() => route.query.github_app_created,
+	(created) => {
+		if (!created) return;
 		open('github');
 		const query = { ...route.query };
 		delete query.github_app_created;
 		router.replace({ query });
-	}
-});
+	},
+	{ immediate: true },
+);
 </script>

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -43,19 +43,46 @@
 				</p>
 			</div>
 		</div>
+
+		<Dialog v-model="showWikiSettings" :options="{ size: '4xl' }">
+			<template #body>
+				<WikiSettings
+					:initial-tab="initialTab"
+					@close="showWikiSettings = false"
+				/>
+			</template>
+		</Dialog>
 	</div>
 </template>
 
 <script setup>
-import { computed } from 'vue';
+import { Dialog } from 'frappe-ui';
+import { computed, onMounted } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
 import Sidebar from '../components/Sidebar.vue';
 import MobileTopNav from '../components/MobileTopNav.vue';
+import WikiSettings from '../components/WikiSettings/WikiSettings.vue';
 import { useMobile } from '../composables/useMobile';
+import { useWikiSettings } from '../composables/useWikiSettings';
 import { useUserStore } from '@/stores/user';
 
 const { isMobile } = useMobile();
 const userStore = useUserStore();
+const route = useRoute();
+const router = useRouter();
+const { showWikiSettings, initialTab, open } = useWikiSettings();
 
 const isLoading = computed(() => userStore.isLoading);
 const hasAccess = computed(() => userStore.canAccessWiki);
+
+// The GitHub-App manifest flow redirects back here with ?github_app_created=1.
+// Re-open the settings dialog on the GitHub tab and strip the query param.
+onMounted(() => {
+	if (route.query.github_app_created) {
+		open('github');
+		const query = { ...route.query };
+		delete query.github_app_created;
+		router.replace({ query });
+	}
+});
 </script>

--- a/specs/frontend_global_wiki_settings.md
+++ b/specs/frontend_global_wiki_settings.md
@@ -45,15 +45,21 @@ importing the CRM/LMS settings shell, for visual + code consistency.
 `Wiki Settings` (`wiki/wiki/doctype/wiki_settings/wiki_settings.json`), grouped by
 its existing Tab Breaks:
 
-- **General:** `default_wiki_space` (Autocomplete, options via `get_all_spaces`),
-  `enable_table_of_contents` (Check), `auto_convert_images_to_webp` (Check)
+- **General:** `enable_table_of_contents` (Check), `auto_convert_images_to_webp`
+  (Check)
 - **Feedback:** `enable_feedback` (Check), `feedback_submission_limit`
-  (Int, depends on `enable_feedback`), `ask_for_contact_details` (Check)
-- **Header / Robots:** `head_html` (Code/HTML), `javascript` (Code/JS)
-- **GitHub App:** `github_app_id`, `github_app_client_id`,
+  (Int, depends on `enable_feedback`)
+- **Header & Robots:** `head_html` (Code/HTML)
+- **GitHub Sync:** `github_app_id`, `github_app_client_id`,
   `github_app_public_link` (Data — round-trip normally) +
   `github_app_client_secret`, `github_app_private_key`, `github_webhook_secret`
   (**Password — do NOT round-trip via the doc API**)
+
+Deliberately **not** surfaced — dead `Wiki Settings` fields with no runtime
+consumer in v3: `default_wiki_space` (only ever written by an old sidebar
+migration patch), `ask_for_contact_details`, and `javascript` (only `head_html`
+is actually injected, via `wiki_document.py` → `templates/wiki/layout.html`).
+The DocType still carries these columns; removing them is a separate cleanup.
 
 ## Implementation (tracer-bullet phases)
 

--- a/specs/frontend_global_wiki_settings.md
+++ b/specs/frontend_global_wiki_settings.md
@@ -1,7 +1,13 @@
 # Global Wiki Settings in the Frontend
 
 Date: 2026-06-29
-Status: **Planned**
+Status: **Implemented**
+
+> Reconciliation: implemented on `feat/frontend-wiki-settings` across all five
+> phases. One deviation from the plan: the dialog is opened on the GitHub-return
+> path via a reactive query watcher in `MainLayout.vue` (not `onMounted`) because
+> the app mounts before the router resolves the initial route. A small reusable
+> `SettingToggle.vue` was added to share the switch-row layout/save across panels.
 
 ## Goal
 

--- a/wiki/api/github.py
+++ b/wiki/api/github.py
@@ -511,6 +511,51 @@ def app_install_url() -> str | None:
 	return _settings().github_app_public_link or None
 
 
+@frappe.whitelist()
+def get_app_config() -> dict[str, Any]:
+	"""Non-secret GitHub App config + secret-presence flags for the settings UI.
+
+	Password fields never round-trip through the normal doc API, so the frontend
+	can't otherwise tell whether a secret is configured. We return booleans (never
+	the values) so the panel can show "configured" vs "not set".
+	"""
+	if not frappe.has_permission("Wiki Settings", "read"):
+		frappe.throw(_("Not permitted to read Wiki Settings."), frappe.PermissionError)
+	settings = _settings()
+	return {
+		"app_id": settings.github_app_id,
+		"client_id": settings.github_app_client_id,
+		"public_link": settings.github_app_public_link,
+		"has_client_secret": bool(settings.get_password("github_app_client_secret", raise_exception=False)),
+		"has_private_key": bool(settings.get_password("github_app_private_key", raise_exception=False)),
+		"has_webhook_secret": bool(settings.get_password("github_webhook_secret", raise_exception=False)),
+	}
+
+
+@frappe.whitelist()
+def save_app_credentials(
+	client_secret: str | None = None,
+	private_key: str | None = None,
+	webhook_secret: str | None = None,
+) -> None:
+	"""Write-only update of the GitHub App secrets from the settings UI.
+
+	Only overwrites a secret when a non-empty value is supplied; a blank field
+	leaves the stored secret untouched, so the panel never needs to read it back.
+	"""
+	if not frappe.has_permission("Wiki Settings", "write"):
+		frappe.throw(_("Not permitted to configure the GitHub App."), frappe.PermissionError)
+	settings = frappe.get_doc("Wiki Settings")
+	if client_secret:
+		settings.github_app_client_secret = client_secret
+	if private_key:
+		settings.github_app_private_key = private_key
+	if webhook_secret:
+		settings.github_webhook_secret = webhook_secret
+	settings.save()
+	frappe.clear_cache(doctype="Wiki Settings")
+
+
 # --------------------------------------------------------------------------- #
 # Push webhook — real-time sync (auto-configured by the App installation)
 # --------------------------------------------------------------------------- #

--- a/wiki/api/test_github.py
+++ b/wiki/api/test_github.py
@@ -585,3 +585,70 @@ class TestGithubWebhook(FrappeTestCase):
 		self.assertTrue(second["duplicate"])
 		self.assertEqual(len(self.enqueued), 1)  # not re-enqueued
 		self.assertEqual(frappe.db.count("Wiki GitHub Webhook Log", {"name": "dup-1"}), 1)
+
+
+class TestGithubAppConfigApi(FrappeTestCase):
+	"""The SPA-facing GitHub App config endpoints (presence flags + write-only secrets)."""
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		frappe.db.rollback()
+		frappe.clear_cache(doctype="Wiki Settings")
+
+	def _set_fields(self, **fields):
+		settings = frappe.get_doc("Wiki Settings")
+		for key, value in fields.items():
+			setattr(settings, key, value)
+		settings.save()
+		frappe.clear_cache(doctype="Wiki Settings")
+
+	def test_get_app_config_reports_presence_without_leaking_secrets(self):
+		self._set_fields(
+			github_app_id="42",
+			github_app_client_id="Iv1.abc",
+			github_app_public_link="https://github.com/apps/x/installations/new",
+			github_app_client_secret="supersecret",
+			github_app_private_key="-----BEGIN RSA PRIVATE KEY-----\nx\n-----END RSA PRIVATE KEY-----\n",
+			github_webhook_secret="hooksecret",
+		)
+		config = github.get_app_config()
+		self.assertEqual(config["app_id"], "42")
+		self.assertEqual(config["client_id"], "Iv1.abc")
+		self.assertTrue(config["has_client_secret"])
+		self.assertTrue(config["has_private_key"])
+		self.assertTrue(config["has_webhook_secret"])
+		# No secret value leaks into the payload.
+		serialized = json.dumps(config)
+		self.assertNotIn("supersecret", serialized)
+		self.assertNotIn("hooksecret", serialized)
+		self.assertNotIn("BEGIN RSA PRIVATE KEY", serialized)
+
+	def test_get_app_config_unconfigured_reports_absent(self):
+		self._set_fields(
+			github_app_client_secret="",
+			github_app_private_key="",
+			github_webhook_secret="",
+		)
+		config = github.get_app_config()
+		self.assertFalse(config["has_client_secret"])
+		self.assertFalse(config["has_private_key"])
+		self.assertFalse(config["has_webhook_secret"])
+
+	def test_save_app_credentials_writes_only_nonempty(self):
+		self._set_fields(github_app_client_secret="original", github_webhook_secret="orig-hook")
+		# Blank fields must leave the existing secrets untouched.
+		github.save_app_credentials(client_secret="updated", private_key="", webhook_secret="")
+		frappe.clear_cache(doctype="Wiki Settings")
+		settings = frappe.get_doc("Wiki Settings")
+		self.assertEqual(settings.get_password("github_app_client_secret"), "updated")
+		self.assertEqual(settings.get_password("github_webhook_secret"), "orig-hook")
+
+	def test_get_app_config_requires_read_permission(self):
+		frappe.set_user("Guest")
+		with self.assertRaises(frappe.PermissionError):
+			github.get_app_config()
+
+	def test_save_app_credentials_requires_write_permission(self):
+		frappe.set_user("Guest")
+		with self.assertRaises(frappe.PermissionError):
+			github.save_app_credentials(client_secret="nope")

--- a/wiki/wiki/doctype/wiki_settings/test_wiki_settings.py
+++ b/wiki/wiki/doctype/wiki_settings/test_wiki_settings.py
@@ -1,9 +1,16 @@
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
 
-# import frappe
-import unittest
+import frappe
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestWikiSettings(unittest.TestCase):
-	pass
+class TestWikiSettings(FrappeTestCase):
+	def test_wiki_manager_can_read_and_write(self):
+		# The frontend settings dialog is gated on the Wiki Manager role, so that
+		# role must hold read+write on the singleton for saves to go through.
+		permissions = frappe.get_meta("Wiki Settings").permissions
+		read_roles = {p.role for p in permissions if p.read}
+		write_roles = {p.role for p in permissions if p.write}
+		self.assertIn("Wiki Manager", read_roles)
+		self.assertIn("Wiki Manager", write_roles)

--- a/wiki/wiki/doctype/wiki_settings/wiki_settings.json
+++ b/wiki/wiki/doctype/wiki_settings/wiki_settings.json
@@ -197,6 +197,14 @@
    "role": "Wiki Approver",
    "share": 1,
    "write": 1
+  },
+  {
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "Wiki Manager",
+   "share": 1,
+   "write": 1
   }
  ],
  "quick_entry": 1,

--- a/wiki/wiki/report/wiki_broken_links/test_broken_link_checker.py
+++ b/wiki/wiki/report/wiki_broken_links/test_broken_link_checker.py
@@ -8,7 +8,9 @@ from frappe.tests.utils import FrappeTestCase
 
 from wiki.wiki.report.wiki_broken_links.wiki_broken_links import execute, get_broken_links
 
-WORKING_EXTERNAL_URL = "https://frappe.io"
+# RFC 2606 reserved domain: always resolves, never flakes in CI (unlike a real
+# site, which can intermittently be unreachable and get mis-flagged as broken).
+WORKING_EXTERNAL_URL = "https://example.com"
 BROKEN_EXTERNAL_URL = "https://frappewiki.notavalidtld"
 BROKEN_IMG_URL = "https://img.notavalidtld/failed.jpeg"
 WORKING_INTERNAL_URL = "/api/method/ping"

--- a/wiki/www/github/manifest_redirect.py
+++ b/wiki/www/github/manifest_redirect.py
@@ -37,5 +37,5 @@ def get_context(context):
 	# this the freshly-stored credentials roll back at the end of the request.
 	frappe.db.commit()  # nosemgrep
 
-	frappe.local.flags.redirect_location = "/app/wiki-settings?github_app_created=1"
+	frappe.local.flags.redirect_location = "/wiki?github_app_created=1"
 	raise frappe.Redirect


### PR DESCRIPTION
## Why?

Global **Wiki Settings** could only be changed from the Frappe Desk. This brings them into the SPA so admins never have to leave the wiki to configure it.

## What?

An admin-only (**Wiki Manager** / **System Manager**) **Settings** dialog, opened from the sidebar menu and mirroring the existing per-space Settings UX. Its tabs surface the **live** `Wiki Settings` fields:

| Tab | Settings |
|---|---|
| General | Table of Contents, WebP conversion |
| Feedback | Enable feedback, hourly submission limit |
| Header & Robots | `<head>` HTML |
| GitHub Sync | App ID / Client ID / Public Link + write-only secrets, one-click Create App |

Dead `Wiki Settings` fields with no runtime consumer in v3 are intentionally **not** surfaced: `default_wiki_space` (only written by an old sidebar migration), `ask_for_contact_details`, and `javascript` (only `head_html` is actually injected into the page `<head>`).

## How?

- Reuses the Space Settings shell pattern; one shared `Wiki Settings` document resource, per-field `setValue` saves.
- GitHub secrets are `Password` fields that don't round-trip through the doc API, so a new whitelisted `get_app_config` returns **presence flags only** (never values) and `save_app_credentials` writes them write-only.
- Added a `Wiki Manager` read/write permission row on `Wiki Settings` to match the SPA admin gate.
- The one-click "Create GitHub App" manifest flow now returns to the SPA (`/wiki`) instead of the Desk.

Spec: `specs/frontend_global_wiki_settings.md`.

## Screenshots

**General**
![General](https://raw.githubusercontent.com/NagariaHussain/wiki/pr-assets-frontend-wiki-settings/settings-general.png?v=3)

**Feedback**
![Feedback](https://raw.githubusercontent.com/NagariaHussain/wiki/pr-assets-frontend-wiki-settings/settings-feedback.png?v=3)

**Header & Robots**
![Header and Robots](https://raw.githubusercontent.com/NagariaHussain/wiki/pr-assets-frontend-wiki-settings/settings-code.png?v=3)

**GitHub Sync**
![GitHub Sync](https://raw.githubusercontent.com/NagariaHussain/wiki/pr-assets-frontend-wiki-settings/settings-github.png?v=3)

## Tests

- **Unit:** `get_app_config` presence flags (no secret leakage), `save_app_credentials` write-only + permission gates, `Wiki Manager` perm row.
- **E2E:** open settings from the sidebar menu and the GitHub-return param; a General toggle round-trips to the backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
