### PR TITLE
fix(reader): reveal current page in sidebar on load and navigation

### DIFF
--- a/e2e/tests/sidebar-reveal.spec.ts
+++ b/e2e/tests/sidebar-reveal.spec.ts
@@ -1,0 +1,128 @@
+import { expect, test } from '@playwright/test';
+import { updateDoc } from '../helpers/frappe';
+import {
+	type WikiDocument,
+	type WikiSpace,
+	cleanupWikiSpacesByRoute,
+	createTestWikiDocument,
+	createTestWikiSpace,
+} from '../helpers/wiki';
+
+/**
+ * The reader sidebar must always reveal the current page: expand its ancestor
+ * groups, highlight it, and scroll it into view — both on a direct page load
+ * (shared link / search result) and after client-side navigation via the
+ * prev/next buttons (see issue #685).
+ */
+test.describe('Reader sidebar reveals current page', () => {
+	const spaceRoute = `sidebar-reveal-${Date.now()}`;
+	let space: WikiSpace;
+	let topPage: WikiDocument;
+	let deepPage: WikiDocument;
+	let lastFiller: WikiDocument;
+
+	const FILLER_COUNT = 30;
+
+	test.beforeAll(async ({ request }) => {
+		space = await createTestWikiSpace(request, {
+			route: spaceRoute,
+			is_published: true,
+		});
+		const rootGroup = await createTestWikiDocument(request, {
+			title: 'Root',
+			route: `${spaceRoute}/root`,
+			is_group: true,
+			is_published: true,
+		});
+		await updateDoc(request, 'Wiki Space', space.name, {
+			root_group: rootGroup.name,
+		});
+
+		topPage = await createTestWikiDocument(request, {
+			title: 'Top Page',
+			route: `${spaceRoute}/top`,
+			is_published: true,
+			parent_wiki_document: rootGroup.name,
+		});
+
+		// Group > Sub Group > Deep Page — two collapsed levels above the page
+		const group = await createTestWikiDocument(request, {
+			title: 'Outer Group',
+			route: `${spaceRoute}/outer`,
+			is_group: true,
+			is_published: true,
+			parent_wiki_document: rootGroup.name,
+		});
+		const subGroup = await createTestWikiDocument(request, {
+			title: 'Inner Group',
+			route: `${spaceRoute}/outer/inner`,
+			is_group: true,
+			is_published: true,
+			parent_wiki_document: group.name,
+		});
+		deepPage = await createTestWikiDocument(request, {
+			title: 'Deep Page',
+			route: `${spaceRoute}/outer/inner/deep`,
+			is_published: true,
+			parent_wiki_document: subGroup.name,
+		});
+
+		// Enough siblings after the deep page to overflow the sidebar viewport
+		for (let i = 0; i < FILLER_COUNT; i++) {
+			lastFiller = await createTestWikiDocument(request, {
+				title: `Filler Page ${String(i).padStart(2, '0')}`,
+				route: `${spaceRoute}/filler-${String(i).padStart(2, '0')}`,
+				is_published: true,
+				parent_wiki_document: rootGroup.name,
+			});
+		}
+	});
+
+	test.afterAll(async ({ request }) => {
+		await cleanupWikiSpacesByRoute(request, spaceRoute);
+	});
+
+	function sidebarLink(page: import('@playwright/test').Page, route: string) {
+		return page.locator(`.wiki-sidebar a[data-route="${route}"]`);
+	}
+
+	test('direct load expands ancestor groups and highlights the page', async ({
+		page,
+	}) => {
+		await page.goto(`/${deepPage.route}`);
+		await page.waitForLoadState('networkidle');
+
+		const link = sidebarLink(page, deepPage.route);
+		await expect(link).toBeVisible();
+		await expect(link).toHaveAttribute('aria-current', 'page');
+	});
+
+	test('direct load scrolls a far-down page into view', async ({ page }) => {
+		await page.goto(`/${lastFiller.route}`);
+		await page.waitForLoadState('networkidle');
+
+		const link = sidebarLink(page, lastFiller.route);
+		// scrollIntoView runs 300ms after the expand transition
+		await expect(link).toBeInViewport({ timeout: 5000 });
+		await expect(link).toHaveAttribute('aria-current', 'page');
+	});
+
+	test('client-side prev/next navigation reveals the new page', async ({
+		page,
+	}) => {
+		await page.goto(`/${topPage.route}`);
+		await page.waitForLoadState('networkidle');
+
+		// Deep page is hidden inside two collapsed groups
+		await expect(sidebarLink(page, deepPage.route)).toBeHidden();
+
+		// "Next Page" goes to the deep page (adjacent in the flattened tree)
+		await page.locator('#wiki-nav-buttons a', { hasText: 'Next Page' }).click();
+		await page.waitForURL(`**/${deepPage.route}`);
+
+		const link = sidebarLink(page, deepPage.route);
+		await expect(link).toBeVisible();
+		await expect(link).toHaveAttribute('aria-current', 'page');
+		await expect(link).toBeInViewport({ timeout: 5000 });
+	});
+});

