### PR TITLE
fix: detect metadata-only edits as revision changes

### DIFF
--- a/wiki/frappe_wiki/doctype/wiki_change_request/test_wiki_change_request.py
+++ b/wiki/frappe_wiki/doctype/wiki_change_request/test_wiki_change_request.py
@@ -19,6 +19,7 @@ from wiki.frappe_wiki.doctype.wiki_change_request.wiki_change_request import (
 	get_cr_tree,
 	get_merge_conflicts,
 	get_or_create_draft_change_request,
+	has_revision_changes,
 	list_change_requests,
 	merge_change_request,
 	merge_content_three_way,
@@ -387,6 +388,37 @@ class TestWikiChangeRequest(FrappeTestCase):
 
 		with self.assertRaises(frappe.ValidationError):
 			submit_change_request(cr.name)
+
+	def test_title_only_change_is_submittable_and_merges(self):
+		"""A title-only rename must count as a change (frappe/wiki#681)."""
+		space = create_test_wiki_space()
+		page = create_test_wiki_document(space.root_group, title="Old Title")
+		cr = create_change_request(space.name, "CR title only")
+
+		page_key = frappe.get_value("Wiki Document", page.name, "doc_key")
+		update_cr_page(cr.name, page_key, {"title": "New Title"})
+
+		self.assertTrue(has_revision_changes(cr.base_revision, cr.head_revision))
+		changes = diff_change_request(cr.name)
+		self.assertEqual([c["doc_key"] for c in changes], [page_key])
+
+		submit_change_request(cr.name)
+		approve_change_request(cr.name)
+		merge_change_request(cr.name)
+
+		self.assertEqual(frappe.db.get_value("Wiki Document", page.name, "title"), "New Title")
+
+	def test_metadata_only_changes_are_detected(self):
+		"""is_published / external_url edits alone must register as changes."""
+		space = create_test_wiki_space()
+		page = create_test_wiki_document(space.root_group, title="Page A")
+		page_key = frappe.get_value("Wiki Document", page.name, "doc_key")
+
+		cr = create_change_request(space.name, "CR unpublish only")
+		update_cr_page(cr.name, page_key, {"is_published": 0})
+
+		self.assertTrue(has_revision_changes(cr.base_revision, cr.head_revision))
+		self.assertEqual([c["doc_key"] for c in diff_change_request(cr.name)], [page_key])
 
 	def test_approve_then_merge_self_serve(self):
 		space = create_test_wiki_space()

--- a/wiki/frappe_wiki/doctype/wiki_change_request/wiki_change_request.py
+++ b/wiki/frappe_wiki/doctype/wiki_change_request/wiki_change_request.py
@@ -1190,7 +1190,16 @@ def diff_change_request(name: str, scope: str = "summary", doc_key: str | None =
 			continue
 		if base != head:
 			change_type = "modified"
-			metadata_fields = ["title", "slug", "route", "is_group", "is_published", "parent_key"]
+			metadata_fields = [
+				"title",
+				"slug",
+				"route",
+				"is_group",
+				"is_published",
+				"parent_key",
+				"is_external_link",
+				"external_url",
+			]
 			metadata_changed = any(base.get(field) != head.get(field) for field in metadata_fields)
 			content_changed = base.get("content_hash") != head.get("content_hash")
 			if base.get("content_hash") is None and head.get("content_hash") is None:

--- a/wiki/frappe_wiki/doctype/wiki_revision/patches/mark_hashes_stale_for_metadata_hashing.py
+++ b/wiki/frappe_wiki/doctype/wiki_revision/patches/mark_hashes_stale_for_metadata_hashing.py
@@ -1,0 +1,14 @@
+"""Mark all revision hashes stale after the hash formula change.
+
+The tree hash now covers item metadata (title, route, is_group, is_published,
+is_external_link, external_url) so metadata-only edits are detected as changes
+(frappe/wiki#681). Stored hashes were computed with the old formula; comparing
+an old-formula hash against a new-formula one would report phantom changes, so
+every revision is flagged for lazy recomputation.
+"""
+
+import frappe
+
+
+def execute():
+	frappe.db.sql("UPDATE `tabWiki Revision` SET hashes_stale = 1")

--- a/wiki/frappe_wiki/doctype/wiki_revision/patches/mark_hashes_stale_for_metadata_hashing.py
+++ b/wiki/frappe_wiki/doctype/wiki_revision/patches/mark_hashes_stale_for_metadata_hashing.py
@@ -8,7 +8,9 @@ every revision is flagged for lazy recomputation.
 """
 
 import frappe
+from frappe.query_builder import DocType
 
 
 def execute():
-	frappe.db.sql("UPDATE `tabWiki Revision` SET hashes_stale = 1")
+	WikiRevision = DocType("Wiki Revision")
+	frappe.qb.update(WikiRevision).set(WikiRevision.hashes_stale, 1).run()

--- a/wiki/frappe_wiki/doctype/wiki_revision/wiki_revision.py
+++ b/wiki/frappe_wiki/doctype/wiki_revision/wiki_revision.py
@@ -212,7 +212,20 @@ def recompute_revision_hashes(revision: str) -> None:
 	else:
 		items = frappe.get_all(
 			"Wiki Revision Item",
-			fields=["doc_key", "parent_key", "order_index", "slug", "content_blob", "is_deleted"],
+			fields=[
+				"doc_key",
+				"parent_key",
+				"order_index",
+				"slug",
+				"title",
+				"route",
+				"is_group",
+				"is_published",
+				"is_external_link",
+				"external_url",
+				"content_blob",
+				"is_deleted",
+			],
 			filters={"revision": revision},
 		)
 		blob_names = {item["content_blob"] for item in items if item.get("content_blob")}
@@ -239,6 +252,12 @@ def recompute_revision_hashes(revision: str) -> None:
 					item.get("parent_key") or "",
 					str(item.get("order_index") or 0),
 					item.get("slug") or "",
+					item.get("title") or "",
+					item.get("route") or "",
+					str(int(item.get("is_group") or 0)),
+					str(int(item.get("is_published") or 0)),
+					str(int(item.get("is_external_link") or 0)),
+					item.get("external_url") or "",
 				]
 			)
 		)
@@ -252,9 +271,8 @@ def recompute_revision_hashes(revision: str) -> None:
 		"tree_hash": tree_hash,
 		"content_hash": content_hash,
 		"doc_count": len([item for item in items if not item.get("is_deleted")]),
+		"hashes_stale": 0,
 	}
-	if is_overlay:
-		update_fields["hashes_stale"] = 0
 
 	frappe.db.set_value("Wiki Revision", revision, update_fields)
 

--- a/wiki/patches.txt
+++ b/wiki/patches.txt
@@ -21,3 +21,4 @@ wiki.wiki.doctype.wiki_space.patches.backfill_space_access
 wiki.wiki.doctype.wiki_space.patches.seed_space_roles_from_published
 wiki.frappe_wiki.doctype.wiki_change_request.patches.drop_reviewer_participant_tables
 wiki.wiki.doctype.wiki_space.patches.set_allow_contributions_default
+wiki.frappe_wiki.doctype.wiki_revision.patches.mark_hashes_stale_for_metadata_hashing


### PR DESCRIPTION
## Problem

A title-only rename (or any metadata-only edit like unpublishing a page) showed up in the review UI, but merging failed with "There are no changes to submit for review". The revision tree hash only covered `doc_key`, `parent_key`, `order_index` and `slug`, so `has_revision_changes` couldn't see the change.

Fixes #681

## Solution

- Include `title`, `route`, `is_group`, `is_published`, `is_external_link` and `external_url` in the tree hash.
- Add the external-link fields to the diff's metadata comparison so both checks agree.
- Patch marks existing revision hashes stale so old-formula hashes are never compared against new-formula ones (lazy recompute). Recompute now clears the stale flag for non-overlay revisions too, so patched revisions don't recompute on every check.
- Regression tests for title-only and metadata-only changes (verified fail-before / pass-after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)