### PR TITLE
fix: hide unpublished content from search results

### DIFF
--- a/wiki/frappe_wiki/doctype/wiki_change_request/test_wiki_change_request.py
+++ b/wiki/frappe_wiki/doctype/wiki_change_request/test_wiki_change_request.py
@@ -272,6 +272,33 @@ class TestWikiChangeRequest(FrappeTestCase):
 		self.assertEqual(cr_doc.status, "Merged")
 		self.assertIsNotNone(cr_doc.merge_revision)
 
+	def test_content_only_merge_queues_search_reindex(self):
+		"""Content-only merges write via raw db.set_value, which skips the
+		on_update hook — the merge must queue the re-index itself, or search
+		keeps serving the pre-merge content."""
+		from frappe.search.sqlite_search import index_docs_in_queue
+
+		from wiki.frappe_wiki.doctype.wiki_document.wiki_sqlite_search import WikiSQLiteSearch
+
+		space = create_test_wiki_space()
+		page = create_test_wiki_document(space.root_group, title="Search Page", content="staletermv1zzz")
+
+		search = WikiSQLiteSearch()
+		search.drop_index()
+		search.build_index()
+
+		cr = create_change_request(space.name, "CR Search Reindex")
+		page_key = frappe.get_value("Wiki Document", page.name, "doc_key")
+		update_cr_page(cr.name, page_key, {"content": "freshtermv2zzz"})
+		_approve_and_merge(cr.name)
+
+		index_docs_in_queue()
+
+		stale_names = [r["name"] for r in search.search("staletermv1zzz")["results"]]
+		fresh_names = [r["name"] for r in search.search("freshtermv2zzz")["results"]]
+		self.assertNotIn(page.name, stale_names)
+		self.assertIn(page.name, fresh_names)
+
 	def test_merge_deletes_wiki_document_when_marked_deleted(self):
 		space = create_test_wiki_space()
 		page = create_test_wiki_document(space.root_group, title="Page to Delete", content="content")

--- a/wiki/frappe_wiki/doctype/wiki_change_request/wiki_change_request.py
+++ b/wiki/frappe_wiki/doctype/wiki_change_request/wiki_change_request.py
@@ -1912,7 +1912,10 @@ def _apply_merge_changes_only(
 		)
 		blob_contents = {blob["name"]: blob.get("content") or "" for blob in blobs}
 
-	# Content-only fast path: direct DB update, skip doc.save() validation
+	# Content-only fast path: direct DB update, skip doc.save() validation.
+	# Raw set_value skips the on_update hook that queues search re-indexing,
+	# so queue the touched documents explicitly.
+	content_updated_names = []
 	for doc_key in content_only_keys:
 		if doc_key not in key_to_name:
 			continue
