### PR TITLE
fix: redirect space URL to first page in sidebar order

### DIFF
--- a/wiki/api/wiki_space.py
+++ b/wiki/api/wiki_space.py
@@ -165,6 +165,11 @@ def reorder_wiki_documents(
 	finally:
 		frappe.flags.in_reorder_wiki_documents = False
 
+	from wiki.frappe_wiki.doctype.wiki_document.wiki_document import clear_wiki_tree_cache
+
+	# Reorders bypass on_update (raw sort_order writes), so bust the tree cache here.
+	clear_wiki_tree_cache()
+
 	_sync_main_revision_for_space(_get_wiki_space_for_document(doc.name))
 
 	return {"is_contribution": False}

--- a/wiki/frappe_wiki/doctype/wiki_change_request/wiki_change_request.py
+++ b/wiki/frappe_wiki/doctype/wiki_change_request/wiki_change_request.py
@@ -1985,11 +1985,16 @@ def _apply_merge_changes_only(
 
 def _finalize_merge(cr: Document, merge_revision: Document) -> None:
 	"""Update CR status after successful merge."""
+	from wiki.frappe_wiki.doctype.wiki_document.wiki_document import clear_wiki_tree_cache
+
 	cr.status = "Merged"
 	cr.merge_revision = merge_revision.name
 	cr.merged_by = frappe.session.user
 	cr.merged_at = now_datetime()
 	cr.save()
+
+	# Merge applies rewrite structure/sort_order with raw db writes that skip on_update.
+	clear_wiki_tree_cache()
 	_notify_cr_owner(cr, _("Your change request “{0}” was merged.").format(cr.title))
 
 
@@ -2296,11 +2301,16 @@ def create_merge_revision(cr: Document, merged_items: dict[str, dict[str, Any]])
 
 
 def apply_merge_revision(space: Document, revision: Document) -> None:
+	from wiki.frappe_wiki.doctype.wiki_document.wiki_document import clear_wiki_tree_cache
+
 	frappe.flags.in_apply_merge_revision = True
 	try:
 		_apply_merge_revision(space, revision)
 	finally:
 		frappe.flags.in_apply_merge_revision = False
+
+	# Merges rewrite structure/sort_order with raw db writes that skip on_update.
+	clear_wiki_tree_cache()
 
 
 def _apply_merge_revision(space: Document, revision: Document) -> None:

--- a/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
@@ -1784,3 +1784,127 @@ class TestStale404CacheInvalidation(WikiDocumentTestBase):
 		doc.reload()
 		self.assertEqual(doc.route, new_route)
 		self.assertIsInstance(self._resolve(new_route), WikiDocumentRenderer)
+
+
+class TestSpaceUrlFirstPage(WikiDocumentTestBase):
+	"""The space URL must land on the first page in sidebar order (sort_order),
+	not the first descendant in NestedSet (lft) order."""
+
+	def test_first_page_follows_sidebar_sort_order_not_lft(self):
+		from wiki.frappe_wiki.doctype.wiki_document.wiki_document import get_first_published_page
+
+		root = create_test_wiki_document(self, "FirstPage Root", is_group=True)
+		# Created first, so it has the lower lft — but reordered last in the sidebar.
+		created_first = create_test_wiki_document(
+			self, "Created First", parent=root.name, slug="fp-created-first"
+		)
+		sidebar_first = create_test_wiki_document(
+			self, "Sidebar First", parent=root.name, slug="fp-sidebar-first"
+		)
+		create_test_wiki_space(self, "FirstPage Space", "fp-space", root.name)
+		# Raw sort_order writes, exactly like reorder_wiki_documents does.
+		frappe.db.set_value("Wiki Document", sidebar_first.name, "sort_order", 0)
+		frappe.db.set_value("Wiki Document", created_first.name, "sort_order", 1)
+
+		first = get_first_published_page(root.name)
+		self.assertEqual(first["route"], sidebar_first.route)
+
+	def test_first_page_descends_into_first_group(self):
+		from wiki.frappe_wiki.doctype.wiki_document.wiki_document import get_first_published_page
+
+		root = create_test_wiki_document(self, "FirstPage GRoot", is_group=True)
+		later = create_test_wiki_document(self, "Later Page", parent=root.name, slug="fpg-later")
+		group = create_test_wiki_document(
+			self, "First Group", parent=root.name, is_group=True, slug="fpg-group"
+		)
+		nested = create_test_wiki_document(self, "Nested Page", parent=group.name, slug="fpg-nested")
+		create_test_wiki_space(self, "FirstPage GSpace", "fpg-space", root.name)
+		frappe.db.set_value("Wiki Document", group.name, "sort_order", 0)
+		frappe.db.set_value("Wiki Document", later.name, "sort_order", 1)
+
+		first = get_first_published_page(root.name)
+		self.assertEqual(first["route"], nested.route)
+
+	def test_first_page_skips_unpublished_and_external(self):
+		from wiki.frappe_wiki.doctype.wiki_document.wiki_document import get_first_published_page
+
+		root = create_test_wiki_document(self, "FirstPage SRoot", is_group=True)
+		create_test_wiki_document(
+			self, "Unpublished", parent=root.name, sort_order=0, slug="fps-unpub", is_published=False
+		)
+		create_test_wiki_document(
+			self,
+			"External",
+			parent=root.name,
+			sort_order=1,
+			slug="fps-ext",
+			is_external_link=True,
+			external_url="https://example.com",
+		)
+		page = create_test_wiki_document(self, "Real Page", parent=root.name, sort_order=2, slug="fps-real")
+		create_test_wiki_space(self, "FirstPage SSpace", "fps-space", root.name)
+
+		first = get_first_published_page(root.name)
+		self.assertEqual(first["route"], page.route)
+
+	def test_space_route_redirects_to_first_sidebar_page(self):
+		root = create_test_wiki_document(self, "FirstPage RRoot", is_group=True)
+		later = create_test_wiki_document(self, "Redirect Later", parent=root.name, slug="fpr-later")
+		target = create_test_wiki_document(self, "Redirect Target", parent=root.name, slug="fpr-target")
+		create_test_wiki_space(self, "FirstPage RSpace", "fpr-space", root.name)
+		frappe.db.set_value("Wiki Document", target.name, "sort_order", 0)
+		frappe.db.set_value("Wiki Document", later.name, "sort_order", 1)
+
+		renderer = WikiDocumentRenderer(path="fpr-space")
+		with self.assertRaises(frappe.Redirect):
+			renderer.can_render()
+		self.assertEqual(frappe.local.flags.redirect_location, "/" + target.route)
+
+
+class TestWikiTreeCache(WikiDocumentTestBase):
+	def test_tree_is_cached_and_busted_on_document_update(self):
+		from wiki.frappe_wiki.doctype.wiki_document.wiki_document import (
+			WIKI_TREE_CACHE_KEY,
+			get_public_wiki_tree,
+		)
+
+		root = create_test_wiki_document(self, "TreeCache Root", is_group=True)
+		page = create_test_wiki_document(self, "TreeCache Page", parent=root.name, slug="tc-page")
+		create_test_wiki_space(self, "TreeCache Space", "tc-space", root.name)
+
+		tree = get_public_wiki_tree(root.name)
+		self.assertEqual(tree[0]["title"], "TreeCache Page")
+		self.assertIsNotNone(frappe.cache().hget(WIKI_TREE_CACHE_KEY, root.name))
+
+		page.title = "TreeCache Page Renamed"
+		page.save()
+
+		self.assertIsNone(frappe.cache().hget(WIKI_TREE_CACHE_KEY, root.name))
+		tree = get_public_wiki_tree(root.name)
+		self.assertEqual(tree[0]["title"], "TreeCache Page Renamed")
+
+	def test_tree_cache_busted_on_reorder(self):
+		from wiki.api.wiki_space import reorder_wiki_documents
+		from wiki.frappe_wiki.doctype.wiki_document.wiki_document import (
+			WIKI_TREE_CACHE_KEY,
+			get_public_wiki_tree,
+		)
+
+		root = create_test_wiki_document(self, "TreeCache RRoot", is_group=True)
+		page_a = create_test_wiki_document(self, "Reorder A", parent=root.name, sort_order=0, slug="tcr-a")
+		page_b = create_test_wiki_document(self, "Reorder B", parent=root.name, sort_order=1, slug="tcr-b")
+		create_test_wiki_space(self, "TreeCache RSpace", "tcr-space", root.name)
+
+		tree = get_public_wiki_tree(root.name)
+		self.assertEqual([n["title"] for n in tree], ["Reorder A", "Reorder B"])
+
+		reorder_wiki_documents(
+			doc_name=page_b.name,
+			new_parent=root.name,
+			new_index=0,
+			siblings=json.dumps([page_b.name, page_a.name]),
+		)
+
+		self.assertIsNone(frappe.cache().hget(WIKI_TREE_CACHE_KEY, root.name))
+		tree = get_public_wiki_tree(root.name)
+		self.assertEqual([n["title"] for n in tree], ["Reorder B", "Reorder A"])

--- a/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
@@ -18,6 +18,8 @@ from wiki.wiki.markdown import render_markdown, render_markdown_with_toc
 
 WIKI_DOCUMENT_PRINT_FORMAT = "Standard Wiki Document"
 
+WIKI_TREE_CACHE_KEY = "wiki_public_tree"
+
 # Mapping of known service domains to icon identifiers
 KNOWN_SERVICE_ICONS = {
 	"github.com": "github",
@@ -306,8 +308,7 @@ class WikiDocument(NestedSet):
 		if not root_group:
 			return [], {"prev": None, "next": None}
 
-		descendants = get_descendants_of("Wiki Document", root_group, ignore_permissions=True)
-		nested_tree = build_nested_wiki_tree(descendants)
+		nested_tree = get_public_wiki_tree(root_group)
 		adjacent_docs = get_adjacent_documents(nested_tree, self.route)
 
 		return nested_tree, adjacent_docs
@@ -531,15 +532,12 @@ class WikiDocumentRenderer(BaseRenderer):
 			"Wiki Document", {"route": self.path, "is_group": 1}, "name"
 		) or frappe.db.get_value("Wiki Space", {"route": self.path, "is_published": 1}, "root_group")
 
-		# Redirect to first published child document if available
+		# Redirect to the first page in sidebar order (sort_order at each level),
+		# so the space URL lands on the same document the sidebar shows first.
 		if root_group:
-			child_docs = get_descendants_of(
-				"Wiki Document", root_group, order_by="lft asc, sort_order desc", ignore_permissions=True
-			)
-			for child_name in child_docs:
-				child_doc = frappe.get_cached_doc("Wiki Document", child_name)
-				if not child_doc.is_group and child_doc.is_published:
-					frappe.redirect("/" + child_doc.route)
+			first_page = get_first_published_page(root_group)
+			if first_page:
+				frappe.redirect("/" + first_page["route"])
 
 		return False
 
@@ -641,6 +639,49 @@ def build_nested_wiki_tree(documents: list[str]):
 	return remove_empty_groups(root_nodes)
 
 
+def get_public_wiki_tree(root_group: str) -> list:
+	"""Return the published sidebar tree for a root group, cached in Redis.
+
+	The cache is invalidated on any Wiki Document change (see
+	clear_wiki_tree_cache), so a hit always reflects the committed tree.
+	"""
+	tree = frappe.cache().hget(WIKI_TREE_CACHE_KEY, root_group)
+	if tree is None:
+		descendants = get_descendants_of("Wiki Document", root_group, ignore_permissions=True)
+		tree = build_nested_wiki_tree(descendants)
+		frappe.cache().hset(WIKI_TREE_CACHE_KEY, root_group, tree)
+	return tree
+
+
+def get_first_published_page(root_group: str) -> dict | None:
+	"""First non-group, non-external page in sidebar order — the document a
+	space URL should land on. Walks the same tree the sidebar renders, so the
+	two can't disagree."""
+
+	def find_first(nodes):
+		for node in nodes:
+			if not node["is_group"] and not node.get("is_external_link"):
+				return node
+			found = find_first(node["children"])
+			if found:
+				return found
+		return None
+
+	return find_first(get_public_wiki_tree(root_group))
+
+
+def clear_wiki_tree_cache():
+	"""Drop all cached sidebar trees.
+
+	Cleared wholesale rather than per space: a move can pull a subtree from one
+	space into another, staling both trees while the document only knows its
+	new space. Cleared again after commit to close the race where another
+	worker re-caches from pre-commit DB state.
+	"""
+	frappe.cache().delete_value(WIKI_TREE_CACHE_KEY)
+	frappe.db.after_commit.add(lambda: frappe.cache().delete_value(WIKI_TREE_CACHE_KEY))
+
+
 @frappe.whitelist()
 def get_breadcrumbs(name: str) -> dict:
 	"""Get the breadcrumb trail for a Wiki Document including space info."""
@@ -697,6 +738,7 @@ def on_wiki_document_update(doc, method):
 	stamp_wiki_space(doc)
 	_sync_document_to_revision(doc)
 	_clear_stale_website_cache(doc)
+	clear_wiki_tree_cache()
 
 
 def stamp_wiki_space(doc):
@@ -728,6 +770,7 @@ def on_wiki_document_trash(doc, method):
 	"""Sync desk deletions to the revision system."""
 	_sync_document_to_revision(doc)
 	_clear_stale_website_cache(doc, deleted=True)
+	clear_wiki_tree_cache()
 
 
 def _clear_stale_website_cache(doc, deleted=False):


### PR DESCRIPTION
## Problem

Visiting a space URL redirects to the first descendant in NestedSet (`lft`) order — the order the desk tree view shows. The sidebar sorts by `sort_order` at each level, so after any reorder the space URL lands on a different page than the one shown first in the sidebar.

## Solution

The redirect now walks the same nested tree the sidebar renders and picks the first published, non-group, non-external page — so the two can never disagree.

The published sidebar tree is also now cached in Redis (previously rebuilt on every page view), invalidated on Wiki Document update/trash, reorder, and change request merge (the latter two bypass `on_update` with raw db writes).

Includes a regression test verified against the old behavior (fails before the fix, passes after), plus tests for cache hit and invalidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjihfYwEXCQrwcuJ3yWLNM