### PR TITLE
feat(editor): open a page by default when entering a space

### DIFF
--- a/e2e/tests/space-default-page.spec.ts
+++ b/e2e/tests/space-default-page.spec.ts
@@ -1,0 +1,106 @@
+import { expect, test } from '@playwright/test';
+import { updateDoc } from '../helpers/frappe';
+import {
+	type WikiDocument,
+	type WikiSpace,
+	cleanupWikiSpacesByRoute,
+	createTestWikiDocument,
+	createTestWikiSpace,
+} from '../helpers/wiki';
+
+/**
+ * Opening a space in the editor should never strand the user on the "Select a
+ * page" welcome screen: it auto-opens the first page, and on re-entry reopens
+ * whichever page the user last had open (persisted per-space in localStorage).
+ */
+test.describe('Space default page', () => {
+	const populatedRoute = `default-page-${Date.now()}`;
+	const emptyRoute = `default-page-empty-${Date.now()}`;
+	let space: WikiSpace;
+	let alpha: WikiDocument;
+	let beta: WikiDocument;
+	let emptySpace: WikiSpace;
+
+	test.beforeAll(async ({ request }) => {
+		// A space with two published pages, Alpha before Beta.
+		space = await createTestWikiSpace(request, {
+			route: populatedRoute,
+			is_published: true,
+		});
+		const rootGroup = await createTestWikiDocument(request, {
+			title: 'Root',
+			route: `${populatedRoute}/root`,
+			is_group: true,
+			is_published: true,
+		});
+		await updateDoc(request, 'Wiki Space', space.name, {
+			root_group: rootGroup.name,
+		});
+		alpha = await createTestWikiDocument(request, {
+			title: 'Alpha Page',
+			route: `${populatedRoute}/alpha`,
+			is_published: true,
+			parent_wiki_document: rootGroup.name,
+		});
+		beta = await createTestWikiDocument(request, {
+			title: 'Beta Page',
+			route: `${populatedRoute}/beta`,
+			is_published: true,
+			parent_wiki_document: rootGroup.name,
+		});
+
+		// A space with no pages, to exercise the empty-tree fallback.
+		emptySpace = await createTestWikiSpace(request, {
+			route: emptyRoute,
+			is_published: true,
+		});
+		const emptyRoot = await createTestWikiDocument(request, {
+			title: 'Root',
+			route: `${emptyRoute}/root`,
+			is_group: true,
+			is_published: true,
+		});
+		await updateDoc(request, 'Wiki Space', emptySpace.name, {
+			root_group: emptyRoot.name,
+		});
+	});
+
+	test.afterAll(async ({ request }) => {
+		await cleanupWikiSpacesByRoute(request, populatedRoute);
+		await cleanupWikiSpacesByRoute(request, emptyRoute);
+	});
+
+	test('auto-opens the first page, then reopens the last opened page', async ({
+		page,
+	}) => {
+		// Entering at the bare space route opens the first page (Alpha).
+		await page.goto(`/wiki/spaces/${space.name}`);
+		await page.waitForURL(`**/spaces/${space.name}/page/${alpha.name}`, {
+			timeout: 15000,
+		});
+
+		// Open Beta directly — this records it as the last opened page.
+		await page.goto(`/wiki/spaces/${space.name}/page/${beta.name}`);
+		await page.waitForLoadState('networkidle');
+
+		// Re-entering the bare space route now reopens Beta, not Alpha.
+		await page.goto(`/wiki/spaces/${space.name}`);
+		await page.waitForURL(`**/spaces/${space.name}/page/${beta.name}`, {
+			timeout: 15000,
+		});
+	});
+
+	test('stays on the welcome screen when the space has no pages', async ({
+		page,
+	}) => {
+		await page.goto(`/wiki/spaces/${emptySpace.name}`);
+		// Wait for the tree to resolve (sidebar reports it's empty), so any
+		// redirect would already have happened.
+		await expect(page.locator('aside >> text=No pages yet')).toBeVisible({
+			timeout: 15000,
+		});
+		// No page was opened — URL is still the bare space route.
+		await expect(page).toHaveURL(new RegExp(`/spaces/${emptySpace.name}$`));
+		await expect(page.locator('text=Select a page')).toBeVisible();
+	});
+});