@@ -1920,6 +1923,12 @@ def _apply_merge_changes_only(
 		content_blob = item.get("content_blob")
 		content = blob_contents.get(content_blob, "") if content_blob else ""
 		frappe.db.set_value("Wiki Document", key_to_name[doc_key], "content", content)
+		content_updated_names.append(key_to_name[doc_key])
+
+	if content_updated_names:
+		from wiki.frappe_wiki.doctype.wiki_document.wiki_sqlite_search import enqueue_reindex
+
+		enqueue_reindex(content_updated_names)
 
 	# Structural changes and additions need full save (process in tree order)
 	full_save_keys = structural_keys | added_keys

--- a/wiki/frappe_wiki/doctype/wiki_document/search.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/search.py
@@ -23,7 +23,7 @@ def search(query: str, space: str | None = None) -> dict:
 
 	result = search_engine.search(query, filters=filters)
 
-	hits = _filter_hits_by_read_access(result["results"])
+	hits = _filter_hits_by_space_visibility(result["results"])
 
 	return {
 		"results": [
@@ -40,13 +40,15 @@ def search(query: str, space: str | None = None) -> dict:
 	}
 
 
-def _filter_hits_by_read_access(hits: list[dict]) -> list[dict]:
-	"""Drop search hits in spaces the current user can't read.
+def _filter_hits_by_space_visibility(hits: list[dict]) -> list[dict]:
+	"""Drop search hits the current user couldn't open as a page.
 
 	The SQLite index is built without user context, so titles/snippets from
 	restricted spaces can surface here. Resolve each hit's denormalized
-	wiki_space and gate it through the same read check as page rendering.
-	Orphan documents (no wiki_space) stay readable by all.
+	wiki_space and gate it through the same checks as page rendering: the
+	space must be published (`check_published`) and readable by the current
+	user (`check_space_access`). Orphan documents (no wiki_space) stay
+	readable by all.
 	"""
 	from wiki.permissions import can_read_space
 
@@ -63,16 +65,17 @@ def _filter_hits_by_read_access(hits: list[dict]) -> list[dict]:
 		)
 	}
 
-	readable: dict[str, bool] = {}
+	visible: dict[str, bool] = {}
 
-	def _can_read(space_name: str) -> bool:
-		if space_name not in readable:
-			readable[space_name] = can_read_space(space_name)
-		return readable[space_name]
+	def _is_visible(space_name: str) -> bool:
+		if space_name not in visible:
+			space_published = frappe.get_cached_value("Wiki Space", space_name, "is_published")
+			visible[space_name] = bool(space_published) and can_read_space(space_name)
+		return visible[space_name]
 
 	allowed = []
 	for hit in hits:
 		hit_space = space_by_name.get(hit["name"])
-		if not hit_space or _can_read(hit_space):
+		if not hit_space or _is_visible(hit_space):
 			allowed.append(hit)
 	return allowed

--- a/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
@@ -1908,3 +1908,73 @@ class TestWikiTreeCache(WikiDocumentTestBase):
 		self.assertIsNone(frappe.cache().hget(WIKI_TREE_CACHE_KEY, root.name))
 		tree = get_public_wiki_tree(root.name)
 		self.assertEqual([n["title"] for n in tree], ["Reorder B", "Reorder A"])
+
+
+class TestSearchPublishGating(WikiDocumentTestBase):
+	"""
+	Search must mirror page-render visibility: no hits from unpublished
+	spaces, and unpublishing a page must drop it from results immediately
+	(not after the 5-minute index queue catches up).
+	"""
+
+	def _build_index(self):
+		from wiki.frappe_wiki.doctype.wiki_document.wiki_sqlite_search import WikiSQLiteSearch
+
+		search = WikiSQLiteSearch()
+		search.drop_index()
+		search.build_index()
+		return search
+
+	def test_search_hides_docs_in_unpublished_space(self):
+		from wiki.frappe_wiki.doctype.wiki_document.search import search as wiki_search
+
+		visible_root = create_test_wiki_document(self, "Root PubSpace", is_group=True)
+		create_test_wiki_space(self, "Published Space", "pub-space-gate", visible_root.name)
+		visible_page = create_test_wiki_document(
+			self, "Visible Page", parent=visible_root.name, content="spacegate_searchterm"
+		)
+
+		hidden_root = create_test_wiki_document(self, "Root UnpubSpace", is_group=True)
+		create_test_wiki_space(
+			self, "Unpublished Space", "unpub-space-gate", hidden_root.name, is_published=False
+		)
+		hidden_page = create_test_wiki_document(
+			self, "Hidden Page", parent=hidden_root.name, content="spacegate_searchterm"
+		)
+
+		self._build_index()
+
+		result = wiki_search("spacegate_searchterm")
+		result_names = [r["name"] for r in result["results"]]
+
+		self.assertIn(visible_page.name, result_names)
+		self.assertNotIn(hidden_page.name, result_names)
+
+	def test_unpublish_drops_doc_from_search_immediately(self):
+		from wiki.frappe_wiki.doctype.wiki_document.search import search as wiki_search
+
+		root = create_test_wiki_document(self, "Root UnpubDoc", is_group=True)
+		page = create_test_wiki_document(
+			self, "Soon Unpublished", parent=root.name, content="unpubdoc_searchterm"
+		)
+		create_test_wiki_space(self, "UnpubDoc Space", "unpub-doc-gate", root.name)
+
+		search = self._build_index()
+
+		result = wiki_search("unpubdoc_searchterm")
+		self.assertIn(page.name, [r["name"] for r in result["results"]])
+
+		page.reload()
+		page.is_published = 0
+		page.save()
+
+		# No queue processing in between: the index row must already be gone.
+		rows = search.sql(
+			"SELECT count(*) AS c FROM search_fts WHERE doc_id = ?",
+			(f"Wiki Document:{page.name}",),
+			read_only=True,
+		)
+		self.assertEqual(rows[0]["c"], 0)
+
+		result = wiki_search("unpubdoc_searchterm")
+		self.assertNotIn(page.name, [r["name"] for r in result["results"]])

--- a/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
@@ -1968,13 +1968,47 @@ class TestSearchPublishGating(WikiDocumentTestBase):
 		page.is_published = 0
 		page.save()
 
+		def index_row_count():
+			rows = search.sql(
+				"SELECT count(*) AS c FROM search_fts WHERE doc_id = ?",
+				(f"Wiki Document:{page.name}",),
+				read_only=True,
+			)
+			return rows[0]["c"]
+
+		# Removal is deferred until the transaction commits, so the row must
+		# survive a save that could still roll back.
+		self.assertEqual(index_row_count(), 1)
+
+		# Run the post-commit callbacks without committing (keeps test isolation).
+		frappe.db.after_commit.run()
+
 		# No queue processing in between: the index row must already be gone.
+		self.assertEqual(index_row_count(), 0)
+
+		result = wiki_search("unpubdoc_searchterm")
+		self.assertNotIn(page.name, [r["name"] for r in result["results"]])
+
+	def test_unpublish_index_removal_discarded_on_rollback(self):
+		root = create_test_wiki_document(self, "Root RollbackDoc", is_group=True)
+		page = create_test_wiki_document(
+			self, "Rollback Page", parent=root.name, content="rollbackterm_search"
+		)
+		create_test_wiki_space(self, "Rollback Space", "unpub-rollback-gate", root.name)
+
+		search = self._build_index()
+
+		page.reload()
+		page.is_published = 0
+		page.save()
+
+		# The save never commits: the page stays published in the database, so
+		# its index row must survive too.
+		frappe.db.rollback()
+
 		rows = search.sql(
 			"SELECT count(*) AS c FROM search_fts WHERE doc_id = ?",
 			(f"Wiki Document:{page.name}",),
 			read_only=True,
 		)
-		self.assertEqual(rows[0]["c"], 0)
-
-		result = wiki_search("unpubdoc_searchterm")
-		self.assertNotIn(page.name, [r["name"] for r in result["results"]])
+		self.assertEqual(rows[0]["c"], 1)

--- a/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
@@ -746,7 +746,11 @@ def _drop_from_search_index_on_unpublish(doc):
 	from wiki.frappe_wiki.doctype.wiki_document.wiki_sqlite_search import remove_doc_from_index
 
 	if doc.has_value_changed("is_published") and not doc.is_published:
-		remove_doc_from_index(doc.name)
+		# The index lives in a separate SQLite file, outside this transaction.
+		# Deferring until after commit keeps the row when the save rolls back;
+		# on rollback the callback queue is discarded.
+		docname = doc.name
+		frappe.db.after_commit.add(lambda: remove_doc_from_index(docname))
 
 
 def stamp_wiki_space(doc):

--- a/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
@@ -739,6 +739,14 @@ def on_wiki_document_update(doc, method):
 	_sync_document_to_revision(doc)
 	_clear_stale_website_cache(doc)
 	clear_wiki_tree_cache()
+	_drop_from_search_index_on_unpublish(doc)
+
+
+def _drop_from_search_index_on_unpublish(doc):
+	from wiki.frappe_wiki.doctype.wiki_document.wiki_sqlite_search import remove_doc_from_index
+
+	if doc.has_value_changed("is_published") and not doc.is_published:
+		remove_doc_from_index(doc.name)
 
 
 def stamp_wiki_space(doc):

--- a/wiki/frappe_wiki/doctype/wiki_document/wiki_sqlite_search.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/wiki_sqlite_search.py
@@ -89,6 +89,27 @@ class WikiSQLiteSearch(SQLiteSearch):
 		return wiki_doc.get_root_group() or docname
 
 
+def enqueue_reindex(docnames: list[str]):
+	"""Queue Wiki Documents for search re-indexing.
+
+	Merge fast paths write content with raw ``frappe.db.set_value``, which
+	skips the framework's on_update hook that normally queues the re-index —
+	without this, the search index keeps serving the pre-merge content.
+	"""
+	search = WikiSQLiteSearch()
+	if not (search.is_search_enabled() and search.index_exists()):
+		return
+
+	try:
+		for docname in docnames:
+			search.add_to_queue(f"Wiki Document:{docname}")
+	except Exception:
+		frappe.log_error(
+			title="Wiki Search Reindex Queue Error",
+			message=f"Failed to queue Wiki Documents for re-indexing: {docnames}",
+		)
+
+
 def remove_doc_from_index(docname: str):
 	"""Remove a Wiki Document from the search index immediately.
 

--- a/wiki/frappe_wiki/doctype/wiki_document/wiki_sqlite_search.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/wiki_sqlite_search.py
@@ -87,3 +87,24 @@ class WikiSQLiteSearch(SQLiteSearch):
 		"""Get the root wiki space for a document"""
 		wiki_doc = frappe.get_doc("Wiki Document", docname)
 		return wiki_doc.get_root_group() or docname
+
+
+def remove_doc_from_index(docname: str):
+	"""Remove a Wiki Document from the search index immediately.
+
+	The framework's index update path only *queues* a re-index (drained by a
+	5-minute scheduler job, 30 docs per run), so an unpublished page would keep
+	surfacing in search until the queue catches up. Unpublishing must take
+	effect right away, so we delete the row synchronously.
+	"""
+	search = WikiSQLiteSearch()
+	if not (search.is_search_enabled() and search.index_exists()):
+		return
+
+	try:
+		search.remove_doc("Wiki Document", docname)
+	except Exception:
+		frappe.log_error(
+			title="Wiki Search Index Removal Error",
+			message=f"Failed to remove Wiki Document {docname} from the search index",
+		)


### PR DESCRIPTION
## Problem

Search results show unpublished/stale documents (part of #697):

1. Pages in **unpublished spaces** appear in search (title + content snippet) even though opening them 404s — the search visibility filter checked space roles but never `Wiki Space.is_published`.
2. **Unpublishing a page** only queues a re-index, drained by a 5-minute scheduler job in batches of 30 — the page keeps showing in search until the queue catches up (indefinitely if the queue backs up, e.g. after a large git sync).
3. **Content-only CR merges** write with raw `frappe.db.set_value`, skipping the on_update hook that queues re-indexing — search serves pre-merge content forever (until a full index rebuild).

## Solution

1. The query-time filter in `search.search` now mirrors page rendering: a hit's space must be published **and** readable by the current user.
2. On unpublish, the document's search index row is deleted synchronously (`remove_doc_from_index`) instead of waiting for the queue.
3. Content-only merges now queue the touched documents for re-indexing explicitly (`enqueue_reindex`).

Regression tests included for all three (each verified to fail without its fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PXJnZXUyt5vyE7DiuLnD3