--- a/wiki/templates/wiki/includes/mobile_header.html
+++ b/wiki/templates/wiki/includes/mobile_header.html
@@ -230,6 +230,12 @@
                 // Auto-expand parents of current page
                 this.expandCurrentPageParents();
 
+                // Keep the tree in sync when navigation happens client-side
+                this.$watch('$store.navigation.currentRoute', (route) => {
+                    this.currentRoute = route;
+                    this.expandCurrentPageParents();
+                });
+
                 // Add global event listeners for drag
                 document.addEventListener('mousemove', this.onDrag.bind(this));
                 document.addEventListener('mouseup', this.endDrag.bind(this));
@@ -265,6 +271,13 @@
             toggleSidebar() {
                 this.sidebarOpen = !this.sidebarOpen;
                 document.body.style.overflow = this.sidebarOpen ? 'hidden' : '';
+                if (this.sidebarOpen) {
+                    // Drawer content is only measurable once it is visible
+                    this.$nextTick(() => {
+                        const el = this.$root.querySelector(`[data-route="${this.currentRoute}"]`);
+                        el?.scrollIntoView({ block: 'nearest' });
+                    });
+                }
             },
 
             closeSidebar() {
@@ -332,7 +345,8 @@
                 if (!this.currentRoute) return;
 
                 this.$nextTick(() => {
-                    const currentPageElement = document.querySelector(`[data-route="${this.currentRoute}"]`);
+                    // Scoped to $root so we don't match the desktop sidebar's copy of the tree
+                    const currentPageElement = this.$root.querySelector(`[data-route="${this.currentRoute}"]`);
                     if (!currentPageElement) return;
 
                     let parentElement = currentPageElement.parentElement;

--- a/wiki/templates/wiki/includes/mobile_header.html
+++ b/wiki/templates/wiki/includes/mobile_header.html
@@ -350,7 +350,7 @@
                     if (!currentPageElement) return;
 
                     let parentElement = currentPageElement.parentElement;
-                    while (parentElement) {
+                    while (parentElement && parentElement !== this.$root) {
                         if (parentElement.classList.contains('wiki-children')) {
                             const parentItem = parentElement.parentElement;
                             if (parentItem) {

--- a/wiki/templates/wiki/includes/sidebar.html
+++ b/wiki/templates/wiki/includes/sidebar.html
@@ -405,24 +405,44 @@
                     const currentPageElement = this.$root.querySelector(`[data-route="${route}"]`);
                     if (!currentPageElement) return;
 
+                    // Containers whose x-collapse expansion this call triggers
+                    const expandingContainers = [];
                     let parentElement = currentPageElement.parentElement;
                     while (parentElement && parentElement !== this.$root) {
                         if (parentElement.classList.contains('wiki-children')) {
                             const parentItem = parentElement.parentElement;
                             const parentContent = parentItem?.querySelector('.wiki-item-content[data-node-id]');
                             const nodeId = parentContent?.getAttribute('data-node-id');
-                            if (nodeId) {
+                            if (nodeId && !this.expandedStates[nodeId]) {
                                 this.expandedStates[nodeId] = true;
+                                expandingContainers.push(parentElement);
                             }
                         }
                         parentElement = parentElement.parentElement;
                     }
 
-                    // Wait for the x-collapse expand transition (250ms) to finish
-                    // so the scroll position is measured against the final layout
-                    setTimeout(() => {
+                    const scrollToCurrentPage = () =>
                         currentPageElement.scrollIntoView({ block: 'nearest' });
-                    }, 300);
+
+                    if (!expandingContainers.length) {
+                        scrollToCurrentPage();
+                        return;
+                    }
+
+                    // Scroll only once the x-collapse height transition has
+                    // settled, so the position is measured against the final
+                    // layout. The timer is a fallback for when no transition
+                    // fires at all (e.g. prefers-reduced-motion).
+                    const outermost = expandingContainers[expandingContainers.length - 1];
+                    let scrolled = false;
+                    const finish = () => {
+                        if (scrolled) return;
+                        scrolled = true;
+                        outermost.removeEventListener('transitionend', finish);
+                        scrollToCurrentPage();
+                    };
+                    outermost.addEventListener('transitionend', finish);
+                    setTimeout(finish, 400);
                 });
             }
         }

--- a/wiki/templates/wiki/includes/sidebar.html
+++ b/wiki/templates/wiki/includes/sidebar.html
@@ -372,12 +372,13 @@
             },
             
             init() {
-                // Auto-expand parents of current page
-                this.expandCurrentPageParents();
-                
-                // Debug: log all route elements
-                this.$nextTick(() => {
-                    const allRouteElements = document.querySelectorAll('[data-route]');
+                this.revealCurrentPage(this.currentRoute);
+
+                // Keep the tree in sync when navigation happens client-side
+                // (sidebar links, prev/next buttons, browser back/forward)
+                this.$watch('$store.navigation.currentRoute', (route) => {
+                    this.currentRoute = route;
+                    this.revealCurrentPage(route);
                 });
             },
             
@@ -395,35 +396,33 @@
                 return this.expandedStates[nodeId] || false;
             },
             
-            expandCurrentPageParents() {
-                // Find and expand all parent groups of the current page
-                if (!this.currentRoute) return;
-                
-                // Wait for DOM to be fully rendered
+            revealCurrentPage(route) {
+                // Expand all parent groups of the current page, then scroll it into view
+                if (!route) return;
+
                 this.$nextTick(() => {
-                    // Find the current page element
-                    const currentPageElement = document.querySelector(`[data-route="${this.currentRoute}"]`);
+                    // Scoped to $root so we don't match the mobile drawer's copy of the tree
+                    const currentPageElement = this.$root.querySelector(`[data-route="${route}"]`);
                     if (!currentPageElement) return;
-                    
-                    // Find all parent group containers and expand them
+
                     let parentElement = currentPageElement.parentElement;
-                    while (parentElement) {
-                        // Look for parent wiki-children containers
+                    while (parentElement && parentElement !== this.$root) {
                         if (parentElement.classList.contains('wiki-children')) {
-                            // Find the sibling wiki-item-content that has a data-node-id
                             const parentItem = parentElement.parentElement;
-                            if (parentItem) {
-                                const parentContent = parentItem.querySelector('.wiki-item-content[data-node-id]');
-                                if (parentContent) {
-                                    const nodeId = parentContent.getAttribute('data-node-id');
-                                    if (nodeId) {
-                                        this.expandedStates[nodeId] = true;
-                                    }
-                                }
+                            const parentContent = parentItem?.querySelector('.wiki-item-content[data-node-id]');
+                            const nodeId = parentContent?.getAttribute('data-node-id');
+                            if (nodeId) {
+                                this.expandedStates[nodeId] = true;
                             }
                         }
                         parentElement = parentElement.parentElement;
                     }
+
+                    // Wait for the x-collapse expand transition (250ms) to finish
+                    // so the scroll position is measured against the final layout
+                    setTimeout(() => {
+                        currentPageElement.scrollIntoView({ block: 'nearest' });
+                    }, 300);
                 });
             }
         }


### PR DESCRIPTION
## Problem

Landing on a wiki page via a shared link or search result (and navigating with the prev/next buttons) could leave the current page invisible in the sidebar — ancestor groups collapsed, and on long trees the highlighted item scrolled out of view.

Fixes #685

## Solution

- On load, after expanding ancestor groups, scroll the current page's sidebar item into view (desktop sidebar; mobile drawer scrolls when opened).
- Watch `$store.navigation.currentRoute` so client-side prev/next navigation also expands ancestor groups and reveals the new page.
- Scope tree lookups to each component's root so the desktop sidebar and mobile drawer don't match each other's copy of the tree.

Regression e2e spec covers all three behaviors (direct-load reveal, scroll-into-view on long trees, SPA prev/next reveal); the latter two fail without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)