### PR TITLE
ci: shard Playwright E2E tests 4 ways

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -15,7 +15,12 @@ jobs:
   ui-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    name: Playwright E2E Tests
+    name: Playwright E2E Tests (${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
+    strategy:
+      fail-fast: false
+      matrix:
+        shardIndex: [1, 2, 3]
+        shardTotal: [3]
 
     services:
       redis-cache:
@@ -126,25 +131,25 @@ jobs:
           npx playwright install --with-deps chromium
 
       - name: Run Playwright Tests
-        run: npx playwright test
+        run: npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
         env:
           BASE_URL: http://wiki.test:8000
           FRAPPE_USER: Administrator
           FRAPPE_PASSWORD: admin
 
-      - name: Upload Playwright Report
+      - name: Upload Blob Report
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 7
+          name: blob-report-${{ matrix.shardIndex }}
+          path: blob-report/
+          retention-days: 3
 
       - name: Upload Test Results
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: test-results
+          name: test-results-${{ matrix.shardIndex }}
           path: test-results/
           retention-days: 7
 
@@ -157,3 +162,41 @@ jobs:
           echo ""
           echo "=== Frappe Logs ==="
           cat logs/*.log || true
+
+  merge-reports:
+    # Merge the per-shard blob reports into a single HTML report.
+    if: ${{ !cancelled() }}
+    needs: ui-tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    name: Merge Playwright Reports
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          check-latest: true
+
+      - name: Install Playwright
+        run: npm install
+
+      - name: Download Blob Reports
+        uses: actions/download-artifact@v4
+        with:
+          path: all-blob-reports
+          pattern: blob-report-*
+          merge-multiple: true
+
+      - name: Merge Reports
+        run: npx playwright merge-reports --reporter html ./all-blob-reports
+
+      - name: Upload Playwright Report
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -19,8 +19,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shardIndex: [1, 2, 3]
-        shardTotal: [3]
+        shardIndex: [1, 2, 3, 4]
+        shardTotal: [4]
 
     services:
       redis-cache:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,8 +19,10 @@ export default defineConfig({
 	forbidOnly: !!process.env.CI,
 	retries: process.env.CI ? 2 : 0,
 	workers: 1, // Single worker for Frappe session management
-	// Use multiple reporters in CI for both inline annotations and HTML artifacts
-	reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'html',
+	// CI shards the run across machines: blob reports from each shard are
+	// merged into one HTML report by the merge-reports job; the github
+	// reporter still annotates failures inline per shard.
+	reporter: process.env.CI ? [['github'], ['blob']] : 'html',
 	timeout: 60000, // 60s per test
 
 	expect: {


### PR DESCRIPTION
## Problem

The E2E job runs all specs sequentially on one machine: ~10 min per PR, of which ~6.5 min is the test run and ~3 min is bench setup.

## Solution

- Shard the suite across 4 parallel jobs (`--shard=N/4`), each with its own bench — no shared-state risk, `workers: 1` semantics unchanged per machine.
- Each shard uploads a blob report; a `merge-reports` job merges them into the single HTML report artifact ([Playwright sharding docs](https://playwright.dev/docs/test-sharding)).
- Inline GitHub failure annotations still come from each shard.

Shard split: 29/27/25/26 tests. Baseline ~10 min; 3-shard run ~7 min wall; 4-shard timings in the checks below.

Note: if branch protection requires the old `Playwright E2E Tests` check, the required checks need updating to the four sharded job names (or `Merge Playwright Reports`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBSBqpbJNLLsNYnPKJqFWe
