### PR TITLE
fix(editor): flush dirty page buffers on navigation and save

### DIFF
--- a/e2e/tests/local-first-store.spec.ts
+++ b/e2e/tests/local-first-store.spec.ts
@@ -354,7 +354,7 @@ test.describe('Local-first draft workspace', () => {
 		await expect(submitButton).toBeEnabled();
 	});
 
-	test('navigating away from dirty content keeps Submit disabled and restores the local buffer', async ({
+	test('navigating away from dirty content auto-saves it and re-enables Submit', async ({
 		page,
 		request,
 	}) => {
@@ -423,17 +423,15 @@ test.describe('Local-first draft workspace', () => {
 		await editor.click();
 		await expect(submitButton).toBeDisabled();
 
+		// Navigating away flushes the dirty buffer to the server.
 		await page.locator('aside').getByText(secondTitle, { exact: true }).click();
-		await expect(submitButton).toBeDisabled();
-
-		await page.locator('aside').getByText(firstTitle, { exact: true }).click();
-		await expect(page.getByText(typedContent)).toBeVisible({ timeout: 5000 });
-		await expect(submitButton).toBeDisabled();
-
-		await page.getByRole('button', { name: 'Save' }).click();
 		await expect(page.getByText('All changes saved')).toBeVisible({
 			timeout: 5000,
 		});
+		await expect(submitButton).toBeEnabled();
+
+		await page.locator('aside').getByText(firstTitle, { exact: true }).click();
+		await expect(page.getByText(typedContent)).toBeVisible({ timeout: 5000 });
 		await expect(submitButton).toBeEnabled();
 	});
 

--- a/frontend/src/components/DraftContributionPanel.vue
+++ b/frontend/src/components/DraftContributionPanel.vue
@@ -50,7 +50,7 @@
 			</div>
 
 			<div v-if="!crPage.is_group" class="flex-1 overflow-auto px-6 pb-6">
-				<WikiEditor v-if="editorKey" :key="editorKey" ref="editorRef" :content="editorContent" :document-key="props.docKey" :saved-content="savedContent" @save="saveContent" @content-change="onEditorContentChange" @content-ready="onEditorContentReady" />
+				<WikiEditor v-if="editorKey" :key="editorKey" ref="editorRef" :content="editorContent" :document-key="props.docKey" :saved-content="savedContent" @save="saveContent" @save-all="flushOtherDirtyPages" @content-change="onEditorContentChange" @content-ready="onEditorContentReady" />
 			</div>
 
 			<div v-else class="flex-1 flex items-center justify-center text-ink-gray-5">
@@ -245,6 +245,8 @@ onMounted(async () => {
 	if (props.spaceId) {
 		await draftStore.hydrate(props.spaceId);
 	}
+	// Restored IndexedDB drafts may belong to pages never revisited.
+	draftStore.flushDirtyPages(props.docKey).catch(() => {});
 	await loadCrPage();
 });
 
@@ -252,10 +254,25 @@ watch(
 	() => props.docKey,
 	async (newId) => {
 		if (newId) {
+			// Navigation cancels the previous page's debounced autosave;
+			// flush its buffer now. Failures surface via the sync pill.
+			draftStore.flushDirtyPages(newId).catch(() => {});
 			await loadCrPage();
 		}
 	},
 );
+
+// Drain dirty buffers for pages other than the one on screen; the open
+// page's saves go through the editor instead.
+async function flushOtherDirtyPages() {
+	const failures = await draftStore.flushDirtyPages(props.docKey);
+	if (failures.length) {
+		const error = failures[0];
+		toast.error(
+			error?.messages?.[0] || error?.message || __('Error saving draft'),
+		);
+	}
+}
 
 function onEditorContentChange(content, docKey = props.docKey, options = {}) {
 	if (!docKey) return;

--- a/frontend/src/components/WikiDocumentPanel.vue
+++ b/frontend/src/components/WikiDocumentPanel.vue
@@ -76,7 +76,7 @@
 			</div>
 
 			<div class="flex-1 overflow-auto px-6 pb-6 mt-4">
-				<WikiEditor v-if="editorKey" :key="editorKey" ref="editorRef" :content="editorContent" :document-key="wikiDoc.doc?.doc_key" :saved-content="savedContent" :readonly="readonly" @save="saveContent" @content-change="onEditorContentChange" @content-ready="onEditorContentReady" />
+				<WikiEditor v-if="editorKey" :key="editorKey" ref="editorRef" :content="editorContent" :document-key="wikiDoc.doc?.doc_key" :saved-content="savedContent" :readonly="readonly" @save="saveContent" @save-all="flushOtherDirtyPages" @content-change="onEditorContentChange" @content-ready="onEditorContentReady" />
 				<!-- Editor body skeleton while the CR page overlay loads -->
 				<div v-else class="space-y-4 animate-pulse">
 					<div class="h-4 w-3/4 rounded bg-surface-gray-3" />
@@ -233,6 +233,9 @@ watch(
 		// no change request overlay, so skip the CR-page load entirely.
 		if (props.readonly) return;
 		if (docKey) {
+			// Navigation cancels the previous page's debounced autosave;
+			// flush its buffer now. Failures surface via the sync pill.
+			draftStore.flushDirtyPages(docKey).catch(() => {});
 			await loadCrPage();
 		} else {
 			currentCrPage.value = null;
@@ -319,7 +322,12 @@ const editorContent = computed(() => {
 });
 
 const displayTitle = computed(() => {
-	return activePage.value?.title || currentCrPage.value?.title || wikiDoc.value.doc?.title || '';
+	return (
+		activePage.value?.title ||
+		currentCrPage.value?.title ||
+		wikiDoc.value.doc?.title ||
+		''
+	);
 });
 
 const displayPublished = computed(() => {
@@ -333,7 +341,12 @@ const displayPublished = computed(() => {
 });
 
 const displayRoute = computed(() => {
-	return activePage.value?.route || currentCrPage.value?.route || wikiDoc.value.doc?.route || '';
+	return (
+		activePage.value?.route ||
+		currentCrPage.value?.route ||
+		wikiDoc.value.doc?.route ||
+		''
+	);
 });
 
 // Browser tab title: "{page} | {space}". Returning undefined while the doc
@@ -504,6 +517,19 @@ function openPage() {
 
 function saveFromHeader() {
 	editorRef.value?.saveToDB();
+}
+
+// Drain dirty buffers for pages other than the one on screen; the open
+// page's saves go through the editor instead.
+async function flushOtherDirtyPages() {
+	if (props.readonly) return;
+	const failures = await draftStore.flushDirtyPages(wikiDoc.value.doc?.doc_key);
+	if (failures.length) {
+		const error = failures[0];
+		toast.error(
+			error?.messages?.[0] || error?.message || __('Error saving draft'),
+		);
+	}
 }
 
 async function saveContent(content) {

--- a/frontend/src/components/WikiEditor.vue
+++ b/frontend/src/components/WikiEditor.vue
@@ -112,7 +112,12 @@ const props = defineProps({
 	},
 });
 
-const emit = defineEmits(['save', 'content-change', 'content-ready']);
+const emit = defineEmits([
+	'save',
+	'save-all',
+	'content-change',
+	'content-ready',
+]);
 
 const AUTOSAVE_DELAY = 10 * 1000;
 let autosaveTimer = null;
@@ -206,10 +211,7 @@ async function insertAndUploadImage(file) {
 		preview = '';
 	}
 
-	ed.chain()
-		.focus()
-		.setImage({ src: preview, uploadId, loading: true })
-		.run();
+	ed.chain().focus().setImage({ src: preview, uploadId, loading: true }).run();
 
 	try {
 		const url = await uploadFile(file);
@@ -745,6 +747,8 @@ function saveToDB() {
 		if (markdown !== normalizeMarkdown(props.savedContent)) {
 			emit('save', markdown);
 		}
+		// "Save" means all of the user's work, not just this page.
+		emit('save-all');
 		document.dispatchEvent(new CustomEvent('wiki-editor-after-save'));
 	} else {
 		toast.error('Could not get content from editor');

--- a/frontend/src/stores/draftWorkspace.js
+++ b/frontend/src/stores/draftWorkspace.js
@@ -758,6 +758,22 @@ export const useDraftWorkspaceStore = defineStore('draftWorkspace', () => {
 		);
 	}
 
+	// Save every divergent buffer, not just the page on screen; pages left
+	// mid-autosave would otherwise gate submit/merge. `exceptDocKey` skips
+	// the open editor's page — its saves stay editor-canonicalized.
+	async function flushDirtyPages(exceptDocKey = null) {
+		if (!crName.value) return [];
+		const dirty = pageBuffers
+			.dirtyPages()
+			.filter((page) => page.docKey !== exceptDocKey);
+		const results = await Promise.allSettled(
+			dirty.map((page) =>
+				saveContent(page.docKey, page.localContent, page.title || null),
+			),
+		);
+		return results.filter((r) => r.status === 'rejected').map((r) => r.reason);
+	}
+
 	async function doSaveContent(docKey, content, title) {
 		const page = pageBuffers.ensure(docKey, {
 			title: title || '',
@@ -957,6 +973,7 @@ export const useDraftWorkspaceStore = defineStore('draftWorkspace', () => {
 		deleteNode,
 		moveNode,
 		saveContent,
+		flushDirtyPages,
 		recordEditorContent,
 		reconcileEditorContent,
 		// queue helpers (used by upcoming mutation actions)

--- a/frontend/src/stores/draftWorkspace/pageBuffers.js
+++ b/frontend/src/stores/draftWorkspace/pageBuffers.js
@@ -33,6 +33,12 @@ export function createPageBuffers() {
 		return false;
 	});
 
+	function dirtyPages() {
+		return Object.keys(pagesByKey)
+			.map((key) => pagesByKey[key])
+			.filter((page) => isDirty(page));
+	}
+
 	function get(docKey) {
 		return pagesByKey[docKey] || null;
 	}
@@ -119,6 +125,7 @@ export function createPageBuffers() {
 	return {
 		pagesByKey,
 		hasUnsavedEditorContent,
+		dirtyPages,
 		emptyPage,
 		isDirty,
 		get,

--- a/frontend/src/stores/draftWorkspace/pageBuffers.test.js
+++ b/frontend/src/stores/draftWorkspace/pageBuffers.test.js
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createPageBuffers } from './pageBuffers.js';
+
+test('dirtyPages returns only buffers whose local snapshot diverges', () => {
+	const buffers = createPageBuffers();
+
+	buffers.ensure('clean', { content: 'same' });
+	buffers.setLocalContent('clean', 'same');
+
+	buffers.ensure('dirty-a', { content: 'server a' });
+	buffers.setLocalContent('dirty-a', 'local a');
+
+	buffers.ensure('dirty-b', { content: 'server b' });
+	buffers.setLocalContent('dirty-b', 'local b');
+
+	const dirty = buffers.dirtyPages();
+	assert.deepEqual(dirty.map((p) => p.docKey).sort(), ['dirty-a', 'dirty-b']);
+	assert.equal(buffers.hasUnsavedEditorContent.value, true);
+});
+
+test('dirtyPages is empty when local content matches the baseline', () => {
+	const buffers = createPageBuffers();
+
+	buffers.ensure('a', { content: 'hello' });
+	buffers.setLocalContent('a', 'hello');
+	buffers.ensure('b', { content: 'world' });
+
+	assert.deepEqual(buffers.dirtyPages(), []);
+	assert.equal(buffers.hasUnsavedEditorContent.value, false);
+});
+
+test('a flushed save clears the page from dirtyPages', () => {
+	const buffers = createPageBuffers();
+
+	buffers.ensure('page', { content: 'old' });
+	buffers.setLocalContent('page', 'new');
+	assert.equal(buffers.dirtyPages().length, 1);
+
+	// Mirrors doSaveContent's success path.
+	const page = buffers.get('page');
+	page.content = 'new';
+	if (page.localContent === 'new') page.localContent = null;
+
+	assert.deepEqual(buffers.dirtyPages(), []);
+	assert.equal(buffers.hasUnsavedEditorContent.value, false);
+});


### PR DESCRIPTION
## Problem

Editing a page and navigating away before the 10s debounced autosave fired cancelled the pending save, leaving that page's buffer divergent. The global "Unsaved changes" blocker kept **Merge** / **Submit for Review** disabled, while clicking **Save** on the open page silently no-oped (it had no changes of its own) — a dead end with no indication of which page was holding the draft hostage.

Fixes #689

## Solution

- **Save now saves all pages**: the editor emits a `save-all` event so both edit panels drain every divergent buffer, not just the page on screen.
- **Navigation auto-saves**: switching pages (and mounting the draft panel after hydrate) flushes other pages' dirty buffers to the change request automatically.
- The open page is always excluded from the flush — its saves flow through the editor so content stays canonicalized.

Unit tests for the new `dirtyPages()` buffer helper (verified fail-before/pass-after), and the navigate-away e2e spec updated to the new auto-save semantics. Full `local-first-store`, `change-request-flow`, and `accept-contributions` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBSBqpbJNLLsNYnPKJqFWe