### PR TITLE
fix: clear stale website 404 cache when wiki routes change

### DIFF
--- a/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
@@ -13,6 +13,7 @@ from frappe.tests import IntegrationTestCase
 from frappe.utils import get_test_client
 
 from wiki.frappe_wiki.doctype.wiki_document.wiki_document import (
+	WikiDocumentRenderer,
 	download_pdf,
 	process_navbar_items,
 )
@@ -1675,3 +1676,111 @@ class TestMarkdownContentNegotiation(WikiDocumentTestBase):
 		self.assertEqual(response.status_code, 200)
 		content_type = response.headers.get("Content-Type", "")
 		self.assertIn("charset=utf-8", content_type)
+
+
+class TestStale404CacheInvalidation(WikiDocumentTestBase):
+	"""
+	Regression tests for GH-684: Frappe caches every guest URL that 404s
+	(the ``website_404`` cache) and short-circuits later requests to it, so a
+	page published or renamed after its URL was visited kept returning 404
+	until the cache was cleared manually. Wiki Document writes must invalidate
+	that cache.
+	"""
+
+	def setUp(self):
+		self._original_request = getattr(frappe.local, "request", None)
+		frappe.cache.delete_value("website_404")
+
+	def tearDown(self):
+		if self._original_request is not None:
+			frappe.local.request = self._original_request
+		elif hasattr(frappe.local, "request"):
+			del frappe.local.request
+		super().tearDown()
+
+	def _unique(self, prefix):
+		return f"{prefix}-{frappe.generate_hash(length=6)}"
+
+	def _poison_404_cache(self, route):
+		"""Simulate NotFoundPage caching a guest 404 hit for this URL."""
+		from werkzeug.test import EnvironBuilder
+		from werkzeug.wrappers import Request
+
+		builder = EnvironBuilder(path=f"/{route}", base_url=frappe.utils.get_url())
+		frappe.local.request = Request(builder.get_environ())
+		frappe.cache.hset("website_404", frappe.local.request.url, True)
+
+	def _resolve(self, route):
+		"""Resolve a route the way a web request would, with 404 caching active."""
+		from frappe.website.path_resolver import PathResolver
+
+		with patch("frappe.website.path_resolver.can_cache", return_value=True):
+			return PathResolver(route).resolve()[1]
+
+	def _create_space(self, prefix):
+		route = self._unique(prefix)
+		space = create_test_wiki_space(self, f"Space {route}", route, None, roles=[("Guest", "Read")])
+		return space, route
+
+	def test_publishing_new_page_clears_cached_404(self):
+		from frappe.website.page_renderers.not_found_page import NotFoundPage
+
+		space, space_route = self._create_space("cache-684")
+		slug = self._unique("page")
+		route = f"{space_route}/{slug}"
+
+		self._poison_404_cache(route)
+		self.assertIsInstance(self._resolve(route), NotFoundPage)
+
+		create_test_wiki_document(self, "Cache Test Page", parent=space.root_group, slug=slug)
+
+		self.assertIsInstance(self._resolve(route), WikiDocumentRenderer)
+
+	def test_route_change_clears_cached_404_for_new_route(self):
+		from frappe.website.page_renderers.not_found_page import NotFoundPage
+
+		space, space_route = self._create_space("cache-684-mv")
+		doc = create_test_wiki_document(self, "Move Me", parent=space.root_group, slug=self._unique("old"))
+		new_slug = self._unique("new")
+		new_route = f"{space_route}/{new_slug}"
+
+		self._poison_404_cache(new_route)
+		self.assertIsInstance(self._resolve(new_route), NotFoundPage)
+
+		doc.slug = new_slug
+		doc.route = new_route
+		doc.save()
+
+		self.assertIsInstance(self._resolve(new_route), WikiDocumentRenderer)
+
+	def test_publish_toggle_clears_cached_404(self):
+		space, space_route = self._create_space("cache-684-pub")
+		slug = self._unique("draft")
+		doc = create_test_wiki_document(
+			self, "Draft Page", parent=space.root_group, slug=slug, is_published=False
+		)
+		route = f"{space_route}/{slug}"
+
+		self._poison_404_cache(route)
+
+		doc.is_published = 1
+		doc.save()
+
+		self.assertIsInstance(self._resolve(route), WikiDocumentRenderer)
+
+	def test_space_route_rename_clears_cached_404(self):
+		space, space_route = self._create_space("cache-684-sp")
+		slug = self._unique("page")
+		doc = create_test_wiki_document(self, "Space Rename Page", parent=space.root_group, slug=slug)
+
+		new_space_route = self._unique("cache-684-renamed")
+		new_route = f"{new_space_route}/{slug}"
+
+		self._poison_404_cache(new_route)
+
+		space.reload()
+		space.update_routes(new_space_route)
+
+		doc.reload()
+		self.assertEqual(doc.route, new_route)
+		self.assertIsInstance(self._resolve(new_route), WikiDocumentRenderer)