--- a/e2e/tests/space-default-page.spec.ts
+++ b/e2e/tests/space-default-page.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { type APIRequestContext, expect, test } from '@playwright/test';
 import { updateDoc } from '../helpers/frappe';
 import {
 	type WikiDocument,
@@ -107,5 +107,106 @@ test.describe('Space default page', () => {
 		// No page was opened — URL is still the bare space route.
 		await expect(page).toHaveURL(new RegExp(`/spaces/${emptySpace.name}$`));
 		await expect(page.locator('text=Select a page')).toBeVisible();
+	});
+});
+
+/**
+ * Regression: switching between spaces *in-app* (without a full reload) must
+ * open the new space's page, never the previous space's. SpaceDetails is reused
+ * across /spaces/:spaceId and the draft store is a global singleton, so the
+ * previous space's tree lingers during the switch — auto-open used to navigate
+ * into that stale tree's page. The earlier tests miss this because they enter
+ * each space with a fresh page.goto().
+ */
+test.describe('Space default page — in-app space switch', () => {
+	const ts = Date.now();
+	const routeA = `switch-a-${ts}`;
+	const routeB = `switch-b-${ts}`;
+	const nameB = `Bravo Space ${ts}`;
+	let spaceA: WikiSpace;
+	let spaceB: WikiSpace;
+	let aFirst: WikiDocument;
+	let bFirst: WikiDocument;
+
+	async function buildSpace(
+		request: APIRequestContext,
+		route: string,
+		spaceName: string,
+		pagePrefix: string,
+	): Promise<{ space: WikiSpace; firstPage: WikiDocument }> {
+		const space = await createTestWikiSpace(request, {
+			route,
+			is_published: true,
+		});
+		await updateDoc(request, 'Wiki Space', space.name, {
+			space_name: spaceName,
+		});
+		const rootGroup = await createTestWikiDocument(request, {
+			title: `${pagePrefix} Root`,
+			route: `${route}/root`,
+			is_group: true,
+			is_published: true,
+		});
+		await updateDoc(request, 'Wiki Space', space.name, {
+			root_group: rootGroup.name,
+		});
+		const firstPage = await createTestWikiDocument(request, {
+			title: `${pagePrefix} One`,
+			route: `${route}/one`,
+			is_published: true,
+			parent_wiki_document: rootGroup.name,
+		});
+		await createTestWikiDocument(request, {
+			title: `${pagePrefix} Two`,
+			route: `${route}/two`,
+			is_published: true,
+			parent_wiki_document: rootGroup.name,
+		});
+		return { space, firstPage };
+	}
+
+	test.beforeAll(async ({ request }) => {
+		({ space: spaceA, firstPage: aFirst } = await buildSpace(
+			request,
+			routeA,
+			`Alpha Space ${ts}`,
+			'Alpha',
+		));
+		({ space: spaceB, firstPage: bFirst } = await buildSpace(
+			request,
+			routeB,
+			nameB,
+			'Bravo',
+		));
+	});
+
+	test.afterAll(async ({ request }) => {
+		await cleanupWikiSpacesByRoute(request, routeA);
+		await cleanupWikiSpacesByRoute(request, routeB);
+	});
+
+	test('opens the switched-to space page, not the previous space page', async ({
+		page,
+	}) => {
+		// Enter space A — it auto-opens A's first page and hydrates the singleton
+		// draft store for A.
+		await page.goto(`/wiki/spaces/${spaceA.name}`);
+		await page.waitForURL(`**/spaces/${spaceA.name}/page/${aFirst.name}`, {
+			timeout: 15000,
+		});
+
+		// Switch to space B entirely in-app: back to the list, then into B. No
+		// full reload, so the store still holds A's tree at the moment B mounts.
+		await page.getByText('Back to Spaces').click();
+		await page.waitForURL(/\/spaces$/, { timeout: 15000 });
+		// Target the row by its href (router-link) — robust to how the row text
+		// is rendered — and click it for a client-side nav into B.
+		await page.locator(`a[href="/wiki/spaces/${spaceB.name}"]`).first().click();
+
+		// B must open *B's* first page — not A's page from the stale tree.
+		await page.waitForURL(`**/spaces/${spaceB.name}/page/${bFirst.name}`, {
+			timeout: 15000,
+		});
+		expect(page.url()).not.toContain(`/page/${aFirst.name}`);
 	});
 });

--- a/e2e/tests/space-default-page.spec.ts
+++ b/e2e/tests/space-default-page.spec.ts
@@ -79,9 +79,14 @@ test.describe('Space default page', () => {
 			timeout: 15000,
 		});
 
-		// Open Beta directly — this records it as the last opened page.
+		// Open Beta directly — this records it as the last opened page. Wait on
+		// the rendered title (the page-title input) rather than networkidle: it's
+		// the "page mounted" signal the persist watcher rides on, and avoids
+		// networkidle's flaky 500ms-quiet wait on slow CI.
 		await page.goto(`/wiki/spaces/${space.name}/page/${beta.name}`);
