### PR TITLE
fix(editor): broken link formatting on paste (#667)

### DIFF
--- a/frontend/src/components/WikiContentViewer.vue
+++ b/frontend/src/components/WikiContentViewer.vue
@@ -9,7 +9,6 @@ import { Extension } from '@tiptap/core';
 import { TaskItem, TaskList } from '@tiptap/extension-list';
 import { Table, TableCell, TableHeader, TableRow } from '@tiptap/extension-table';
 import { Markdown } from '@tiptap/markdown';
-import { StarterKit } from '@tiptap/starter-kit';
 import { Editor, EditorContent } from '@tiptap/vue-3';
 import { common, createLowlight } from 'lowlight';
 import { onBeforeUnmount, onMounted, ref, watch } from 'vue';
@@ -21,6 +20,7 @@ import { WikiImage } from './tiptap-extensions/image-extension.js';
 import { WikiLink } from './tiptap-extensions/link-extension.js';
 import { PdfBlock } from './tiptap-extensions/pdf-block.js';
 import { VideoBlock } from './tiptap-extensions/video-block.js';
+import { wikiStarterKit } from './tiptap-extensions/wiki-starterkit.js';
 
 // A read-only render of wiki markdown through the same TipTap extensions the
 // editor uses, so previews match what readers see — lowlight syntax
@@ -48,10 +48,7 @@ onMounted(() => {
 	editor.value = new Editor({
 		editable: false,
 		extensions: [
-			StarterKit.configure({
-				codeBlock: false, // WikiCodeBlock (lowlight) instead
-				link: false, // WikiLink instead
-			}),
+			wikiStarterKit(),
 			WikiLink.configure({
 				openOnClick: true,
 				HTMLAttributes: { rel: 'noopener noreferrer' },

--- a/frontend/src/components/WikiEditor.vue
+++ b/frontend/src/components/WikiEditor.vue
@@ -35,7 +35,6 @@ import {
 } from '@tiptap/extension-table';
 import { Placeholder } from '@tiptap/extensions';
 import { Markdown } from '@tiptap/markdown';
-import { StarterKit } from '@tiptap/starter-kit';
 import { Editor, EditorContent } from '@tiptap/vue-3';
 import { onKeyStroke } from '@vueuse/core';
 import { toast, useFileUpload } from 'frappe-ui';
@@ -59,6 +58,7 @@ import {
 	filterCommands,
 } from './tiptap-extensions/slash-commands.js';
 import { VideoBlock } from './tiptap-extensions/video-block.js';
+import { wikiStarterKit } from './tiptap-extensions/wiki-starterkit.js';
 
 // Import tippy for slash command popup
 import tippy from 'tippy.js';
@@ -581,11 +581,7 @@ function createSlashCommandsSuggestion() {
 function initEditor() {
 	editor.value = new Editor({
 		extensions: [
-			StarterKit.configure({
-				codeBlock: false, // We use CodeBlockLowlight instead
-				link: false, // We use our custom WikiLink
-				paragraph: false, // We use WikiParagraph for blank line support
-			}),
+			wikiStarterKit({ paragraph: false }),
 			WikiParagraph,
 			// Custom link extension with Cmd+K support
 			WikiLink.configure({

--- a/frontend/src/components/tiptap-extensions/IframeBlockView.vue
+++ b/frontend/src/components/tiptap-extensions/IframeBlockView.vue
@@ -14,7 +14,7 @@ import {
 	isAllowedIframeSrc,
 	matchProvider,
 	normalizeEmbedUrl,
-} from './iframe-block.js';
+} from './iframe-embed.js';
 
 const props = defineProps({
 	node: { type: Object, required: true },

--- a/frontend/src/components/tiptap-extensions/iframe-block.js
+++ b/frontend/src/components/tiptap-extensions/iframe-block.js
@@ -11,185 +11,26 @@
 import { Node, mergeAttributes, nodePasteRule } from '@tiptap/core';
 import { VueNodeViewRenderer } from '@tiptap/vue-3';
 import IframeBlockView from './IframeBlockView.vue';
+import {
+	EMBED_HTML_PASTE_RE_G,
+	EMBED_URL_PASTE_RE,
+	escapeAttr,
+	iframeAttrsFromHtml,
+	isAllowedIframeSrc,
+	normalizeEmbedUrl,
+	parseIframeAttrs,
+} from './iframe-embed.js';
 
-export const IFRAME_PROVIDERS = [
-	{
-		name: 'youtube',
-		hosts: ['youtube.com', 'youtube-nocookie.com', 'youtu.be'],
-	},
-	{ name: 'vimeo', hosts: ['vimeo.com', 'player.vimeo.com'] },
-	{ name: 'loom', hosts: ['loom.com'] },
-	{ name: 'codepen', hosts: ['codepen.io'] },
-	{ name: 'codesandbox', hosts: ['codesandbox.io'] },
-	{ name: 'figma', hosts: ['figma.com'] },
-	{ name: 'framer', hosts: ['framer.com'] },
-	{ name: 'miro', hosts: ['miro.com'] },
-	{ name: 'google', hosts: ['docs.google.com', 'drive.google.com'] },
-	{
-		name: 'cloudflare-stream',
-		hosts: ['cloudflarestream.com', 'videodelivery.net'],
-	},
-	{
-		name: 'bunny-stream',
-		hosts: ['mediadelivery.net', 'bunnycdn.com'],
-	},
-	{ name: 'aparat', hosts: ['aparat.com'] },
-	{ name: 'github-gist', hosts: ['gist.github.com'] },
-];
-
-function hostOf(url) {
-	try {
-		return new URL(url).hostname.toLowerCase();
-	} catch {
-		return null;
-	}
-}
-
-export function matchProvider(url) {
-	const host = hostOf(url);
-	if (!host) return null;
-	for (const provider of IFRAME_PROVIDERS) {
-		if (provider.hosts.some((h) => host === h || host.endsWith(`.${h}`))) {
-			return provider.name;
-		}
-	}
-	return null;
-}
-
-export function isAllowedIframeSrc(url) {
-	return matchProvider(url) !== null;
-}
-
-/**
- * Convert user-friendly URLs (watch pages, share links) into the provider's
- * embed URL. Pasting a plain youtube.com/watch?v=X should Just Work.
- */
-export function normalizeEmbedUrl(url) {
-	if (!url) return '';
-	const input = String(url).trim();
-	let u;
-	try {
-		u = new URL(input);
-	} catch {
-		return input;
-	}
-	const host = u.hostname.toLowerCase().replace(/^www\./, '');
-
-	if (host === 'youtube.com' || host === 'youtube-nocookie.com') {
-		if (u.pathname === '/watch' && u.searchParams.get('v')) {
-			return `https://www.youtube.com/embed/${u.searchParams.get('v')}`;
-		}
-		if (u.pathname.startsWith('/shorts/')) {
-			return `https://www.youtube.com/embed/${u.pathname.slice(
-				'/shorts/'.length,
-			)}`;
-		}
-		return input;
-	}
-	if (host === 'youtu.be') {
-		const id = u.pathname.slice(1);
-		return id ? `https://www.youtube.com/embed/${id}` : input;
-	}
-	if (host === 'vimeo.com') {
-		const id = u.pathname.match(/^\/(\d+)/)?.[1];
-		if (id) return `https://player.vimeo.com/video/${id}`;
-	}
-	if (host === 'loom.com' && u.pathname.startsWith('/share/')) {
-		return `https://www.loom.com/embed/${u.pathname.slice('/share/'.length)}`;
-	}
-
-	// Google Drive: /file/d/<id>/view[?…] → /file/d/<id>/preview
-	if (host === 'drive.google.com') {
-		const id = u.pathname.match(/^\/file\/d\/([A-Za-z0-9_-]+)/)?.[1];
-		if (id) return `https://drive.google.com/file/d/${id}/preview`;
-	}
-
-	// Google Docs / Sheets / Slides: /<kind>/d/<id>/edit|pub → /preview or /embed
-	if (host === 'docs.google.com') {
-		const m = u.pathname.match(
-			/^\/(document|spreadsheets|presentation)\/d\/([A-Za-z0-9_-]+)(\/(edit|pub|view))?/,
-		);
-		if (m) {
-			const kind = m[1];
-			const id = m[2];
-			const action = kind === 'presentation' ? 'embed' : 'preview';
-			return `https://docs.google.com/${kind}/d/${id}/${action}`;
-		}
-	}
-
-	// Cloudflare Stream: customer-*.cloudflarestream.com/<uid>/watch
-	if (host.endsWith('.cloudflarestream.com')) {
-		const id = u.pathname.match(/^\/([a-f0-9]{32})\/watch$/)?.[1];
-		if (id) return `https://iframe.videodelivery.net/${id}`;
-	}
-
-	// Bunny Stream share URLs → player.mediadelivery.net/embed
-	if (
-		host === 'iframe.mediadelivery.net' ||
-		host === 'video.bunnycdn.com' ||
-		host === 'player.mediadelivery.net'
-	) {
-		const match = u.pathname.match(/^\/play\/([A-Za-z0-9]+\/[A-Za-z0-9-]+)$/);
-		if (match) return `https://player.mediadelivery.net/embed/${match[1]}`;
-	}
-
-	// Aparat: /v/<hash> → /video/video/embed/videohash/<hash>/vt/frame
-	if (host === 'aparat.com') {
-		const id = u.pathname.match(/^\/v\/([^/?&]+)\/?$/)?.[1];
-		if (id) {
-			return `https://www.aparat.com/video/video/embed/videohash/${id}/vt/frame`;
-		}
-	}
-
-	return input;
-}
-
-/**
- * Regex matching a paste whose *entire content* is a URL on an allowlisted
- * host. Anchored to the full text so pasting a URL inline inside a sentence
- * doesn't trigger replacement — only paste-alone embeds.
- */
-const EMBED_HOSTS_RE = IFRAME_PROVIDERS.flatMap((p) => p.hosts)
-	.map((h) => h.replace(/\./g, '\\.'))
-	.join('|');
-const EMBED_URL_PASTE_RE = new RegExp(
-	`^\\s*(https?://(?:[\\w-]+\\.)*(?:${EMBED_HOSTS_RE})/\\S+)\\s*$`,
-);
-const EMBED_HTML_PASTE_RE = /^\s*<iframe\b([^>]*)>\s*(?:<\/iframe>)?\s*$/i;
-
-/**
- * Parse a raw <iframe …> tag string into the attrs shape iframeBlock stores.
- * Returns null if the src isn't on the allowlist.
- */
-export function iframeAttrsFromHtml(html) {
-	const match = EMBED_HTML_PASTE_RE.exec(html);
-	if (!match) return null;
-	const parsed = parseIframeAttrs(match[1]);
-	if (!isAllowedIframeSrc(parsed.src)) return null;
-	return {
-		src: parsed.src,
-		width: parsed.width || null,
-		height: parsed.height || null,
-		title: parsed.title || null,
-		allow: parsed.allow || null,
-		allowfullscreen: 'allowfullscreen' in parsed,
-		frameborder: parsed.frameborder || null,
-	};
-}
-
-function parseIframeAttrs(attrString) {
-	const attrs = {};
-	const re =
-		/([a-zA-Z_:][\w:.\-]*)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]*)))?/g;
-	for (const m of attrString.matchAll(re)) {
-		attrs[m[1].toLowerCase()] = m[2] ?? m[3] ?? m[4] ?? '';
-	}
-	return attrs;
-}
-
-function escapeAttr(value) {
-	return String(value).replace(/"/g, '&quot;');
-}
+// Pure embed-parsing helpers (providers, URL normalization, attr parsing) now
+// live in ./iframe-embed.js so they can be unit-tested without this Vue/TipTap
+// module. Re-export them for existing importers.
+export {
+	IFRAME_PROVIDERS,
+	iframeAttrsFromHtml,
+	isAllowedIframeSrc,
+	matchProvider,
+	normalizeEmbedUrl,
+} from './iframe-embed.js';
 
 export const IframeBlock = Node.create({
 	name: 'iframeBlock',
@@ -286,7 +127,7 @@ export const IframeBlock = Node.create({
 				},
 			}),
 			nodePasteRule({
-				find: EMBED_HTML_PASTE_RE,
+				find: EMBED_HTML_PASTE_RE_G,
 				type: this.type,
 				getAttributes: (match) => iframeAttrsFromHtml(match[0]) || false,
 			}),

--- a/frontend/src/components/tiptap-extensions/iframe-embed.js
+++ b/frontend/src/components/tiptap-extensions/iframe-embed.js
@@ -1,0 +1,203 @@
+/**
+ * Pure embed-parsing helpers for the iframe block.
+ *
+ * Split out from iframe-block.js so this logic stays free of the TipTap node
+ * and its Vue NodeView — keeping it importable from plain unit tests and
+ * breaking the iframe-block.js ⇄ IframeBlockView.vue import cycle.
+ *
+ * Only src URLs from IFRAME_PROVIDERS are accepted. Unknown hosts are dropped
+ * so arbitrary iframes can't be smuggled into wiki pages.
+ */
+
+export const IFRAME_PROVIDERS = [
+	{
+		name: 'youtube',
+		hosts: ['youtube.com', 'youtube-nocookie.com', 'youtu.be'],
+	},
+	{ name: 'vimeo', hosts: ['vimeo.com', 'player.vimeo.com'] },
+	{ name: 'loom', hosts: ['loom.com'] },
+	{ name: 'codepen', hosts: ['codepen.io'] },
+	{ name: 'codesandbox', hosts: ['codesandbox.io'] },
+	{ name: 'figma', hosts: ['figma.com'] },
+	{ name: 'framer', hosts: ['framer.com'] },
+	{ name: 'miro', hosts: ['miro.com'] },
+	{ name: 'google', hosts: ['docs.google.com', 'drive.google.com'] },
+	{
+		name: 'cloudflare-stream',
+		hosts: ['cloudflarestream.com', 'videodelivery.net'],
+	},
+	{
+		name: 'bunny-stream',
+		hosts: ['mediadelivery.net', 'bunnycdn.com'],
+	},
+	{ name: 'aparat', hosts: ['aparat.com'] },
+	{ name: 'github-gist', hosts: ['gist.github.com'] },
+];
+
+function hostOf(url) {
+	try {
+		return new URL(url).hostname.toLowerCase();
+	} catch {
+		return null;
+	}
+}
+
+export function matchProvider(url) {
+	const host = hostOf(url);
+	if (!host) return null;
+	for (const provider of IFRAME_PROVIDERS) {
+		if (provider.hosts.some((h) => host === h || host.endsWith(`.${h}`))) {
+			return provider.name;
+		}
+	}
+	return null;
+}
+
+export function isAllowedIframeSrc(url) {
+	return matchProvider(url) !== null;
+}
+
+/**
+ * Convert user-friendly URLs (watch pages, share links) into the provider's
+ * embed URL. Pasting a plain youtube.com/watch?v=X should Just Work.
+ */
+export function normalizeEmbedUrl(url) {
+	if (!url) return '';
+	const input = String(url).trim();
+	let u;
+	try {
+		u = new URL(input);
+	} catch {
+		return input;
+	}
+	const host = u.hostname.toLowerCase().replace(/^www\./, '');
+
+	if (host === 'youtube.com' || host === 'youtube-nocookie.com') {
+		if (u.pathname === '/watch' && u.searchParams.get('v')) {
+			return `https://www.youtube.com/embed/${u.searchParams.get('v')}`;
+		}
+		if (u.pathname.startsWith('/shorts/')) {
+			return `https://www.youtube.com/embed/${u.pathname.slice(
+				'/shorts/'.length,
+			)}`;
+		}
+		return input;
+	}
+	if (host === 'youtu.be') {
+		const id = u.pathname.slice(1);
+		return id ? `https://www.youtube.com/embed/${id}` : input;
+	}
+	if (host === 'vimeo.com') {
+		const id = u.pathname.match(/^\/(\d+)/)?.[1];
+		if (id) return `https://player.vimeo.com/video/${id}`;
+	}
+	if (host === 'loom.com' && u.pathname.startsWith('/share/')) {
+		return `https://www.loom.com/embed/${u.pathname.slice('/share/'.length)}`;
+	}
+
+	// Google Drive: /file/d/<id>/view[?…] → /file/d/<id>/preview
+	if (host === 'drive.google.com') {
+		const id = u.pathname.match(/^\/file\/d\/([A-Za-z0-9_-]+)/)?.[1];
+		if (id) return `https://drive.google.com/file/d/${id}/preview`;
+	}
+
+	// Google Docs / Sheets / Slides: /<kind>/d/<id>/edit|pub → /preview or /embed
+	if (host === 'docs.google.com') {
+		const m = u.pathname.match(
+			/^\/(document|spreadsheets|presentation)\/d\/([A-Za-z0-9_-]+)(\/(edit|pub|view))?/,
+		);
+		if (m) {
+			const kind = m[1];
+			const id = m[2];
+			const action = kind === 'presentation' ? 'embed' : 'preview';
+			return `https://docs.google.com/${kind}/d/${id}/${action}`;
+		}
+	}
+
+	// Cloudflare Stream: customer-*.cloudflarestream.com/<uid>/watch
+	if (host.endsWith('.cloudflarestream.com')) {
+		const id = u.pathname.match(/^\/([a-f0-9]{32})\/watch$/)?.[1];
+		if (id) return `https://iframe.videodelivery.net/${id}`;
+	}
+
+	// Bunny Stream share URLs → player.mediadelivery.net/embed
+	if (
+		host === 'iframe.mediadelivery.net' ||
+		host === 'video.bunnycdn.com' ||
+		host === 'player.mediadelivery.net'
+	) {
+		const match = u.pathname.match(/^\/play\/([A-Za-z0-9]+\/[A-Za-z0-9-]+)$/);
+		if (match) return `https://player.mediadelivery.net/embed/${match[1]}`;
+	}
+
+	// Aparat: /v/<hash> → /video/video/embed/videohash/<hash>/vt/frame
+	if (host === 'aparat.com') {
+		const id = u.pathname.match(/^\/v\/([^/?&]+)\/?$/)?.[1];
+		if (id) {
+			return `https://www.aparat.com/video/video/embed/videohash/${id}/vt/frame`;
+		}
+	}
+
+	return input;
+}
+
+const EMBED_HOSTS_RE = IFRAME_PROVIDERS.flatMap((p) => p.hosts)
+	.map((h) => h.replace(/\./g, '\\.'))
+	.join('|');
+
+/**
+ * Regex matching a paste whose *entire content* is a URL on an allowlisted
+ * host. Anchored to the full text so pasting a URL inline inside a sentence
+ * doesn't trigger replacement — only paste-alone embeds.
+ *
+ * TipTap's paste-rule engine feeds each `find` to String.prototype.matchAll(),
+ * which throws on a non-global RegExp — so paste-rule patterns MUST be global.
+ */
+export const EMBED_URL_PASTE_RE = new RegExp(
+	`^\\s*(https?://(?:[\\w-]+\\.)*(?:${EMBED_HOSTS_RE})/\\S+)\\s*$`,
+	'g',
+);
+
+// Non-global form drives the stateless .exec() in iframeAttrsFromHtml (a global
+// regex would carry lastIndex across calls); EMBED_HTML_PASTE_RE_G is its global
+// twin for the paste rule, which goes through matchAll.
+export const EMBED_HTML_PASTE_RE =
+	/^\s*<iframe\b([^>]*)>\s*(?:<\/iframe>)?\s*$/i;
+export const EMBED_HTML_PASTE_RE_G = new RegExp(
+	EMBED_HTML_PASTE_RE.source,
+	`${EMBED_HTML_PASTE_RE.flags}g`,
+);
+
+/**
+ * Parse a raw <iframe …> tag string into the attrs shape iframeBlock stores.
+ * Returns null if the src isn't on the allowlist.
+ */
+export function iframeAttrsFromHtml(html) {
+	const match = EMBED_HTML_PASTE_RE.exec(html);
+	if (!match) return null;
+	const parsed = parseIframeAttrs(match[1]);
+	if (!isAllowedIframeSrc(parsed.src)) return null;
+	return {
+		src: parsed.src,
+		width: parsed.width || null,
+		height: parsed.height || null,
+		title: parsed.title || null,
+		allow: parsed.allow || null,
+		allowfullscreen: 'allowfullscreen' in parsed,
+		frameborder: parsed.frameborder || null,
+	};
+}
+
+export function parseIframeAttrs(attrString) {
+	const attrs = {};
+	const re =
+		/([a-zA-Z_:][\w:.\-]*)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]*)))?/g;
+	for (const m of attrString.matchAll(re)) {
+		attrs[m[1].toLowerCase()] = m[2] ?? m[3] ?? m[4] ?? '';
+	}
+	return attrs;
+}
+
+export function escapeAttr(value) {
+	return String(value).replace(/"/g, '&quot;');
+}

--- a/frontend/src/components/tiptap-extensions/iframe-embed.test.js
+++ b/frontend/src/components/tiptap-extensions/iframe-embed.test.js
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+	EMBED_HTML_PASTE_RE_G,
+	EMBED_URL_PASTE_RE,
+	iframeAttrsFromHtml,
+	isAllowedIframeSrc,
+	normalizeEmbedUrl,
+} from './iframe-embed.js';
+
+// Regression: TipTap's paste-rule engine feeds each `find` to String.matchAll(),
+// which throws "called with a non-global RegExp argument" unless the regex is
+// global. Both paste-rule patterns must therefore carry the `g` flag, or every
+// paste into the editor blows up in appendTransaction. See issue #667.
+test('paste-rule regexes are global so matchAll() does not throw', () => {
+	for (const re of [EMBED_URL_PASTE_RE, EMBED_HTML_PASTE_RE_G]) {
+		assert.ok(re.global, `${re} must have the global flag`);
+		assert.doesNotThrow(() => [...'just some pasted text'.matchAll(re)]);
+	}
+});
+
+test('URL paste regex matches a paste that is only an allowlisted embed URL', () => {
+	const text = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+	const matches = [...text.matchAll(EMBED_URL_PASTE_RE)];
+	assert.equal(matches.length, 1);
+	assert.equal(matches[0][1], text);
+});
+
+test('URL paste regex ignores an embed URL sitting inside a sentence', () => {
+	const text = 'see https://www.youtube.com/watch?v=x for details';
+	assert.equal([...text.matchAll(EMBED_URL_PASTE_RE)].length, 0);
+});
+
+test('HTML paste regex extracts attrs from a self-contained <iframe>', () => {
+	const html =
+		'<iframe src="https://www.youtube.com/embed/abc" width="560"></iframe>';
+	const matches = [...html.matchAll(EMBED_HTML_PASTE_RE_G)];
+	assert.equal(matches.length, 1);
+	const attrs = iframeAttrsFromHtml(matches[0][0]);
+	assert.equal(attrs.src, 'https://www.youtube.com/embed/abc');
+	assert.equal(attrs.width, '560');
+});
+
+// iframeAttrsFromHtml uses a shared non-global regex via .exec(); guard against a
+// regression where it gains the `g` flag and starts carrying lastIndex between
+// calls (which would make every other call spuriously return null).
+test('iframeAttrsFromHtml is stateless across repeated calls', () => {
+	const html = '<iframe src="https://player.vimeo.com/video/1"></iframe>';
+	for (let i = 0; i < 3; i++) {
+		assert.equal(
+			iframeAttrsFromHtml(html).src,
+			'https://player.vimeo.com/video/1',
+		);
+	}
+});
+
+test('disallowed hosts are rejected on parse', () => {
+	assert.equal(isAllowedIframeSrc('https://evil.example.com/x'), false);
+	assert.equal(
+		iframeAttrsFromHtml('<iframe src="https://evil.example.com/x"></iframe>'),
+		null,
+	);
+});
+
+test('normalizeEmbedUrl upgrades a youtube watch URL to its embed URL', () => {
+	assert.equal(
+		normalizeEmbedUrl('https://www.youtube.com/watch?v=abc'),
+		'https://www.youtube.com/embed/abc',
+	);
+});

--- a/frontend/src/components/tiptap-extensions/link-markdown.test.js
+++ b/frontend/src/components/tiptap-extensions/link-markdown.test.js
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { MarkdownManager } from '@tiptap/markdown';
+import { StarterKit } from '@tiptap/starter-kit';
+
+import { WikiLink } from './link-extension.js';
+import { wikiStarterKit } from './wiki-starterkit.js';
+
+// A paragraph holding one link whose text also carries an underline mark — the
+// exact shape ProseMirror produces when you paste a hyperlink copied from another
+// source, since copied links arrive with `text-decoration: underline`.
+const LINKED_UNDERLINED_TEXT = {
+	type: 'doc',
+	content: [
+		{
+			type: 'paragraph',
+			content: [
+				{
+					type: 'text',
+					text: 'Frappe',
+					marks: [
+						{ type: 'link', attrs: { href: 'https://frappe.io' } },
+						{ type: 'underline' },
+					],
+				},
+			],
+		},
+	],
+};
+
+// Builds a markdown serializer from a StarterKit instance plus WikiLink — the
+// same extension set the editors feed TipTap — so this exercises the real
+// round-trip the editor performs on save, no DOM required.
+function serialize(starterKit) {
+	const baseExtensions = starterKit.config.addExtensions.call({
+		options: starterKit.options,
+		name: 'starterKit',
+	});
+	const manager = new MarkdownManager({
+		extensions: [...baseExtensions, WikiLink],
+		markedOptions: { breaks: true },
+	});
+	return manager.serialize(LINKED_UNDERLINED_TEXT);
+}
+
+// Pins the root cause: StarterKit's default Underline mark serializes to `++…++`,
+// which leaks onto pasted links as `++[text](url)++`. Documents *why* the shared
+// wikiStarterKit disables underline. See issue #667.
+test('default StarterKit corrupts a pasted underlined link with ++', () => {
+	assert.equal(
+		serialize(StarterKit.configure({ link: false })),
+		'++[Frappe](https://frappe.io)++',
+	);
+});
+
+// Regression: WikiEditor.vue and WikiContentViewer.vue both build their
+// StarterKit via wikiStarterKit(), which disables underline. The pasted link
+// must serialize cleanly through that exact config.
+test('wikiStarterKit serializes a pasted underlined link without ++', () => {
+	assert.equal(serialize(wikiStarterKit()), '[Frappe](https://frappe.io)');
+});

--- a/frontend/src/components/tiptap-extensions/wiki-starterkit.js
+++ b/frontend/src/components/tiptap-extensions/wiki-starterkit.js
@@ -1,0 +1,26 @@
+import { StarterKit } from '@tiptap/starter-kit';
+
+/**
+ * Shared StarterKit configuration for the wiki editor (WikiEditor.vue) and the
+ * read-only renderer (WikiContentViewer.vue), so the two never drift apart.
+ *
+ * Disabled marks/nodes:
+ * - codeBlock: replaced by WikiCodeBlock (lowlight syntax highlighting).
+ * - link: replaced by WikiLink (Cmd+K editor, markdown round-trip).
+ * - underline: wiki markdown has no underline, and StarterKit's Underline mark
+ *   serializes to `++…++`. Copied hyperlinks arrive with `text-decoration:
+ *   underline`, so without this the editor corrupts pasted links into
+ *   `++[text](url)++`. See issue #667.
+ *
+ * @param {Object} [opts]
+ * @param {boolean} [opts.paragraph=true] Pass false to disable StarterKit's
+ *   paragraph node (WikiEditor swaps in WikiParagraph for blank-line support).
+ */
+export function wikiStarterKit({ paragraph = true } = {}) {
+	return StarterKit.configure({
+		codeBlock: false,
+		link: false,
+		underline: false,
+		...(paragraph ? {} : { paragraph: false }),
+	});
+}


### PR DESCRIPTION
## Problem

Two bugs in the editor's paste path:

1. **#667 — pasted links corrupted with `++`.** Copying a hyperlink from another source and pasting it wrote `++[text](url)++` into the saved markdown. StarterKit v3 enables the `Underline` mark, whose markdown serializer wraps text in `++…++`; copied links arrive carrying `text-decoration: underline`, so an underline mark gets stacked on the link and serialization corrupts it.
2. **Every paste threw.** The iframe embed paste rules used non-global regexes. TipTap feeds each paste-rule `find` to `String.prototype.matchAll()`, which throws `called with a non-global RegExp argument` — so any paste blew up in `appendTransaction` and the iframe paste rules never worked.

## Solution

- Disable the `Underline` mark (wiki markdown has no underline). Extract the shared StarterKit config into `wikiStarterKit()` so the editor and the read-only viewer stay in sync.
- Add the `g` flag to both iframe paste-rule regexes. The HTML pattern keeps a non-global twin for its stateless `.exec()` path.
- Move the pure embed-parsing helpers into `iframe-embed.js` so they're unit-testable without the Vue NodeView (also breaks the `iframe-block.js ↔ IframeBlockView.vue` import cycle).

## Tests

- `link-markdown.test.js` — drives the real `@tiptap/markdown` serializer over a pasted underlined link: default StarterKit yields `++[text](url)++`, `wikiStarterKit()` yields clean `[text](url)`.
- `iframe-embed.test.js` — paste regexes are global / `matchAll` doesn't throw, `.exec()` path stays stateless, host allowlist holds.

Both verified by temp-reverting each fix. All frontend unit tests pass and `yarn build` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)