--- a/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
@@ -10,6 +10,7 @@ from frappe.utils import pretty_date
 from frappe.utils.nestedset import NestedSet, get_descendants_of
 from frappe.utils.print_utils import get_print
 from frappe.website.page_renderers.base_renderer import BaseRenderer
+from frappe.website.utils import clear_cache as clear_website_cache
 from frappe.website.website_components.metatags import MetaTags
 from werkzeug.wrappers import Response
 
@@ -695,6 +696,7 @@ def on_wiki_document_update(doc, method):
 	"""Stamp the owning Wiki Space and sync desk edits to the revision system."""
 	stamp_wiki_space(doc)
 	_sync_document_to_revision(doc)
+	_clear_stale_website_cache(doc)
 
 
 def stamp_wiki_space(doc):
@@ -725,6 +727,34 @@ def stamp_wiki_space_subtree(root_doc_name):
 def on_wiki_document_trash(doc, method):
 	"""Sync desk deletions to the revision system."""
 	_sync_document_to_revision(doc)
+	_clear_stale_website_cache(doc, deleted=True)
+
+
+def _clear_stale_website_cache(doc, deleted=False):
+	"""Invalidate Frappe's website caches for this document's routes.
+
+	Frappe remembers every guest URL that 404'd (the ``website_404`` cache) and
+	short-circuits all later requests to it, so a page published or renamed
+	after its URL was ever visited keeps returning 404 until the cache is
+	invalidated. ``clear_website_cache`` drops the whole ``website_404`` map
+	along with the routing caches for the given path.
+
+	The immediate clear serves the current process; the after-commit clear
+	closes the race where another worker re-caches a 404 from pre-commit DB
+	state between our clear and the transaction commit.
+	"""
+	route_affecting_fields = ("route", "is_published", "is_external_link")
+	if not deleted and not any(doc.has_value_changed(f) for f in route_affecting_fields):
+		return
+
+	before = doc.get_doc_before_save()
+	routes = {doc.route, before.route if before else None} - {None, ""}
+	if not routes:
+		return
+
+	for route in routes:
+		clear_website_cache(route)
+	frappe.db.after_commit.add(lambda routes=routes: [clear_website_cache(route) for route in routes])
 
 
 def _sync_document_to_revision(doc):

--- a/wiki/wiki/doctype/wiki_space/wiki_space.py
+++ b/wiki/wiki/doctype/wiki_space/wiki_space.py
@@ -3,6 +3,7 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.website.utils import clear_cache as clear_website_cache
 
 _CHILD_ROW_META_FIELDS = {
 	"name",
@@ -253,6 +254,12 @@ class WikiSpace(Document):
 		# Update space route
 		self.route = new_route
 		self.save()
+
+		# Document routes were rewritten with raw SQL (no per-doc hooks), so drop
+		# the website caches wholesale — stale website_404 entries would otherwise
+		# keep serving 404s for the renamed URLs.
+		clear_website_cache()
+		frappe.db.after_commit.add(clear_website_cache)
 
 		return {"updated_count": updated_count}
 


### PR DESCRIPTION
## Problem

Frappe caches every guest URL that 404s (the `website_404` cache) and short-circuits all later requests to it. A Wiki Document published or renamed after its URL was ever visited keeps returning 404 until the whole website cache is cleared manually.

Fixes #684

## Solution

Invalidate the website cache from the Wiki Document update/trash hooks whenever a route-affecting field (`route`, `is_published`, `is_external_link`) changes, and after Wiki Space bulk route renames (which rewrite routes with raw SQL and bypass per-doc hooks). Clear both immediately and after commit so a parallel worker cannot re-poison the cache from pre-commit state.

Includes regression tests that poison the `website_404` cache the same way `NotFoundPage` does and resolve through the real `PathResolver`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)