### PR TITLE
fix(editor): stop selection bubble menu overlapping the sticky toolbar

### DIFF
--- a/e2e/tests/bubble-menu.spec.ts
+++ b/e2e/tests/bubble-menu.spec.ts
@@ -1,0 +1,92 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Regression: the selection bubble menu must never render on top of the sticky
+ * editor toolbar. When the selected text sits on the first line (right under the
+ * toolbar) there is no room above it, so the menu has to flip below the selection
+ * instead of overlapping the toolbar. See WikiBubbleMenu.vue.
+ */
+test.describe('Editor bubble menu placement', () => {
+	async function createPageAndOpenEditor(
+		page: import('@playwright/test').Page,
+		pageTitle: string,
+	) {
+		await page.goto('/wiki');
+		await page.waitForLoadState('networkidle');
+
+		const spaceLink = page.locator('a[href*="/wiki/spaces/"]').first();
+		await expect(spaceLink).toBeVisible({ timeout: 5000 });
+		await spaceLink.click();
+		await page.waitForLoadState('networkidle');
+
+		const createFirstPage = page.locator(
+			'button:has-text("Create First Page")',
+		);
+		const newPageButton = page.locator('button[title="New Page"]');
+
+		if (await createFirstPage.isVisible({ timeout: 2000 }).catch(() => false)) {
+			await createFirstPage.click();
+		} else {
+			await newPageButton.click();
+		}
+
+		await page.getByLabel('Title').fill(pageTitle);
+		await page
+			.getByRole('dialog')
+			.getByRole('button', { name: 'Save' })
+			.click();
+		await page.waitForLoadState('networkidle');
+
+		await page.locator('aside').getByText(pageTitle, { exact: true }).click();
+
+		const editor = page.locator('.ProseMirror, [contenteditable="true"]');
+		await expect(editor).toBeVisible({ timeout: 10000 });
+		return editor;
+	}
+
+	test('bubble menu flips below a first-line selection instead of covering the toolbar', async ({
+		page,
+	}) => {
+		await createPageAndOpenEditor(page, `bubble-menu-${Date.now()}`);
+
+		// Put text on the very first line and select it — this sits directly under
+		// the sticky toolbar, the exact case that used to overlap.
+		const selected = await page.evaluate(() => {
+			type ChainStep = {
+				focus: () => ChainStep;
+				setContent: (html: string) => ChainStep;
+				setTextSelection: (range: { from: number; to: number }) => ChainStep;
+				run: () => boolean;
+			};
+			const editor = (
+				window as unknown as { wikiEditor?: { chain: () => ChainStep } }
+			).wikiEditor;
+			if (!editor) return false;
+			editor.chain().focus().setContent('<p>first line text</p>').run();
+			editor.chain().focus().setTextSelection({ from: 1, to: 11 }).run();
+			return true;
+		});
+		expect(selected).toBe(true);
+
+		const bubbleMenu = page.locator('.wiki-bubble-menu');
+		await expect(bubbleMenu).toBeVisible({ timeout: 5000 });
+
+		const menuBox = await bubbleMenu.boundingBox();
+		const toolbarBox = await page.locator('.wiki-toolbar').boundingBox();
+		const selectionBox = await page.evaluate(() => {
+			const r = window.getSelection()?.getRangeAt(0).getBoundingClientRect();
+			return r ? { top: r.top, bottom: r.bottom } : null;
+		});
+
+		if (!menuBox || !toolbarBox || !selectionBox) {
+			throw new Error('Missing layout boxes for bubble menu assertion');
+		}
+
+		// The menu must sit entirely below the toolbar (no vertical overlap)...
+		expect(menuBox.y).toBeGreaterThanOrEqual(
+			toolbarBox.y + toolbarBox.height - 1,
+		);
+		// ...and below the selection itself, since it flipped down.
+		expect(menuBox.y).toBeGreaterThanOrEqual(selectionBox.bottom - 1);
+	});
+});

--- a/frontend/src/components/WikiEditor.vue
+++ b/frontend/src/components/WikiEditor.vue
@@ -1,11 +1,12 @@
 <template>
     <div class="wiki-editor-container">
         <div v-if="editor">
