### PR TITLE
fix: don't flag valid third-party links as broken (#575)

### DIFF
--- a/wiki/wiki/report/wiki_broken_links/test_broken_link_checker.py
+++ b/wiki/wiki/report/wiki_broken_links/test_broken_link_checker.py
@@ -1,12 +1,19 @@
 # Copyright (c) 2024, Frappe and Contributors
 # See license.txt
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from wiki.wiki.report.wiki_broken_links.wiki_broken_links import execute, get_broken_links
+from wiki.wiki.report.wiki_broken_links import wiki_broken_links
+from wiki.wiki.report.wiki_broken_links.wiki_broken_links import (
+	BROWSER_USER_AGENT,
+	execute,
+	get_broken_links,
+	is_broken_link,
+	is_dead_status,
+)
 
 # RFC 2606 reserved domain: always resolves, never flakes in CI (unlike a real
 # site, which can intermittently be unreachable and get mis-flagged as broken).
@@ -132,3 +139,41 @@ class TestWikiBrokenLinkChecker(FrappeTestCase):
 
 	def tearDown(self):
 		frappe.db.rollback()
+
+
+class TestBrokenLinkStatusClassification(FrappeTestCase):
+	"""Regression tests for issue #575: valid third-party links flagged as broken.
+
+	Sites behind bot protection / auth walls answer with 401/403/405/429 to a bare
+	python-requests call. Only 404 and 5xx responses reliably mean a link is dead.
+	"""
+
+	def test_only_404_and_5xx_are_dead(self):
+		for code in (404, 500, 502, 503, 599):
+			self.assertTrue(is_dead_status(code), f"{code} should be dead")
+
+	def test_bot_protection_and_ok_codes_are_not_dead(self):
+		# 403/405/429 are the exact false positives from the issue screenshots.
+		for code in (200, 301, 401, 403, 405, 429):
+			self.assertFalse(is_dead_status(code), f"{code} should not be dead")
+
+	def test_403_is_not_broken(self):
+		with patch.object(wiki_broken_links, "get_request_status_code", return_value=403):
+			self.assertFalse(is_broken_link("https://en.wikipedia.org/wiki/Incoterms"))
+
+	def test_404_is_broken(self):
+		with patch.object(wiki_broken_links, "get_request_status_code", return_value=404):
+			self.assertTrue(is_broken_link("https://erp.fairkom.net/cloud/fairlogin-client"))
+
+	def test_unreachable_host_is_broken(self):
+		# An exception means the host can't be reached at all (DNS failure,
+		# refused/reset connection, timeout) — a genuinely broken link.
+		with patch.object(wiki_broken_links, "get_request_status_code", side_effect=Exception("boom")):
+			self.assertTrue(is_broken_link("https://frappewiki.notavalidtld"))
+
+	def test_request_sends_browser_user_agent(self):
+		# The default python-requests UA is what got these links blocked.
+		response = MagicMock(status_code=200)
+		with patch.object(wiki_broken_links.requests, "head", return_value=response) as mock_head:
+			wiki_broken_links.get_request_status_code("https://en.wikipedia.org/wiki/Incoterms")
+		self.assertEqual(mock_head.call_args.kwargs["headers"]["User-Agent"], BROWSER_USER_AGENT)

--- a/wiki/wiki/report/wiki_broken_links/test_broken_link_checker.py
+++ b/wiki/wiki/report/wiki_broken_links/test_broken_link_checker.py
@@ -145,11 +145,13 @@ class TestBrokenLinkStatusClassification(FrappeTestCase):
 	"""Regression tests for issue #575: valid third-party links flagged as broken.
 
 	Sites behind bot protection / auth walls answer with 401/403/405/429 to a bare
-	python-requests call. Only 404 and 5xx responses reliably mean a link is dead.
+	python-requests call. Only 404, 410, and 5xx responses reliably mean a link
+	is dead.
 	"""
 
-	def test_only_404_and_5xx_are_dead(self):
-		for code in (404, 500, 502, 503, 599):
+	def test_missing_and_server_error_codes_are_dead(self):
+		# 410 Gone is a permanent removal and must stay reported (issue #575 review).
+		for code in (404, 410, 500, 502, 503, 599):
 			self.assertTrue(is_dead_status(code), f"{code} should be dead")
 
 	def test_bot_protection_and_ok_codes_are_not_dead(self):
@@ -177,3 +179,28 @@ class TestBrokenLinkStatusClassification(FrappeTestCase):
 		with patch.object(wiki_broken_links.requests, "head", return_value=response) as mock_head:
 			wiki_broken_links.get_request_status_code("https://en.wikipedia.org/wiki/Incoterms")
 		self.assertEqual(mock_head.call_args.kwargs["headers"]["User-Agent"], BROWSER_USER_AGENT)
+
+	def test_head_falls_back_to_get_when_inconclusive(self):
+		# A HEAD blocked with 403/405 is retried with GET, which may succeed.
+		head = MagicMock(status_code=405)
+		get = MagicMock(status_code=200)
+		with (
+			patch.object(wiki_broken_links.requests, "head", return_value=head),
+			patch.object(wiki_broken_links.requests, "get", return_value=get) as mock_get,
+		):
+			status = wiki_broken_links.get_request_status_code("https://blocks-head.example")
+		mock_get.assert_called_once()
+		self.assertEqual(status, 200)
+
+	def test_dead_head_is_not_masked_by_bot_blocked_get(self):
+		# A definitively dead HEAD (404/410/5xx) must be trusted as-is; falling
+		# back to a bot-blocked GET (403) would otherwise hide the broken link.
+		head = MagicMock(status_code=404)
+		with (
+			patch.object(wiki_broken_links.requests, "head", return_value=head),
+			patch.object(wiki_broken_links.requests, "get") as mock_get,
+		):
+			status = wiki_broken_links.get_request_status_code("https://gone.example")
+		mock_get.assert_not_called()
+		self.assertEqual(status, 404)
+		self.assertTrue(is_dead_status(status))

