### PR TITLE
feat: add "Published pages only" filter to Broken Links report

### DIFF
--- a/wiki/wiki/report/wiki_broken_links/test_broken_link_checker.py
+++ b/wiki/wiki/report/wiki_broken_links/test_broken_link_checker.py
@@ -137,6 +137,35 @@ class TestWikiBrokenLinkChecker(FrappeTestCase):
 		self.assertIn(BROKEN_EXTERNAL_URL, broken_links)
 		self.assertIn(BROKEN_INTERNAL_URL, broken_links)
 
+	def test_published_only_excludes_unpublished(self):
+		# self.test_wiki_document is unpublished (is_published defaults to 0)
+		_, data = execute({"published_only": 1})
+		doc_names = [d["wiki_document"] for d in data]
+		self.assertNotIn(self.test_wiki_document.name, doc_names)
+
+	def test_published_pages_still_reported(self):
+		published_doc = frappe.get_doc(
+			{
+				"doctype": "Wiki Document",
+				"content": TEST_MD_WITH_BROKEN_LINK,
+				"title": "Published Wiki Document",
+				"parent_wiki_document": self.root_group.name,
+				"is_published": 1,
+			}
+		).insert()
+
+		_, data = execute({"published_only": 1})
+		test_data = [d for d in data if d["wiki_document"] == published_doc.name]
+		self.assertEqual(len(test_data), 1)
+		self.assertEqual(test_data[0]["broken_link"], BROKEN_EXTERNAL_URL)
+
+	def test_published_only_disabled_includes_unpublished(self):
+		# Toggling the filter off must surface broken links on unpublished pages
+		_, data = execute({"published_only": 0})
+		test_data = [d for d in data if d["wiki_document"] == self.test_wiki_document.name]
+		self.assertEqual(len(test_data), 1)
+		self.assertEqual(test_data[0]["broken_link"], BROKEN_EXTERNAL_URL)
+
 	def tearDown(self):
 		frappe.db.rollback()
 

--- a/wiki/wiki/report/wiki_broken_links/wiki_broken_links.js
+++ b/wiki/wiki/report/wiki_broken_links/wiki_broken_links.js
@@ -21,5 +21,11 @@ frappe.query_reports['Wiki Broken Links'] = {
 			fieldtype: 'Check',
 			default: 0,
 		},
+		{
+			fieldname: 'published_only',
+			label: __('Published pages only?'),
+			fieldtype: 'Check',
+			default: 1,
+		},
 	],
 };

--- a/wiki/wiki/report/wiki_broken_links/wiki_broken_links.py
+++ b/wiki/wiki/report/wiki_broken_links/wiki_broken_links.py
@@ -52,7 +52,9 @@ def get_data(filters: dict | None = None) -> list[list]:
 
 	data = []
 
-	wiki_documents = frappe.db.get_all("Wiki Document", fields=["name", "content"])
+	doc_filters = {}
+	if filters and filters.get("published_only"):
+		doc_filters["is_published"] = 1
 
 	if filters and filters.get("wiki_space"):
 		wiki_space = filters.get("wiki_space")
@@ -61,15 +63,18 @@ def get_data(filters: dict | None = None) -> list[list]:
 			# Get all descendants of the root group
 			descendants = get_descendants_of("Wiki Document", space_doc.root_group, ignore_permissions=True)
 			if descendants:
+				doc_filters["name"] = ("in", descendants)
 				wiki_documents = frappe.db.get_all(
 					"Wiki Document",
 					fields=["name", "content"],
-					filters={"name": ("in", descendants)},
+					filters=doc_filters,
 				)
 			else:
 				wiki_documents = []
 		else:
 			wiki_documents = []
+	else:
+		wiki_documents = frappe.db.get_all("Wiki Document", fields=["name", "content"], filters=doc_filters)
 
 	include_images = filters and bool(filters.get("check_images"))
 	check_internal_links = filters and bool(filters.get("check_internal_links"))


### PR DESCRIPTION
## Problem

The Wiki Broken Links report scanned **every** Wiki Document — published and unpublished — so broken links on draft pages added noise. Closes #577.

## Solution

Add a `published_only` filter (Check, **default on**) to the report. When enabled, `get_data` restricts the scan to documents where `is_published = 1`. Wired into both the Desk filter config (`.js`) and the backend query (`.py`), with unit tests covering exclude / include / toggle-off behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)