-            <template v-if="!readonly">
-                <WikiToolbar :editor="editor" @uploadImage="handleImageUpload" />
-                <WikiBubbleMenu :editor="editor" />
-            </template>
+            <WikiToolbar v-if="!readonly" :editor="editor" @uploadImage="handleImageUpload" />
             <EditorContent :editor="editor" />
+            <!-- After EditorContent so the ProseMirror DOM is attached when the
+                 bubble menu mounts; it derives its flip boundary from the editor's
+                 scroll ancestor, which must be reachable at that point. -->
+            <WikiBubbleMenu v-if="!readonly" :editor="editor" />
         </div>
         <div v-else class="wiki-editor-loading">
             Loading editor...

--- a/frontend/src/components/tiptap-extensions/WikiBubbleMenu.vue
+++ b/frontend/src/components/tiptap-extensions/WikiBubbleMenu.vue
@@ -144,7 +144,9 @@ const TOOLBAR_HEIGHT = 56;
 const appendToBody = () => document.body;
 
 // Nearest scrollable ancestor of the editor. The sticky toolbar pins to the top
-// of this element, so it's the boundary Floating UI must measure against.
+// of this element, so it's the boundary Floating UI must measure against. Falls
+// back to <body> (a valid, always-connected boundary) when none is found, so the
+// resolved value caches once instead of re-walking the tree on every compute.
 function getScrollParent(node) {
 	let el = node?.parentElement;
 	while (el) {
@@ -152,12 +154,12 @@ function getScrollParent(node) {
 		if (overflowY === 'auto' || overflowY === 'scroll') return el;
 		el = el.parentElement;
 	}
-	return null;
+	return document.body;
 }
 
 // Resolve (and cache) the scroll ancestor lazily. The ProseMirror DOM isn't
-// attached when this component mounts, so resolving at setup time yields null —
-// instead we resolve on first position compute, by which point it's in the tree.
+// attached when this component mounts, so we resolve on first position compute
+// (a selection, always post-mount) by which point it's in the tree.
 let cachedBoundary = null;
 function resolveScrollBoundary() {
 	if (!cachedBoundary || !cachedBoundary.isConnected) {
@@ -178,18 +180,12 @@ const floatingOptions = {
 	strategy: 'fixed',
 	placement: 'top',
 	offset: 8,
-	flip: () => {
-		const boundary = resolveScrollBoundary();
-		return {
-			fallbackPlacements: ['bottom'],
-			padding: { top: TOOLBAR_HEIGHT, bottom: 8 },
-			...(boundary ? { boundary } : {}),
-		};
-	},
-	shift: () => {
-		const boundary = resolveScrollBoundary();
-		return { padding: 8, ...(boundary ? { boundary } : {}) };
-	},
+	flip: () => ({
+		fallbackPlacements: ['bottom'],
+		padding: { top: TOOLBAR_HEIGHT, bottom: 8 },
+		boundary: resolveScrollBoundary(),
+	}),
+	shift: () => ({ padding: 8, boundary: resolveScrollBoundary() }),
 };
 
 function shouldShowBubbleMenu({ editor, state }) {

--- a/frontend/src/components/tiptap-extensions/WikiBubbleMenu.vue
+++ b/frontend/src/components/tiptap-extensions/WikiBubbleMenu.vue
@@ -3,28 +3,8 @@
         v-if="editor"
         :editor="editor"
         :should-show="shouldShowBubbleMenu"
-        :tippy-options="{
-            duration: 100,
-            maxWidth: 'none',
-            zIndex: 50,
-            popperOptions: {
-                modifiers: [
-                    {
-                        name: 'preventOverflow',
-                        options: {
-                            boundary: 'viewport',
-                            padding: 8
-                        }
-                    },
-                    {
-                        name: 'flip',
-                        options: {
-                            fallbackPlacements: ['top', 'bottom', 'right']
-                        }
-                    }
-                ]
-            }
-        }"
+        :options="floatingOptions"
+        :append-to="appendToBody"
         class="wiki-bubble-menu"
     >
         <div class="bubble-menu-buttons">
@@ -157,6 +137,61 @@ const props = defineProps({
 
 const { isMobile } = useMobile();
 
+// Sticky toolbar height (WikiToolbar measures ~49px); pad a little above it so the
+// flip boundary clears the toolbar band with room to spare.
+const TOOLBAR_HEIGHT = 56;
+
+const appendToBody = () => document.body;
+
+// Nearest scrollable ancestor of the editor. The sticky toolbar pins to the top
+// of this element, so it's the boundary Floating UI must measure against.
+function getScrollParent(node) {
+	let el = node?.parentElement;
+	while (el) {
+		const overflowY = getComputedStyle(el).overflowY;
+		if (overflowY === 'auto' || overflowY === 'scroll') return el;
+		el = el.parentElement;
+	}
+	return null;
+}
+
+// Resolve (and cache) the scroll ancestor lazily. The ProseMirror DOM isn't
+// attached when this component mounts, so resolving at setup time yields null —
+// instead we resolve on first position compute, by which point it's in the tree.
+let cachedBoundary = null;
+function resolveScrollBoundary() {
+	if (!cachedBoundary || !cachedBoundary.isConnected) {
+		cachedBoundary = getScrollParent(props.editor?.view?.dom);
+	}
+	return cachedBoundary;
+}
+
+// This BubbleMenu is positioned by Floating UI (not tippy), so config goes through
+// `options`, not `tippy-options`. By default flip measures against the viewport,
+// which never sees the sticky toolbar — so a selection just under the toolbar
+// places the menu on top of it and never flips. We pin the flip/shift boundary to
+// the scroll container (whose top edge is the toolbar) and pad that top by the
+// toolbar's height, so such a selection overflows upward and flips the menu below.
+// flip/shift are Floating UI "derivable" options (functions) so the boundary is
+// resolved at compute time, not at mount.
+const floatingOptions = {
+	strategy: 'fixed',
+	placement: 'top',
+	offset: 8,
+	flip: () => {
+		const boundary = resolveScrollBoundary();
+		return {
+			fallbackPlacements: ['bottom'],
+			padding: { top: TOOLBAR_HEIGHT, bottom: 8 },
+			...(boundary ? { boundary } : {}),
+		};
+	},
+	shift: () => {
+		const boundary = resolveScrollBoundary();
+		return { padding: 8, ...(boundary ? { boundary } : {}) };
+	},
+};
+
 function shouldShowBubbleMenu({ editor, state }) {
 	// On a phone the bubble menu (13 buttons) overflows the screen and fights the
 	// OS text-selection toolbar. The sticky horizontally-scrolling toolbar plus
@@ -184,6 +219,8 @@ function toggleLink() {
 <style scoped>
 .wiki-bubble-menu {
     display: flex;
+    /* Appended to <body>, so it must clear the editor chrome and sidebar. */
+    z-index: 60;
 }
 
 .bubble-menu-buttons {


### PR DESCRIPTION
Closes #668 

<img width="1308" height="492" alt="image" src="https://github.com/user-attachments/assets/b7bab618-787a-45c4-ac9f-c793aa5d9b50" />



## Problem

When you select text on the **first line** of the editor, the selection bubble menu renders on top of the sticky formatting toolbar instead of next to the selection.

## Solution

The bubble menu (`@tiptap/vue-3/menus`) is positioned by **Floating UI**, not tippy — so the existing `tippy-options` block was dead config and never affected placement. The menu fell back to Floating UI defaults, whose `flip` boundary is the **viewport**, which never accounts for the sticky toolbar. A first-line selection therefore had "room above" and never flipped.

The fix:

- Use the real `options` prop instead of the ignored `tippy-options`.
- Pin the `flip`/`shift` boundary to the editor's scroll container (whose top edge is the toolbar), padded by the toolbar's height, so a selection under the toolbar overflows upward and flips **below** the selection.
- Resolve that boundary lazily via Floating UI derivable options (the ProseMirror DOM isn't attached at mount), move the menu after `EditorContent`, and append it to `<body>` for robust positioning.

Mid-document selections still show the menu above as before.

Adds an e2e regression test that fails on the old behaviour and passes with the fix.