--- a/wiki/wiki/report/wiki_broken_links/wiki_broken_links.py
+++ b/wiki/wiki/report/wiki_broken_links/wiki_broken_links.py
@@ -148,19 +148,21 @@ def is_broken_link(url: str) -> bool:
 
 
 def is_dead_status(status_code: int) -> bool:
-	# Only "Not Found" and server errors reliably mean a link is dead. Codes like
-	# 401/403/405/429 usually indicate auth walls or bot protection on pages that
-	# are otherwise valid, so they must not be treated as broken.
-	return status_code == 404 or 500 <= status_code <= 599
+	# 404 Not Found and 410 Gone mean the page is definitively missing, and 5xx
+	# means the server is failing. Codes like 401/403/405/429 usually indicate
+	# auth walls or bot protection on pages that are otherwise valid, so they
+	# must not be treated as broken.
+	return status_code in (404, 410) or 500 <= status_code <= 599
 
 
 def get_request_status_code(url: str) -> int:
 	headers = {"User-Agent": BROWSER_USER_AGENT}
-	# Try HEAD first (faster), fall back to GET if HEAD fails
-	# Many sites block HEAD requests or return 403/405
+	# Try HEAD first (faster). Many sites block HEAD or answer it with 403/405,
+	# so retry with GET only when HEAD was inconclusive. A HEAD that already
+	# reports the link dead (404/410/5xx) is trusted as-is, otherwise a
+	# bot-blocked GET could mask a genuinely broken link.
 	response = requests.head(url, headers=headers, verify=False, timeout=5, allow_redirects=True)
-	if response.status_code >= 400:
-		# HEAD failed, try GET request
+	if response.status_code >= 400 and not is_dead_status(response.status_code):
 		response = requests.get(
 			url, headers=headers, verify=False, timeout=5, allow_redirects=True, stream=True
 		)

--- a/wiki/wiki/report/wiki_broken_links/wiki_broken_links.py
+++ b/wiki/wiki/report/wiki_broken_links/wiki_broken_links.py
@@ -127,23 +127,42 @@ def is_hash_link(url: str) -> bool:
 	return url.startswith("#")
 
 
+# Sent with every check so sites don't reject us as a bot. The default
+# python-requests User-Agent is widely blocked, which made valid third-party
+# links respond with 403/405/429 and get mis-flagged as broken.
+BROWSER_USER_AGENT = (
+	"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+	"(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+
+
 def is_broken_link(url: str) -> bool:
 	try:
 		status_code = get_request_status_code(url)
-		if status_code >= 400:
-			return True
 	except Exception:
+		# Host unreachable (DNS failure, refused/reset connection, timeout):
+		# the link can't be loaded at all, so treat it as broken.
 		return True
 
-	return False
+	return is_dead_status(status_code)
+
+
+def is_dead_status(status_code: int) -> bool:
+	# Only "Not Found" and server errors reliably mean a link is dead. Codes like
+	# 401/403/405/429 usually indicate auth walls or bot protection on pages that
+	# are otherwise valid, so they must not be treated as broken.
+	return status_code == 404 or 500 <= status_code <= 599
 
 
 def get_request_status_code(url: str) -> int:
+	headers = {"User-Agent": BROWSER_USER_AGENT}
 	# Try HEAD first (faster), fall back to GET if HEAD fails
 	# Many sites block HEAD requests or return 403/405
-	response = requests.head(url, verify=False, timeout=5, allow_redirects=True)
+	response = requests.head(url, headers=headers, verify=False, timeout=5, allow_redirects=True)
 	if response.status_code >= 400:
 		# HEAD failed, try GET request
-		response = requests.get(url, verify=False, timeout=5, allow_redirects=True, stream=True)
+		response = requests.get(
+			url, headers=headers, verify=False, timeout=5, allow_redirects=True, stream=True
+		)
 		response.close()  # Close connection immediately, we only need status code
 	return response.status_code


### PR DESCRIPTION
## Problem

The Wiki Broken Links report flags valid third-party links (Wikipedia, Zendesk help centers, Cloudflare-fronted sites, etc.) as broken. Fixes #575.

## Solution

Two causes, both fixed in `wiki_broken_links.py`:

1. **No `User-Agent`.** Requests went out as `python-requests/x.y`, which many sites reject with `401/403/405/429`. Now sends a browser `User-Agent`.
2. **Any `status >= 400` counted as broken.** Auth walls and bot-protection responses are not dead links. Now only `404` and `5xx` are treated as dead; unreachable hosts (DNS / connection / timeout errors) still count as broken.

Verified against the exact links from the issue screenshots: `en.wikipedia.org/wiki/Incoterms`, `support.sendcloud.com/...`, `support-my.plaid.com/hc/en-us` etc. flip from falsely-broken to OK, while genuinely dead links (404) stay flagged.

Regression tests cover the status classification and that the browser `User-Agent` is sent.