-		await page.waitForLoadState('networkidle');
+		await expect(page.getByPlaceholder('Page title')).toHaveValue('Beta Page', {
+			timeout: 15000,
+		});
 
 		// Re-entering the bare space route now reopens Beta, not Alpha.
 		await page.goto(`/wiki/spaces/${space.name}`);

--- a/frontend/src/pages/SpaceDetails.vue
+++ b/frontend/src/pages/SpaceDetails.vue
@@ -513,8 +513,12 @@ function getFirstPage(nodes) {
 // On the bare space route (welcome screen) open a page automatically: the
 // remembered page if it still exists, otherwise the tree's first page. Replace
 // rather than push so the back button returns to the spaces list, not here.
+// `autoOpening` guards the async gap before route.name flips to 'SpacePage':
+// without it, a treeData update mid-navigation (e.g. a git-synced background
+// sync) could fire a second replace and override the in-flight one.
+let autoOpening = false;
 function autoOpenPage() {
-	if (route.name !== 'SpaceDetails') return;
+	if (autoOpening || route.name !== 'SpaceDetails') return;
 	const tree = treeData.value;
 	if (!tree) return;
 
@@ -525,10 +529,15 @@ function autoOpenPage() {
 			: null) || getFirstPage(tree.children);
 
 	if (target) {
-		router.replace({
-			name: 'SpacePage',
-			params: { spaceId: props.spaceId, pageId: target },
-		});
+		autoOpening = true;
+		router
+			.replace({
+				name: 'SpacePage',
+				params: { spaceId: props.spaceId, pageId: target },
+			})
+			.finally(() => {
+				autoOpening = false;
+			});
 	}
 }
 

--- a/frontend/src/pages/SpaceDetails.vue
+++ b/frontend/src/pages/SpaceDetails.vue
@@ -210,6 +210,7 @@ import {
 	createResource,
 	toast,
 } from 'frappe-ui';
+import { useStorage } from '@vueuse/core';
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import LucideGithub from '~icons/lucide/github';
@@ -469,6 +470,71 @@ const treeData = computed(() => {
 	if (isGitSynced.value) return readonlyTreeData.value;
 	return draftStore.hasLoadedTree ? draftStore.treeAsLegacy : null;
 });
+
+// Remember the last page opened in this space (per-space, like the tree's
+// expanded-nodes state) so re-entering the space reopens it instead of the
+// "Select a page" welcome screen. We track saved pages only (document_name);
+// unsaved drafts fall back to the first page.
+const lastOpenedPageKey = computed(() => `wiki-last-page-${props.spaceId}`);
+const lastOpenedPage = useStorage(lastOpenedPageKey, null);
+
+// `immediate` so a direct load onto a page URL (e.g. a bookmark) is remembered
+// too, not only in-app navigations that change `currentPageId`.
+watch(
+	currentPageId,
+	(pageId) => {
+		if (pageId) lastOpenedPage.value = pageId;
+	},
+	{ immediate: true },
+);
+
+function findNodeByDocumentName(nodes, name) {
+	if (!nodes) return null;
+	for (const node of nodes) {
+		if (node.document_name === name) return node;
+		const found = findNodeByDocumentName(node.children, name);
+		if (found) return found;
+	}
+	return null;
+}
+
+function getFirstPage(nodes) {
+	if (!nodes) return null;
+	for (const node of nodes) {
+		if (!node.is_group && node.document_name) return node.document_name;
+		if (node.is_group) {
+			const found = getFirstPage(node.children);
+			if (found) return found;
+		}
+	}
+	return null;
+}
+
+// On the bare space route (welcome screen) open a page automatically: the
+// remembered page if it still exists, otherwise the tree's first page. Replace
+// rather than push so the back button returns to the spaces list, not here.
+function autoOpenPage() {
+	if (route.name !== 'SpaceDetails') return;
+	const tree = treeData.value;
+	if (!tree) return;
+
+	const remembered = lastOpenedPage.value;
+	const target =
+		(remembered && findNodeByDocumentName(tree.children, remembered)
+			? remembered
+			: null) || getFirstPage(tree.children);
+
+	if (target) {
+		router.replace({
+			name: 'SpacePage',
+			params: { spaceId: props.spaceId, pageId: target },
+		});
+	}
+}
+
+// treeData hydrates asynchronously (CR hydrate or readonly fetch), so refire
+// as it — and the route — settle.
+watch([treeData, () => route.name], autoOpenPage, { immediate: true });
 
 const changeTypeMap = computed(() => {
 	const map = new Map();

--- a/frontend/src/pages/SpaceDetails.vue
+++ b/frontend/src/pages/SpaceDetails.vue
@@ -210,7 +210,6 @@ import {
 	createResource,
 	toast,
 } from 'frappe-ui';
-import { useStorage } from '@vueuse/core';
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import LucideGithub from '~icons/lucide/github';
@@ -320,6 +319,12 @@ const readonlyTreeResource = createResource({
 	url: 'wiki.api.wiki_space.get_wiki_tree',
 });
 
+// The space the loaded readonly tree belongs to. This component is reused across
+// spaces (the router keeps one SpaceDetails for /spaces/:spaceId), so the
+// resource holds the previous space's tree until the new one loads — track the
+// owner so `treeData` can reject a stale cross-space tree.
+const readonlyTreeSpaceId = ref(null);
+
 // Adapt get_wiki_tree's (name-keyed) shape into the snake_case shape the tree
 // components consume. The Wiki Document `name` doubles as both the navigation
 // target (document_name) and the row key (doc_key) here — synced trees have no
@@ -352,7 +357,9 @@ const syncing = ref(false);
 // while space.doc re-renders before last_sync_status lands.
 const firstSyncKicked = ref(false);
 async function loadReadonlyTree() {
-	await readonlyTreeResource.submit({ space_id: props.spaceId });
+	const target = props.spaceId;
+	await readonlyTreeResource.submit({ space_id: target });
+	readonlyTreeSpaceId.value = target;
 }
 
 // Cancels an in-flight poll when the user navigates away mid-sync.
@@ -467,23 +474,36 @@ async function cloneSpace(close) {
 // `hasLoadedTree` — otherwise the sidebar flashes "No pages yet" instead of
 // the loading skeleton while the tree is being fetched.
 const treeData = computed(() => {
-	if (isGitSynced.value) return readonlyTreeData.value;
+	// Both sources outlive a space switch: the readonly resource keeps the old
+	// space's tree until the new fetch lands, and draftStore is a global
+	// singleton still hydrated for the previous space. Returning a stale tree
+	// here makes auto-open navigate into the wrong space's page, so gate each on
+	// belonging to the current space.
+	if (isGitSynced.value) {
+		return readonlyTreeSpaceId.value === props.spaceId
+			? readonlyTreeData.value
+			: null;
+	}
+	if (draftStore.spaceId !== props.spaceId) return null;
 	return draftStore.hasLoadedTree ? draftStore.treeAsLegacy : null;
 });
 
 // Remember the last page opened in this space (per-space, like the tree's
 // expanded-nodes state) so re-entering the space reopens it instead of the
 // "Select a page" welcome screen. We track saved pages only (document_name);
-// unsaved drafts fall back to the first page.
-const lastOpenedPageKey = computed(() => `wiki-last-page-${props.spaceId}`);
-const lastOpenedPage = useStorage(lastOpenedPageKey, null);
+// unsaved drafts fall back to the first page. Read/write localStorage directly
+// keyed on the *live* spaceId — a reactive useStorage key can write the old
+// space's value into the new space's key during a switch.
+function lastPageKey() {
+	return `wiki-last-page-${props.spaceId}`;
+}
 
 // `immediate` so a direct load onto a page URL (e.g. a bookmark) is remembered
 // too, not only in-app navigations that change `currentPageId`.
 watch(
 	currentPageId,
 	(pageId) => {
-		if (pageId) lastOpenedPage.value = pageId;
+		if (pageId) localStorage.setItem(lastPageKey(), pageId);
 	},
 	{ immediate: true },
 );
@@ -522,7 +542,7 @@ function autoOpenPage() {
 	const tree = treeData.value;
 	if (!tree) return;
 
-	const remembered = lastOpenedPage.value;
+	const remembered = localStorage.getItem(lastPageKey());
 	const target =
 		(remembered && findNodeByDocumentName(tree.children, remembered)
 			? remembered


### PR DESCRIPTION
## Problem

Opening a space in the editor landed on the "Select a page" welcome screen — no page opened by default, so every visit needed an extra click.

## Solution

Entering a space now auto-opens a page:

- **Last opened page** for that space, if it still exists (persisted per-space in `localStorage`, like the tree's expanded-nodes state).
- Otherwise the **first page** of the tree.
- Empty spaces (and git-synced spaces mid first-sync) still show the welcome / empty state.

Navigation uses `router.replace`, so Back returns to the spaces list rather than the welcome screen. Applies to both editable and git-synced spaces.

All changes are in `frontend/src/pages/SpaceDetails.vue`. Added an e2e spec covering first-page auto-open, last-page recall, and the empty-space fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011h9ezEYiUGapUihBT5VWmX