### PR TITLE
test(editor): cover markdown paste rendering (#609)

### DIFF
--- a/e2e/tests/markdown-paste.spec.ts
+++ b/e2e/tests/markdown-paste.spec.ts
@@ -1,0 +1,147 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Regression coverage for frappe/wiki#609:
+ * "When copy pasting markdown text, wiki editor does not render it automatically."
+ *
+ * The editor's `handlePaste` (WikiEditor.vue) treats plain-text-only clipboard
+ * payloads as markdown, so pasting `# Heading` or `**bold**` renders instead of
+ * staying literal. When the clipboard also carries HTML (Word, Google Docs, web
+ * pages) the default ProseMirror handler keeps the rich formatting untouched.
+ */
+test.describe('Markdown Paste (#609)', () => {
+	/**
+	 * Navigate to a space and create a new page, returning the editor locator.
+	 * Mirrors the harness used by markdown-breaks.spec.ts.
+	 */
+	async function createPageAndOpenEditor(
+		page: import('@playwright/test').Page,
+		pageTitle: string,
+	) {
+		await page.goto('/wiki');
+		await page.waitForLoadState('networkidle');
+
+		const spaceLink = page.locator('a[href*="/wiki/spaces/"]').first();
+		await expect(spaceLink).toBeVisible({ timeout: 5000 });
+		await spaceLink.click();
+		await page.waitForLoadState('networkidle');
+
+		const createFirstPage = page.locator(
+			'button:has-text("Create First Page")',
+		);
+		const newPageButton = page.locator('button[title="New Page"]');
+
+		if (await createFirstPage.isVisible({ timeout: 2000 }).catch(() => false)) {
+			await createFirstPage.click();
+		} else {
+			await newPageButton.click();
+		}
+
+		await page.getByLabel('Title').fill(pageTitle);
+		await page
+			.getByRole('dialog')
+			.getByRole('button', { name: 'Save' })
+			.click();
+		await page.waitForLoadState('networkidle');
+
+		const pageTitleInput = page.getByRole('textbox', { name: 'Page title' });
+		const openedCreatedPage = await pageTitleInput
+			.inputValue({ timeout: 2000 })
+			.then((value) => value === pageTitle)
+			.catch(() => false);
+		if (!openedCreatedPage) {
+			await page.locator('aside').getByText(pageTitle, { exact: true }).click();
+		}
+		await expect(pageTitleInput).toHaveValue(pageTitle, { timeout: 10000 });
+
+		const editor = page.locator('.ProseMirror, [contenteditable="true"]');
+		await expect(editor).toBeVisible({ timeout: 10000 });
+		return editor;
+	}
+
+	/**
+	 * Fire a real `paste` ClipboardEvent at the ProseMirror DOM node so the
+	 * editor's own `handlePaste` runs — exactly the path a user's Cmd+V takes.
+	 * `html` is optional; omitting it reproduces the plain-text-only clipboard
+	 * that issue #609 is about.
+	 */
+	async function pasteIntoEditor(
+		page: import('@playwright/test').Page,
+		text: string,
+		html?: string,
+	) {
+		return page.evaluate(
+			({ text, html }) => {
+				const dom = document.querySelector('.ProseMirror') as
+					| (HTMLElement & { editor?: { getHTML: () => string } })
+					| null;
+				if (!dom) return { error: 'editor not found' };
+				dom.focus();
+
+				const dt = new DataTransfer();
+				dt.setData('text/plain', text);
+				if (html) dt.setData('text/html', html);
+
+				dom.dispatchEvent(
+					new ClipboardEvent('paste', {
+						clipboardData: dt,
+						bubbles: true,
+						cancelable: true,
+					}),
+				);
+
+				return { html: dom.editor?.getHTML() ?? dom.innerHTML };
+			},
+			{ text, html },
+		);
+	}
+
+	test('pasting plain-text markdown renders it (headings, bold, list)', async ({
+		page,
+	}) => {
+		const editor = await createPageAndOpenEditor(
+			page,
+			`md-paste-${Date.now()}`,
+		);
+		await editor.click();
+
+		const result = await pasteIntoEditor(
+			page,
+			'# Heading One\n\n**bold** and *italic*\n\n- item 1\n- item 2',
+		);
+
+		expect(result).not.toHaveProperty('error');
+		// Before the #609 fix this stayed literal (a plain paragraph of the raw
+		// markdown source); now each construct renders to real nodes.
+		expect(result.html).toContain('<h1>Heading One</h1>');
+		expect(result.html).toContain('<strong>bold</strong>');
+		expect(result.html).toContain('<em>italic</em>');
+		expect(result.html).toMatch(/<ul>.*<li>.*item 1.*<\/li>.*<li>.*item 2/s);
+		// The raw markdown markers must NOT survive as literal text.
+		expect(result.html).not.toContain('# Heading One');
+		expect(result.html).not.toContain('**bold**');
+	});
+
+	test('pasting rich HTML keeps its formatting (does not re-parse as markdown)', async ({
+		page,
+	}) => {
+		const editor = await createPageAndOpenEditor(
+			page,
+			`md-paste-html-${Date.now()}`,
+		);
+		await editor.click();
+
+		// A Google-Docs-style clipboard: both text/plain and text/html present.
+		// The plain-text side carries markdown-looking asterisks that must NOT be
+		// interpreted — the HTML side wins and its <strong> is preserved verbatim.
+		const result = await pasteIntoEditor(
+			page,
+			'**not markdown**',
+			'<p><strong>rich bold</strong></p>',
+		);
+
+		expect(result).not.toHaveProperty('error');
+		expect(result.html).toContain('<strong>rich bold</strong>');
+		expect(result.html).not.toContain('not markdown');
+	});
+});

--- a/frontend/src/components/tiptap-extensions/markdown-paste.test.js
+++ b/frontend/src/components/tiptap-extensions/markdown-paste.test.js
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { MarkdownManager } from '@tiptap/markdown';
+
+import { wikiStarterKit } from './wiki-starterkit.js';
+
+/**
+ * Regression coverage for frappe/wiki#609:
+ * "When copy pasting markdown text, wiki editor does not render it automatically."
+ *
+ * WikiEditor.vue's `handlePaste` routes a plain-text-only clipboard through
+ * `insertContent(text, { contentType: 'markdown' })`. Under the hood that runs
+ * the markdown source through the same MarkdownManager built here, so a paste of
+ * `# Heading` / `**bold**` must yield real heading/bold/list nodes rather than a
+ * paragraph of literal source. This pins that parse step against the editor's
+ * real extension set (wikiStarterKit), no DOM required — same style as
+ * link-markdown.test.js.
+ */
+function buildManager() {
+	const starterKit = wikiStarterKit();
+	const baseExtensions = starterKit.config.addExtensions.call({
+		options: starterKit.options,
+		name: 'starterKit',
+	});
+	return new MarkdownManager({
+		extensions: baseExtensions,
+		markedOptions: { breaks: true },
+	});
+}
+
+/** Collect every node `type` present anywhere in a TipTap JSON doc. */
+function nodeTypes(node, acc = new Set()) {
+	if (!node || typeof node !== 'object') return acc;
+	if (node.type) acc.add(node.type);
+	for (const child of node.content ?? []) nodeTypes(child, acc);
+	return acc;
+}
+
+/** Collect every mark `type` applied to any text node in the doc. */
+function markTypes(node, acc = new Set()) {
+	if (!node || typeof node !== 'object') return acc;
+	for (const mark of node.marks ?? []) acc.add(mark.type);
+	for (const child of node.content ?? []) markTypes(child, acc);
+	return acc;
+}
+
+/** Concatenate every text run in the doc. */
+function textContent(node, parts = []) {
+	if (!node || typeof node !== 'object') return parts;
+	if (typeof node.text === 'string') parts.push(node.text);
+	for (const child of node.content ?? []) textContent(child, parts);
+	return parts;
+}
+
+test('pasted markdown parses headings, bold, italic and lists into rich nodes (#609)', () => {
+	const doc = buildManager().parse(
+		'# Heading One\n\n**bold** and *italic*\n\n- item 1\n- item 2',
+	);
+
+	const nodes = nodeTypes(doc);
+	const marks = markTypes(doc);
+
+	assert.ok(nodes.has('heading'), 'expected a heading node');
+	assert.ok(nodes.has('bulletList'), 'expected a bulletList node');
+	assert.ok(nodes.has('listItem'), 'expected listItem nodes');
+	assert.ok(marks.has('bold'), 'expected a bold mark');
+	assert.ok(marks.has('italic'), 'expected an italic mark');
+});
+
+test('raw markdown markers do not survive as literal text (#609)', () => {
+	const doc = buildManager().parse('# Heading One\n\n**bold** and *italic*');
+	const text = textContent(doc).join('');
+
+	// The pre-fix bug: the whole thing stayed as a literal paragraph.
+	assert.ok(!text.includes('#'), `'#' leaked as literal text: ${text}`);
+	assert.ok(!text.includes('**'), `'**' leaked as literal text: ${text}`);
+	// The words themselves survive, unwrapped from their markers.
+	assert.ok(text.includes('Heading One'));
+	assert.ok(text.includes('bold'));
+	assert.ok(text.includes('italic'));
+});


### PR DESCRIPTION
## Problem

[#609](https://github.com/frappe/wiki/issues/609): pasting plain-text markdown (`# Heading`, `**bold**`, `- item`) into the wiki editor left it literal instead of rendering. The fix already landed (`WikiEditor.vue` `handlePaste` routes a plain-text-only clipboard through `insertContent(text, { contentType: 'markdown' })`), but there was no test guarding it.

## Solution

Add regression coverage — no product code change.

- **`e2e/tests/markdown-paste.spec.ts`** — fires a real `paste` ClipboardEvent at the ProseMirror node, exercising `handlePaste` end-to-end. Confirmed it **fails** when the fix is reverted (heading/list markers stay literal) and **passes** with the fix. Also covers the guard branch: a clipboard carrying `text/html` keeps its rich formatting untouched.
- **`markdown-paste.test.js`** — pins the underlying `MarkdownManager` parse against the editor's real `wikiStarterKit` extension set, no DOM required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)