### PR TITLE
feat: auto-generated meta (OG) images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ test-results/
 e2e/.auth/
 .env
 screenshots/
+
+# Local design tool for the generated OG card (/og_playground) — renders the
+# real template with live dials. Handy while iterating, not something to ship.
+wiki/www/og_playground.py
+wiki/www/og_playground.html

--- a/e2e/tests/generated-og-image.spec.ts
+++ b/e2e/tests/generated-og-image.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test } from '@playwright/test';
+import { createDoc, getDoc } from '../helpers/frappe';
+import {
+	type WikiSpace,
+	cleanupWikiSpacesByRoute,
+	createTestWikiDocument,
+} from '../helpers/wiki';
+
+/**
+ * Auto-generated OG (meta) images.
+ *
+ * A page with no uploaded meta_image emits an og:image pointing at
+ * wiki.api.og_image.og_image, which screenshots a branded card with the
+ * server-side headless Chromium. This is the only place that renderer is
+ * exercised for real — every Python test patches it, since CI installs no
+ * server-side Chromium.
+ *
+ * That renderer is therefore not guaranteed on the CI site: a 503 (another
+ * worker holds the render lock) or a 404 (the render failed and is negatively
+ * cached) is treated as "renderer unavailable" and skips the byte assertions.
+ * The og:image tag itself is asserted unconditionally — that part is pure
+ * template work and must never regress.
+ */
+test.describe('Generated OG image', () => {
+	const route = `generated-og-${Date.now()}`;
+	let pageUrl: string;
+
+	test.beforeAll(async ({ request }) => {
+		const space = await createDoc<WikiSpace & { root_group: string }>(
+			request,
+			'Wiki Space',
+			{
+				route,
+				space_name: route,
+				is_published: true,
+				// Guest Read makes the card reachable by an anonymous scraper.
+				roles: [{ role: 'Guest', permission_level: 'Read' }],
+			},
+		);
+
+		const doc = await createTestWikiDocument(request, {
+			title: 'Generated OG Page',
+			content: '# Heading\n\nReader body content.',
+			is_published: true,
+			wiki_space: space.name,
+			parent_wiki_document: space.root_group,
+		});
+
+		// The controller computes the final stored route; read it back.
+		const stored = await getDoc<{ route: string }>(
+			request,
+			'Wiki Document',
+			doc.name,
+		);
+		pageUrl = `/${stored.route}`;
+	});
+
+	test.afterAll(async ({ request }) => {
+		await cleanupWikiSpacesByRoute(request, route);
+	});
+
+	test('the public page advertises a card the endpoint can actually serve', async ({
+		page,
+		request,
+	}) => {
+		await page.goto(pageUrl);
+
+		const ogImage = await page
+			.locator('meta[property="og:image"]')
+			.getAttribute('content');
+		expect(ogImage).toContain('wiki.api.og_image.og_image');
+		await expect(page.locator('meta[name="twitter:card"]')).toHaveAttribute(
+			'content',
+			'summary_large_image',
+		);
+
+		const response = await request.get(ogImage as string);
+		if (response.status() === 503 || response.status() === 404) {
+			test.skip(true, 'No server-side Chromium on this site');
+		}
+
+		expect(response.status()).toBe(200);
+		expect(response.headers()['content-type']).toBe('image/jpeg');
+		expect((await response.body()).byteLength).toBeGreaterThan(0);
+	});
+});

--- a/e2e/tests/page-settings-meta.spec.ts
+++ b/e2e/tests/page-settings-meta.spec.ts
@@ -86,6 +86,12 @@ test.describe('Page Settings meta fields', () => {
 		await expect(saveButton).toBeEnabled();
 
 		await saveButton.click();
+		// The dialog deliberately stays open on save: saving is what regenerates
+		// the social preview, so closing would hide the thing that just changed.
+		// Save disabling itself is the signal the write landed.
+		await expect(saveButton).toBeDisabled({ timeout: 10000 });
+		await expect(dialog).toBeVisible();
+		await dialog.getByRole('button', { name: 'Cancel' }).click();
 		await expect(dialog).not.toBeVisible({ timeout: 10000 });
 
 		// Reopen — values must have persisted to the Wiki Document.
@@ -129,6 +135,8 @@ test.describe('Page Settings meta fields', () => {
 		await dialog.getByLabel('Meta Description').fill('');
 		await expect(saveButton).toBeEnabled();
 		await saveButton.click();
+		await expect(saveButton).toBeDisabled({ timeout: 10000 });
+		await dialog.getByRole('button', { name: 'Cancel' }).click();
 		await expect(dialog).not.toBeVisible({ timeout: 10000 });
 
 		await page.goto(`/${doc.route}`);

--- a/frontend/src/components/PageSettings.vue
+++ b/frontend/src/components/PageSettings.vue
@@ -267,9 +267,7 @@ async function saveSettings() {
 			meta_image: metaImage.value,
 		});
 		toast.success(__('Page settings saved'));
-		// Stay open: saving is what regenerates the social preview, so closing
-		// here would hide the one thing the user just changed. Save disables
-		// itself once the form matches the saved doc.
+		// Retry a preview that failed before this save fixed its inputs.
 		previewImageFailed.value = false;
 		previewVersion.value += 1;
 	} catch (error) {

--- a/frontend/src/components/PageSettings.vue
+++ b/frontend/src/components/PageSettings.vue
@@ -84,16 +84,29 @@
 						class="flex flex-col self-start w-full overflow-hidden rounded-md border border-outline-gray-2"
 					>
 						<div
-							class="flex h-28 w-full flex-shrink-0 items-center justify-center bg-surface-gray-2"
+							class="relative flex h-28 w-full flex-shrink-0 items-center justify-center bg-surface-gray-2"
 						>
 							<img
 								v-if="previewImage"
 								:src="previewImage"
 								alt=""
 								class="h-full w-full object-cover"
+								:class="{ 'opacity-0': previewImageLoading }"
+								@load="previewImageLoading = false"
 								@error="previewImageFailed = true"
 							/>
-							<span v-else class="lucide-image h-7 w-7 text-ink-gray-3" aria-hidden="true" />
+							<span
+								v-else
+								class="lucide-image h-7 w-7 text-ink-gray-3"
+								aria-hidden="true"
+							/>
+							<!-- A cold card takes a Chromium launch to render, so the
+							     placeholder icon would otherwise sit there looking like
+							     "no image" for seconds. -->
+							<div
+								v-if="previewImage && previewImageLoading"
+								class="absolute inset-0 animate-pulse bg-surface-gray-3"
+							/>
 						</div>
 						<div class="flex flex-col gap-1 border-t border-outline-gray-2 p-3">
 							<span class="truncate text-xs text-ink-gray-4">
@@ -196,9 +209,15 @@ const generatedPreview = computed(() => {
 });
 
 const previewImageFailed = ref(false);
+const previewImageLoading = ref(true);
 const previewImage = computed(() => {
 	if (metaImage.value) return metaImage.value;
 	return previewImageFailed.value ? '' : generatedPreview.value;
+});
+
+// Every new URL is a fresh load, so the skeleton comes back until it decodes.
+watch(previewImage, (url) => {
+	previewImageLoading.value = Boolean(url);
 });
 const isGeneratedPreview = computed(
 	() => !metaImage.value && Boolean(previewImage.value),
@@ -225,6 +244,7 @@ watch(show, (isOpen) => {
 	// Retry the generated card on each open; a render that failed once (cold
 	// Chromium, another worker holding the lock) usually succeeds next time.
 	previewImageFailed.value = false;
+	previewImageLoading.value = true;
 });
 
 function pickImage() {

--- a/frontend/src/components/PageSettings.vue
+++ b/frontend/src/components/PageSettings.vue
@@ -87,10 +87,11 @@
 							class="flex h-28 w-full flex-shrink-0 items-center justify-center bg-surface-gray-2"
 						>
 							<img
-								v-if="metaImage"
-								:src="metaImage"
+								v-if="previewImage"
+								:src="previewImage"
 								alt=""
 								class="h-full w-full object-cover"
+								@error="previewImageFailed = true"
 							/>
 							<span v-else class="lucide-image h-7 w-7 text-ink-gray-3" aria-hidden="true" />
 						</div>
@@ -112,6 +113,9 @@
 							</span>
 						</div>
 					</div>
+					<p v-if="isGeneratedPreview" class="text-xs text-ink-gray-4">
+						{{ __('Auto-generated from the page metadata. Upload an image to override it.') }}
+					</p>
 				</div>
 			</div>
 		</template>
@@ -169,6 +173,27 @@ const previewRoute = computed(() => props.docResource.doc?.route || '');
 const previewTitle = computed(() => metaTitle.value || currentTitle.value);
 const previewDescription = computed(() => metaDescription.value);
 
+// With no uploaded image the page still ships an og:image — the generated card
+// from wiki/api/og_image.py. Preview the real endpoint rather than a mock, so
+// what this box shows is literally what a scraper will fetch. The endpoint 404s
+// for every case that emits no card (setting off, unpublished, group, external
+// link, no space, render failure), which is what the @error fallback catches —
+// no need to duplicate those conditions here.
+const generatedPreview = computed(() => {
+	const route = previewRoute.value;
+	if (!route) return '';
+	return `/api/method/wiki.api.og_image.og_image?route=${encodeURIComponent(route)}`;
+});
+
+const previewImageFailed = ref(false);
+const previewImage = computed(() => {
+	if (metaImage.value) return metaImage.value;
+	return previewImageFailed.value ? '' : generatedPreview.value;
+});
+const isGeneratedPreview = computed(
+	() => !metaImage.value && Boolean(previewImage.value),
+);
+
 const isDirty = computed(() => {
 	const doc = props.docResource.doc;
 	if (!doc) return false;
@@ -187,6 +212,9 @@ watch(show, (isOpen) => {
 	metaTitle.value = doc?.meta_title || '';
 	metaDescription.value = doc?.meta_description || '';
 	metaImage.value = doc?.meta_image || '';
+	// Retry the generated card on each open; a render that failed once (cold
+	// Chromium, another worker holding the lock) usually succeeds next time.
+	previewImageFailed.value = false;
 });
 
 function pickImage() {

--- a/frontend/src/components/PageSettings.vue
+++ b/frontend/src/components/PageSettings.vue
@@ -179,10 +179,20 @@ const previewDescription = computed(() => metaDescription.value);
 // for every case that emits no card (setting off, unpublished, group, external
 // link, no space, render failure), which is what the @error fallback catches —
 // no need to duplicate those conditions here.
+// Bumped on each successful save. `v` is ignored server-side (the endpoint
+// always recomputes the fingerprint) and exists only to force the browser to
+// refetch — the img otherwise keeps whatever bytes it got, and a request that
+// raced the save would leave a stale card on screen for the rest of the
+// session. Bumping per *save* rather than per keystroke keeps it to one extra
+// render, instead of launching Chromium on every character typed.
+const previewVersion = ref(0);
+
 const generatedPreview = computed(() => {
-	const route = previewRoute.value;
-	if (!route) return '';
-	return `/api/method/wiki.api.og_image.og_image?route=${encodeURIComponent(route)}`;
+	const doc = props.docResource.doc;
+	if (!doc?.route) return '';
+	return `/api/method/wiki.api.og_image.og_image?route=${encodeURIComponent(
+		doc.route,
+	)}&v=${previewVersion.value}`;
 });
 
 const previewImageFailed = ref(false);
@@ -257,7 +267,11 @@ async function saveSettings() {
 			meta_image: metaImage.value,
 		});
 		toast.success(__('Page settings saved'));
-		show.value = false;
+		// Stay open: saving is what regenerates the social preview, so closing
+		// here would hide the one thing the user just changed. Save disables
+		// itself once the form matches the saved doc.
+		previewImageFailed.value = false;
+		previewVersion.value += 1;
 	} catch (error) {
 		toast.error(error.messages?.[0] || __('Error saving page settings'));
 	}

--- a/frontend/src/components/SpaceSettings/GeneralPanel.vue
+++ b/frontend/src/components/SpaceSettings/GeneralPanel.vue
@@ -25,6 +25,44 @@
 		</SettingsRow>
 
 		<SettingsRow
+			:title="__('Space Logo')"
+			:description="
+				__('Shown in the reader header and on generated social preview images')
+			"
+		>
+			<div class="flex items-center gap-3">
+				<div
+					class="flex h-10 w-16 shrink-0 items-center justify-center overflow-hidden rounded border border-outline-gray-2 bg-surface-gray-1"
+				>
+					<img
+						v-if="logo"
+						:src="logo"
+						alt=""
+						class="h-full w-full object-contain"
+					/>
+					<span
+						v-else
+						class="lucide-image size-4 text-ink-gray-4"
+						aria-hidden="true"
+					/>
+				</div>
+				<Button variant="outline" :loading="uploadingLogo" @click="pickLogo">
+					{{ logo ? __('Replace') : __('Upload') }}
+				</Button>
+				<Button v-if="logo" variant="ghost" theme="red" @click="removeLogo">
+					{{ __('Remove') }}
+				</Button>
+				<input
+					ref="logoInput"
+					type="file"
+					accept="image/*"
+					class="hidden"
+					@change="handleLogoChange"
+				/>
+			</div>
+		</SettingsRow>
+
+		<SettingsRow
 			:title="__('Bulk Update Routes')"
 			:description="__('Change the base route for this space and all its pages')"
 		>
@@ -45,7 +83,7 @@
 </template>
 
 <script setup>
-import { Button, SettingsRow, Switch } from 'frappe-ui';
+import { Button, SettingsRow, Switch, toast, useFileUpload } from 'frappe-ui';
 import { ref, watch } from 'vue';
 
 const props = defineProps({
@@ -62,12 +100,18 @@ const enableFeedbackCollection = ref(false);
 const updatingPublishSetting = ref(false);
 const updatingFeedbackSetting = ref(false);
 
+const logo = ref('');
+const uploadingLogo = ref(false);
+const logoInput = ref(null);
+const fileUploader = useFileUpload();
+
 watch(
 	() => props.space.doc,
 	(doc) => {
 		if (doc) {
 			isPublished.value = Boolean(doc.is_published);
 			enableFeedbackCollection.value = Boolean(doc.enable_feedback_collection);
+			logo.value = doc.app_switcher_logo || '';
 		}
 	},
 	{ immediate: true },
@@ -82,6 +126,47 @@ async function updatePublishSetting(value) {
 		isPublished.value = !value;
 	} finally {
 		updatingPublishSetting.value = false;
+	}
+}
+
+function pickLogo() {
+	logoInput.value?.click();
+}
+
+async function saveLogo(fileUrl) {
+	const previous = logo.value;
+	logo.value = fileUrl;
+	try {
+		await props.space.setValue.submit({ app_switcher_logo: fileUrl });
+	} catch (error) {
+		logo.value = previous;
+		toast.error(error.messages?.[0] || __('Failed to update logo'));
+	}
+}
+
+function removeLogo() {
+	saveLogo('');
+}
+
+async function handleLogoChange(event) {
+	const file = event.target.files?.[0];
+	// Reset the input so re-selecting the same file still fires `change`.
+	event.target.value = '';
+	if (!file) return;
+
+	uploadingLogo.value = true;
+	try {
+		const result = await fileUploader.upload(file, {
+			// Public: the reader header and the OG card are both anonymous
+			// surfaces, and the card renderer cannot read /private/files.
+			private: false,
+			upload_endpoint: '/api/method/wiki.api.upload_wiki_asset',
+		});
+		await saveLogo(result.file_url);
+	} catch (error) {
+		toast.error(error.messages?.[0] || __('Failed to upload logo'));
+	} finally {
+		uploadingLogo.value = false;
 	}
 }
 

--- a/frontend/src/components/WikiSettings/GeneralPanel.vue
+++ b/frontend/src/components/WikiSettings/GeneralPanel.vue
@@ -15,6 +15,17 @@
 				__('Automatically convert uploaded PNG/JPEG images to WebP to reduce page size')
 			"
 		/>
+
+		<SettingToggle
+			:settings="settings"
+			fieldname="auto_generate_meta_images"
+			:title="__('Auto Generate Meta Images')"
+			:description="
+				__(
+					'Generate a branded social preview image for pages that have no Meta Image uploaded',
+				)
+			"
+		/>
 	</div>
 </template>
 

--- a/specs/generated_meta_images.md
+++ b/specs/generated_meta_images.md
@@ -355,6 +355,37 @@ cd frontend && yarn build
 9. Eyeball the card against the app: title, breadcrumb and space name should read as the same greys
    the reader uses, not a second palette.
 
+## Status — implemented 2026-07-25 (branch `feat/generated-meta-images`)
+
+Phases 0–4 are done, tested and verified against `wiki.localhost`. Phase 5 stays
+future work. Where the code departs from the plan above:
+
+- **`--surface-white` is retired.** frappe-ui's tokens-v2 deliberately drops the
+  legacy alias (`tailwind/figma-tokens-to-theme.js:134`) so straggler usage fails
+  visibly. The template declares `--surface-base` (`neutral/white`, `#ffffff`)
+  instead, and that is the name the drift test asserts.
+- **Title tracking is `0em`, not `-0.02em`.** `typography.json` puts every size at
+  or above the card's scale on `0em`; the spec's negative value was invented.
+  Weight stays `600` (`fontWeight.semibold`).
+- **`generate_og_bytes(ctx)` takes the context, not the doc.** The context *is*
+  the render input and is what the fingerprint hashes, so passing the doc would
+  mean building it twice.
+- **The warm-up skips inserts.** A page nobody has shared has no stale card to
+  replace, and warming every insert would turn a git-sync import of a whole wiki
+  into a Chromium storm — the same bulk pre-generation this spec puts out of
+  scope. Renames, publishes and moves (all updates) are covered.
+- **A patch turns the setting on for existing sites.** A new Check on a Single
+  does not backfill its default, so `auto_generate_meta_images` would read as 0
+  everywhere the doctype already existed. `patches.txt` sets it, mirroring the
+  `auto_convert_images_to_webp` line above it.
+- **The merge warm-up tests live in `test_wiki_change_request.py`**, next to the
+  CR fixtures and `_approve_and_merge` they need, rather than in
+  `test_wiki_document.py`.
+
+The escaping guard and the token-drift guard were both verified by temporarily
+reverting what they protect (dropping `| e` from the title; changing one hex
+value) and confirming each test failed.
+
 ## Risks
 
 1. **Chromium cold start blocks a worker.** The first `ChromiumManager` spin-up is seconds. The lock

--- a/specs/generated_meta_images.md
+++ b/specs/generated_meta_images.md
@@ -381,6 +381,15 @@ future work. Where the code departs from the plan above:
 - **The merge warm-up tests live in `test_wiki_change_request.py`**, next to the
   CR fixtures and `_approve_and_merge` they need, rather than in
   `test_wiki_document.py`.
+- **The endpoint honours the settings toggle too**, not just `get_og_image_url()`.
+  The spec only turned the *tag* off; a crawler holding an old `og:image` URL
+  would still have launched Chromium on a site that disabled cards. The kill
+  switch has to actually kill generation.
+- **Page Settings previews the real card.** The dialog's Social Preview showed a
+  placeholder whenever `meta_image` was empty, which is now wrong — the page does
+  ship an image. It points at the live endpoint (so what the box shows is what a
+  scraper fetches) and falls back to the placeholder on `@error`, which covers
+  every no-card case in one branch instead of duplicating the conditions in JS.
 
 The escaping guard and the token-drift guard were both verified by temporarily
 reverting what they protect (dropping `| e` from the title; changing one hex

--- a/specs/generated_meta_images.md
+++ b/specs/generated_meta_images.md
@@ -39,7 +39,7 @@ of an existing wiki is out of scope.
 
 | | |
 |---|---|
-| Serving | `og:image` → whitelisted `allow_guest` endpoint. Cold hit renders + writes a jpg under `public/files/wiki-og/`; warm hits stream that file. |
+| Serving | `og:image` → whitelisted `allow_guest` endpoint. Cold hit renders + writes a jpg under `private/files/wiki-og/`; warm hits stream that file. |
 | Card content | space logo, breadcrumb trail, page title, space name |
 | Rollout | `Wiki Settings.auto_generate_meta_images` checkbox, default **ON** |
 | Template | hardcoded HTML/CSS, not user-configurable yet; colours and type come from **frappe-ui design tokens** |
@@ -69,7 +69,7 @@ Fingerprint every input the template consumes, and nothing else:
 fp   = sha256("\x1f".join([TEMPLATE_VERSION, meta_title or title, breadcrumb_trail,
                            space_name or "", logo_url or "", str(W), str(H)])).hexdigest()[:12]
 
-path      = <site>/public/files/wiki-og/<doc_key>-<fp>.jpg
+path      = <site>/private/files/wiki-og/<doc_key>-<fp>.jpg
 lock key  = wiki_og_lock:<doc_key>:<fp>     (SET nx ex=90)
 fail key  = wiki_og_fail:<doc_key>:<fp>     (ttl 600)
 og:image  = /api/method/wiki.api.og_image.og_image?route=<route>&v=<fp>
@@ -344,13 +344,13 @@ cd frontend && yarn build
 
 1. Open a published wiki page, view source, confirm `og:image` points at the endpoint with `v=`.
 2. Open that URL directly — a 1200×630 jpg card with logo, breadcrumb, title, space name.
-3. Confirm `sites/wiki.localhost/public/files/wiki-og/<doc_key>-<fp>.jpg` exists; reload and confirm
+3. Confirm `sites/wiki.localhost/private/files/wiki-og/<doc_key>-<fp>.jpg` exists; reload and confirm
    mtime is unchanged (cache hit).
 4. Rename the page → new `v`, new file, old sibling pruned.
 5. Upload a `meta_image` → `og:image` switches back to the upload.
 6. Turn the Wiki Settings toggle off → `og:image` disappears from the head.
 7. `curl -A "facebookexternalhit" …` on the page to confirm the card is fetched anonymously.
-8. Merge a change request that renames a page, then `ls sites/wiki.localhost/public/files/wiki-og/`
+8. Merge a change request that renames a page, then `ls sites/wiki.localhost/private/files/wiki-og/`
    before opening anything — the new fingerprint file is already there, the old one gone.
 9. Eyeball the card against the app: title, breadcrumb and space name should read as the same greys
    the reader uses, not a second palette.
@@ -423,10 +423,11 @@ value) and confirming each test failed.
 5. **Disk cache is per-node.** On a multi-node bench without shared storage each node generates once.
    Bounded and self-healing; a shared byte layer can be added later behind the same
    `_read_cached` / `_write_cached` seam.
-6. **`public/files/wiki-og/` is web-readable.** Filenames embed `doc_key` + fingerprint, so a
-   restricted page's card is reachable by anyone who can guess both. `doc_key` is a 12-char
-   `frappe.generate_hash`, so this is capability-URL security — acceptable for a card containing only
-   a title, but noted.
+6. ~~**`public/files/wiki-og/` is web-readable.**~~ **Resolved during review.** Cards live under
+   `private/files/`, which nginx does not serve, so the endpoint's access check is the only way to
+   reach one. This also closes the case the original wording missed: under `public/files` a card
+   outlived the authorization that produced it, still served statically after the page was
+   unpublished or the space's roles changed.
 7. **Disk growth.** One ~60–150 KB jpg per published page, with stale siblings pruned on write.
 8. **Warm-up job storm.** A structural merge touching N pages enqueues up to N short jobs. Bounded by
    the `job_id` dedupe, the fingerprint diff (unchanged inputs enqueue nothing) and the kill switch —

--- a/specs/generated_meta_images.md
+++ b/specs/generated_meta_images.md
@@ -390,6 +390,11 @@ future work. Where the code departs from the plan above:
   ship an image. It points at the live endpoint (so what the box shows is what a
   scraper fetches) and falls back to the placeholder on `@error`, which covers
   every no-card case in one branch instead of duplicating the conditions in JS.
+  Saving keeps the dialog open — saving is what regenerates the card, so closing
+  would hide the thing that just changed — and bumps a counter in the URL's `v`
+  so the browser refetches. Without that bump a preview request that raced the
+  save left a stale card on screen for the rest of the session; keying the bump
+  to saves rather than keystrokes keeps it to one extra render.
 
 The escaping guard and the token-drift guard were both verified by temporarily
 reverting what they protect (dropping `| e` from the title; changing one hex

--- a/specs/generated_meta_images.md
+++ b/specs/generated_meta_images.md
@@ -196,11 +196,21 @@ In `wiki/api/og_image.py`:
   concurrent writers cannot produce a torn read.
 - `_prune_old(doc_key, keep_fp)` — `glob("<doc_key>-*.jpg")`, unlink the rest. Called after each
   successful write, so the directory holds exactly one file per document.
-- Headers: `Cache-Control: public, max-age=86400, stale-while-revalidate=604800`, `ETag: "<fp>"`,
+- Headers: `Cache-Control: private, max-age=300, stale-while-revalidate=10800`, `ETag: "<fp>"`,
   and a `304` when `If-None-Match` matches.
-  `process_response` (`frappe/app.py:258`) uses `setdefault` for `Cache-Control`, so our value wins;
-  and because it contains `public`, `cookie_manager.flush_cookies` is skipped (`app.py:278`) and the
-  response is CDN-cacheable. Note `frappe._dev_server` force-overrides to no-cache in dev.
+  `process_response` (`frappe/app.py:258`) uses `setdefault` for `Cache-Control`, so our value wins.
+  Note `frappe._dev_server` force-overrides to no-cache in dev.
+
+  **Revised during review — this originally said `public, max-age=86400,
+  stale-while-revalidate=604800`.** That is more permissive than frappe serves
+  the wiki page itself (`private,max-age=300,stale-while-revalidate=10800`, in
+  `frappe/website/utils.py`'s `cache_html`), and the card URL carries no
+  identity: a shared cache would go on serving a card for a day — a week
+  stale — after the page was unpublished or the space's roles changed, with no
+  request reaching `_resolve_doc` again. Matching the page's own policy means a
+  card is never cacheable for longer, or by more parties, than the page whose
+  title it shows. The cost is losing CDN offload, which for one image per
+  shared link is a rounding error.
 - Extend `on_wiki_document_trash` in `wiki_document.py` to drop `wiki-og/<doc_key>-*.jpg`, deferred
   via `frappe.db.after_commit` like `_drop_from_search_index_on_unpublish` (`:881`), so a rollback
   does not delete live files.
@@ -386,6 +396,12 @@ future work. Where the code departs from the plan above:
   `--outline-gray-2` stay declared in the `:root` block — that block is the
   card's palette, and keeping them there keeps the drift test guarding values
   the Phase 5 space accent will want back.
+- **Cards are private-cached and stored under `private/files/`.** Two review
+  findings that turned out to be the same mistake: the card was reachable, and
+  replayable, without the access check the endpoint performs. Both the
+  `Cache-Control` header and the cache directory are corrected above; the
+  principle is that a card must never outlive, or out-reach, the authorization
+  that produced it.
 - **The endpoint honours the settings toggle too**, not just `get_og_image_url()`.
   The spec only turned the *tag* off; a crawler holding an old `og:image` URL
   would still have launched Chromium on a site that disabled cards. The kill

--- a/specs/generated_meta_images.md
+++ b/specs/generated_meta_images.md
@@ -381,6 +381,11 @@ future work. Where the code departs from the plan above:
 - **The merge warm-up tests live in `test_wiki_change_request.py`**, next to the
   CR fixtures and `_approve_and_merge` they need, rather than in
   `test_wiki_document.py`.
+- **No accent bar.** The 12px `--surface-gray-2` bar was dropped during design
+  review; the card is a plain white field. `--surface-gray-2` and
+  `--outline-gray-2` stay declared in the `:root` block — that block is the
+  card's palette, and keeping them there keeps the drift test guarding values
+  the Phase 5 space accent will want back.
 - **The endpoint honours the settings toggle too**, not just `get_og_image_url()`.
   The spec only turned the *tag* off; a crawler holding an old `og:image` URL
   would still have launched Chromium on a site that disabled cards. The kill

--- a/specs/page_settings_meta_fields.md
+++ b/specs/page_settings_meta_fields.md
@@ -114,9 +114,10 @@ context.metatags = MetaTags(self.route, context).tags
 Out of scope (phase-2 backlog): sitemap.xml per space, TechArticle JSON-LD,
 space-level meta defaults (default og image / title suffix), auto-description
 from content excerpt, per-page robots field, folding legacy `head_html` into
-structured settings, generated OG-image endpoint (tailwindcss.com pattern:
-`og:image = /api/og?path=...` renders a branded card per page — checked
-2026-07-03; note Tailwind docs ship meta tags only, zero JSON-LD).
+structured settings.
+
+The generated OG-image endpoint moved out of this backlog and into its own
+spec: `specs/generated_meta_images.md`.
 
 ### Phase 5 — BreadcrumbList JSON-LD (added 2026-07-03)
 

--- a/wiki/api/og_image.py
+++ b/wiki/api/og_image.py
@@ -210,6 +210,75 @@ def generate_og_bytes(ctx: dict) -> bytes:
 	return get_preview_from_html(render_og_html(ctx), format="jpg", width=OG_WIDTH, height=OG_HEIGHT)
 
 
+def _cards_enabled() -> bool:
+	return bool(frappe.get_cached_value("Wiki Settings", "Wiki Settings", "auto_generate_meta_images"))
+
+
+def _has_card(doc) -> tuple[str, str] | None:
+	"""``(path, fingerprint)`` for a document that should have a card, else None."""
+	if doc.is_group or doc.is_external_link or not doc.is_published:
+		return None
+	if not doc.get_wiki_space():
+		return None
+
+	fingerprint = og_fingerprint(_og_context(doc))
+	return _cache_path(doc.doc_key, fingerprint), fingerprint
+
+
+def enqueue_og_warmup(doc) -> None:
+	"""Queue a card render when a write moves the fingerprint.
+
+	Serving stays lazy -- this only means the first crawler after a change is
+	usually a cache hit. Nothing in the page render depends on the job.
+
+	Merges need no special handling: _classify_changes counts title, slug,
+	route, parent_key and is_published as metadata fields, so every change that
+	moves the fingerprint merges through a full doc.save() and lands here. The
+	content-only fast path bypasses hooks, but content is not a fingerprint
+	input, so there is nothing to miss.
+	"""
+	if not _cards_enabled():
+		return
+
+	target = _has_card(doc)
+	if not target:
+		return
+
+	path, _fingerprint = target
+	before = doc.get_doc_before_save()
+	if before and os.path.exists(path):
+		previous = _has_card(before)
+		if previous and previous[0] == path:
+			return
+
+	frappe.enqueue(
+		"wiki.api.og_image.warm_og_image",
+		name=doc.name,
+		queue="short",
+		job_id=f"wiki-og-{doc.name}",
+		deduplicate=True,
+		enqueue_after_commit=True,
+	)
+
+
+def warm_og_image(name: str) -> None:
+	"""Render and cache a document's card ahead of the first request."""
+	if not _cards_enabled():
+		return
+
+	doc = frappe.get_cached_doc("Wiki Document", name)
+	target = _has_card(doc)
+	if not target:
+		return
+
+	path, fingerprint = target
+	if os.path.exists(path):
+		return
+
+	_write_cached(path, generate_og_bytes(_og_context(doc)))
+	_prune_old(doc.doc_key, fingerprint)
+
+
 @frappe.whitelist(allow_guest=True)  # nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method
 def og_image(route: str, v: str | None = None):
 	"""Serve the generated OG card for the page at ``route``.

--- a/wiki/api/og_image.py
+++ b/wiki/api/og_image.py
@@ -292,8 +292,17 @@ def enqueue_og_warmup(doc) -> None:
 	moves the fingerprint merges through a full doc.save() and lands here. The
 	content-only fast path bypasses hooks, but content is not a fingerprint
 	input, so there is nothing to miss.
+
+	Inserts are deliberately left to the lazy path: a page nobody has shared yet
+	has no stale card to replace, and warming every insert would turn a git-sync
+	import of a whole wiki into a Chromium storm. Bulk pre-generation is a
+	separate problem.
 	"""
 	if not _cards_enabled():
+		return
+
+	before = doc.get_doc_before_save()
+	if not before:
 		return
 
 	target = _has_card(doc)
@@ -301,8 +310,7 @@ def enqueue_og_warmup(doc) -> None:
 		return
 
 	path, _fingerprint = target
-	before = doc.get_doc_before_save()
-	if before and os.path.exists(path):
+	if os.path.exists(path):
 		previous = _has_card(before)
 		if previous and previous[0] == path:
 			return

--- a/wiki/api/og_image.py
+++ b/wiki/api/og_image.py
@@ -14,6 +14,10 @@ arbitrary HTML server-side is an SSRF surface), so it is only ever called here
 with HTML we build ourselves.
 """
 
+import glob
+import hashlib
+import os
+
 import frappe
 from frappe import _
 from frappe.utils.preview import get_preview_from_html
@@ -28,6 +32,13 @@ OG_HEIGHT = 630
 
 # Deepest ancestors shown in the card's breadcrumb trail.
 MAX_BREADCRUMB_SEGMENTS = 2
+
+CACHE_DIR_NAME = "wiki-og"
+
+# A day in the browser, a week of serving stale while we regenerate. Contains
+# "public" so frappe's process_response leaves it alone and skips flushing
+# cookies onto what is meant to be a CDN-cacheable response.
+CACHE_CONTROL = "public, max-age=86400, stale-while-revalidate=604800"
 
 
 def _resolve_doc(route: str):
@@ -116,6 +127,74 @@ def _og_context(doc) -> dict:
 	}
 
 
+def og_fingerprint(ctx: dict) -> str:
+	"""Hash exactly the inputs the template consumes, and nothing else.
+
+	Fingerprinting inputs rather than ``modified`` means a content-only edit
+	leaves a still-correct card alone, while a title / breadcrumb / space-name /
+	logo change invalidates on its own -- no invalidation hook anywhere.
+	"""
+	parts = [
+		TEMPLATE_VERSION,
+		ctx["title"],
+		ctx["breadcrumb_trail"],
+		ctx["space_name"],
+		ctx["logo_url"],
+		str(OG_WIDTH),
+		str(OG_HEIGHT),
+	]
+	return hashlib.sha256("\x1f".join(parts).encode()).hexdigest()[:12]
+
+
+def _cache_dir() -> str:
+	path = frappe.get_site_path("public", "files", CACHE_DIR_NAME)
+	os.makedirs(path, exist_ok=True)
+	return path
+
+
+def _cache_path(doc_key: str, fp: str) -> str:
+	return os.path.join(_cache_dir(), f"{doc_key}-{fp}.jpg")
+
+
+def _read_cached(path: str) -> bytes | None:
+	try:
+		with open(path, "rb") as f:
+			return f.read()
+	except FileNotFoundError:
+		return None
+
+
+def _write_cached(path: str, data: bytes) -> None:
+	"""Write through a temp file so a concurrent reader never sees a torn image."""
+	tmp = f"{path}.tmp-{frappe.generate_hash(length=8)}"
+	with open(tmp, "wb") as f:
+		f.write(data)
+	os.replace(tmp, path)
+
+
+def _prune_old(doc_key: str, keep_fp: str) -> None:
+	"""Drop this document's stale cards, so the directory holds one file per page."""
+	keep = _cache_path(doc_key, keep_fp)
+	for path in glob.glob(os.path.join(_cache_dir(), f"{doc_key}-*.jpg")):
+		if path == keep:
+			continue
+		try:
+			os.unlink(path)
+		except OSError:
+			pass
+
+
+def clear_cached_cards(doc_key: str) -> None:
+	"""Remove every cached card for a document (used when it is deleted)."""
+	if not doc_key:
+		return
+	for path in glob.glob(os.path.join(_cache_dir(), f"{doc_key}-*.jpg")):
+		try:
+			os.unlink(path)
+		except OSError:
+			pass
+
+
 def render_og_html(ctx: dict) -> str:
 	"""Render the card markup.
 
@@ -144,9 +223,27 @@ def og_image(route: str, v: str | None = None):
 	``Content-Disposition: attachment``, which no ``og:image`` consumer accepts.
 	"""
 	doc = _resolve_doc(route)
-	data = generate_og_bytes(_og_context(doc))
+	ctx = _og_context(doc)
+	fp = og_fingerprint(ctx)
+	etag = f'"{fp}"'
+
+	if frappe.request and frappe.request.headers.get("If-None-Match") == etag:
+		return _cache_headers(Response(status=304), etag)
+
+	path = _cache_path(doc.doc_key, fp)
+	data = _read_cached(path)
+	if data is None:
+		data = generate_og_bytes(ctx)
+		_write_cached(path, data)
+		_prune_old(doc.doc_key, fp)
 
 	response = Response()
 	response.mimetype = "image/jpeg"
 	response.data = data
+	return _cache_headers(response, etag)
+
+
+def _cache_headers(response: Response, etag: str) -> Response:
+	response.headers["Cache-Control"] = CACHE_CONTROL
+	response.headers["ETag"] = etag
 	return response

--- a/wiki/api/og_image.py
+++ b/wiki/api/og_image.py
@@ -20,6 +20,7 @@ import os
 
 import frappe
 from frappe import _
+from frappe.rate_limiter import rate_limit
 from frappe.utils.preview import get_preview_from_html
 from werkzeug.wrappers import Response
 
@@ -39,6 +40,14 @@ CACHE_DIR_NAME = "wiki-og"
 # "public" so frappe's process_response leaves it alone and skips flushing
 # cookies onto what is meant to be a CDN-cacheable response.
 CACHE_CONTROL = "public, max-age=86400, stale-while-revalidate=604800"
+
+# Long enough to cover a cold Chromium spin-up, short enough that a crashed
+# worker's lock frees itself quickly.
+LOCK_TTL = 90
+
+# How long a failed render is remembered, so later hits short-circuit instead
+# of relaunching Chromium.
+FAILURE_TTL = 600
 
 
 def _resolve_doc(route: str):
@@ -210,6 +219,53 @@ def generate_og_bytes(ctx: dict) -> bytes:
 	return get_preview_from_html(render_og_html(ctx), format="jpg", width=OG_WIDTH, height=OG_HEIGHT)
 
 
+class CardBusy(Exception):
+	"""Another worker holds the render lock for this card."""
+
+
+class CardFailed(Exception):
+	"""Rendering this card failed; the failure is negatively cached."""
+
+
+def _lock_key(doc_key: str, fingerprint: str) -> str:
+	return frappe.cache().make_key(f"wiki_og_lock:{doc_key}:{fingerprint}")
+
+
+def _failure_key(doc_key: str, fingerprint: str) -> str:
+	return frappe.cache().make_key(f"wiki_og_fail:{doc_key}:{fingerprint}")
+
+
+def _generate_and_store(doc_key: str, ctx: dict, fingerprint: str, path: str) -> bytes:
+	"""Render one card, at most once at a time across the whole bench.
+
+	Chromium is expensive and its cold start is measured in seconds, so a
+	crawler wave on a fresh page must not queue every worker behind it: the
+	loser of the lock raises CardBusy and the caller answers 503 rather than
+	waiting. A render that actually fails is remembered for FAILURE_TTL so the
+	next hit short-circuits instead of relaunching Chromium.
+	"""
+	cache = frappe.cache()
+	if cache.get(_failure_key(doc_key, fingerprint)):
+		raise CardFailed
+
+	lock = _lock_key(doc_key, fingerprint)
+	if not cache.set(lock, b"1", nx=True, ex=LOCK_TTL):
+		raise CardBusy
+
+	try:
+		data = generate_og_bytes(ctx)
+	except Exception:
+		cache.set(_failure_key(doc_key, fingerprint), b"1", ex=FAILURE_TTL)
+		frappe.log_error("Wiki OG image generation failed")
+		raise CardFailed
+	finally:
+		cache.delete(lock)
+
+	_write_cached(path, data)
+	_prune_old(doc_key, fingerprint)
+	return data
+
+
 def _cards_enabled() -> bool:
 	return bool(frappe.get_cached_value("Wiki Settings", "Wiki Settings", "auto_generate_meta_images"))
 
@@ -275,11 +331,17 @@ def warm_og_image(name: str) -> None:
 	if os.path.exists(path):
 		return
 
-	_write_cached(path, generate_og_bytes(_og_context(doc)))
-	_prune_old(doc.doc_key, fingerprint)
+	try:
+		# Same lock and failure keys as the request path, so a worker and a
+		# crawler never both launch Chromium for one card.
+		_generate_and_store(doc.doc_key, _og_context(doc), fingerprint, path)
+	except (CardBusy, CardFailed):
+		# Serving never depends on the warm-up; the request path retries.
+		pass
 
 
 @frappe.whitelist(allow_guest=True)  # nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method
+@rate_limit(key="route", limit=60, seconds=60 * 60, ip_based=True)
 def og_image(route: str, v: str | None = None):
 	"""Serve the generated OG card for the page at ``route``.
 
@@ -302,9 +364,15 @@ def og_image(route: str, v: str | None = None):
 	path = _cache_path(doc.doc_key, fp)
 	data = _read_cached(path)
 	if data is None:
-		data = generate_og_bytes(ctx)
-		_write_cached(path, data)
-		_prune_old(doc.doc_key, fp)
+		try:
+			data = _generate_and_store(doc.doc_key, ctx, fp, path)
+		except CardBusy:
+			return _transient_response(503, {"Retry-After": "5"})
+		except CardFailed:
+			# A 404 og:image degrades to "no preview image" everywhere, and the
+			# page render is never in this call path, so a broken Chromium
+			# cannot break a wiki page.
+			return _transient_response(404)
 
 	response = Response()
 	response.mimetype = "image/jpeg"
@@ -315,4 +383,12 @@ def og_image(route: str, v: str | None = None):
 def _cache_headers(response: Response, etag: str) -> Response:
 	response.headers["Cache-Control"] = CACHE_CONTROL
 	response.headers["ETag"] = etag
+	return response
+
+
+def _transient_response(status: int, headers: dict | None = None) -> Response:
+	response = Response(status=status)
+	response.headers["Cache-Control"] = "no-store"
+	for key, value in (headers or {}).items():
+		response.headers[key] = value
 	return response

--- a/wiki/api/og_image.py
+++ b/wiki/api/og_image.py
@@ -26,7 +26,7 @@ from werkzeug.wrappers import Response
 
 # Bumped whenever the card template or its token block changes; it is part of
 # the cache fingerprint, so a bump invalidates every cached card for free.
-TEMPLATE_VERSION = "1"
+TEMPLATE_VERSION = "2"
 
 OG_WIDTH = 1200
 OG_HEIGHT = 630

--- a/wiki/api/og_image.py
+++ b/wiki/api/og_image.py
@@ -17,6 +17,7 @@ with HTML we build ourselves.
 import glob
 import hashlib
 import os
+import re
 
 import frappe
 from frappe import _
@@ -36,10 +37,21 @@ MAX_BREADCRUMB_SEGMENTS = 2
 
 CACHE_DIR_NAME = "wiki-og"
 
+# doc_key names the cache file, so it has to be safe as a path segment.
+# WikiDocument.set_doc_key only enforces immutability on *update* — an insert
+# keeps whatever the caller supplied — so it is not trustworthy input here.
+DOC_KEY_PATTERN = re.compile(r"\A[a-zA-Z0-9]{1,32}\Z")
+
 # A day in the browser, a week of serving stale while we regenerate. Contains
 # "public" so frappe's process_response leaves it alone and skips flushing
 # cookies onto what is meant to be a CDN-cacheable response.
 CACHE_CONTROL = "public, max-age=86400, stale-while-revalidate=604800"
+
+# Only ever sent for a card whose page a Guest could read anyway. A restricted
+# space's card must not sit in a shared cache: the URL carries no identity, so a
+# CDN would keep serving the title and breadcrumbs after access is revoked or
+# the page is unpublished, without the request ever reaching _resolve_doc.
+PRIVATE_CACHE_CONTROL = "private, max-age=300, must-revalidate"
 
 # Long enough to cover a cold Chromium spin-up, short enough that a crashed
 # worker's lock frees itself quickly.
@@ -164,12 +176,24 @@ def _cache_dir() -> str:
 	return path
 
 
+def _is_safe_doc_key(doc_key: str | None) -> bool:
+	return bool(doc_key) and bool(DOC_KEY_PATTERN.match(doc_key))
+
+
 def _cache_path(doc_key: str, fp: str) -> str:
+	"""Build a document's cache path, refusing any key that could escape the
+	cache directory. `fp` is our own sha256 digest; `doc_key` is not ours."""
+	if not _is_safe_doc_key(doc_key):
+		frappe.throw(_("Page not found"), frappe.DoesNotExistError)
 	return os.path.join(_cache_dir(), f"{doc_key}-{fp}.jpg")
 
 
 def _read_cached(path: str) -> bytes | None:
 	try:
+		# nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal
+		# `path` only ever comes from _cache_path, which pins the directory and
+		# validates doc_key against DOC_KEY_PATTERN. The endpoint's `v` param is
+		# never used to look a file up.
 		with open(path, "rb") as f:
 			return f.read()
 	except FileNotFoundError:
@@ -179,15 +203,26 @@ def _read_cached(path: str) -> bytes | None:
 def _write_cached(path: str, data: bytes) -> None:
 	"""Write through a temp file so a concurrent reader never sees a torn image."""
 	tmp = f"{path}.tmp-{frappe.generate_hash(length=8)}"
+	# nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal
+	# Same as _read_cached: `path` is _cache_path output and the suffix is a
+	# generated hash.
 	with open(tmp, "wb") as f:
 		f.write(data)
 	os.replace(tmp, path)
 
 
+def _card_files(doc_key: str) -> list[str]:
+	"""Every cached card belonging to one document; nothing for a key we refuse
+	to put in a glob."""
+	if not _is_safe_doc_key(doc_key):
+		return []
+	return glob.glob(os.path.join(_cache_dir(), f"{doc_key}-*.jpg"))
+
+
 def _prune_old(doc_key: str, keep_fp: str) -> None:
 	"""Drop this document's stale cards, so the directory holds one file per page."""
 	keep = _cache_path(doc_key, keep_fp)
-	for path in glob.glob(os.path.join(_cache_dir(), f"{doc_key}-*.jpg")):
+	for path in _card_files(doc_key):
 		if path == keep:
 			continue
 		try:
@@ -198,9 +233,7 @@ def _prune_old(doc_key: str, keep_fp: str) -> None:
 
 def clear_cached_cards(doc_key: str) -> None:
 	"""Remove every cached card for a document (used when it is deleted)."""
-	if not doc_key:
-		return
-	for path in glob.glob(os.path.join(_cache_dir(), f"{doc_key}-*.jpg")):
+	for path in _card_files(doc_key):
 		try:
 			os.unlink(path)
 		except OSError:
@@ -215,6 +248,9 @@ def render_og_html(ctx: dict) -> str:
 	explicitly with ``| e``. Without it a page titled ``"><img src=http://evil>``
 	would make the screenshotter fetch an attacker-controlled URL.
 	"""
+	# nosemgrep: frappe-semgrep-rules.rules.security.frappe-ssti
+	# The template path is a literal owned by this app; only `ctx` varies, and
+	# every value it carries is escaped in the template.
 	return frappe.render_template("templates/wiki/og_image.html", ctx)
 
 
@@ -374,9 +410,10 @@ def og_image(route: str, v: str | None = None):
 	ctx = _og_context(doc)
 	fp = og_fingerprint(ctx)
 	etag = f'"{fp}"'
+	cache_control = CACHE_CONTROL if _is_anonymously_readable(doc) else PRIVATE_CACHE_CONTROL
 
 	if frappe.request and frappe.request.headers.get("If-None-Match") == etag:
-		return _cache_headers(Response(status=304), etag)
+		return _cache_headers(Response(status=304), etag, cache_control)
 
 	path = _cache_path(doc.doc_key, fp)
 	data = _read_cached(path)
@@ -394,11 +431,21 @@ def og_image(route: str, v: str | None = None):
 	response = Response()
 	response.mimetype = "image/jpeg"
 	response.data = data
-	return _cache_headers(response, etag)
+	return _cache_headers(response, etag, cache_control)
 
 
-def _cache_headers(response: Response, etag: str) -> Response:
-	response.headers["Cache-Control"] = CACHE_CONTROL
+def _is_anonymously_readable(doc) -> bool:
+	"""Whether a Guest could read this page, and so whether its card is safe to
+	hand to a shared cache."""
+	from wiki.permissions import can_read_space
+
+	space = doc.wiki_space or (doc.get_wiki_space() or {}).get("name")
+	# Orphan documents are readable by everyone (check_space_access returns early).
+	return True if not space else can_read_space(space, "Guest")
+
+
+def _cache_headers(response: Response, etag: str, cache_control: str) -> Response:
+	response.headers["Cache-Control"] = cache_control
 	response.headers["ETag"] = etag
 	return response
 

--- a/wiki/api/og_image.py
+++ b/wiki/api/og_image.py
@@ -124,7 +124,10 @@ def _og_context(doc) -> dict:
 	logo_url = ""
 	if wiki_space:
 		space_doc = frappe.get_cached_doc("Wiki Space", wiki_space["name"])
-		logo_url = _safe_asset_url(space_doc.light_mode_logo)
+		# app_switcher_logo is the one the reader header actually renders, so
+		# it is the space's real mark; light_mode_logo is a v2 leftover kept as
+		# a fallback for spaces that only ever set that one.
+		logo_url = _safe_asset_url(space_doc.app_switcher_logo or space_doc.light_mode_logo)
 
 	title = doc.meta_title or doc.title or ""
 	return {

--- a/wiki/api/og_image.py
+++ b/wiki/api/og_image.py
@@ -26,7 +26,7 @@ from werkzeug.wrappers import Response
 
 # Bumped whenever the card template or its token block changes; it is part of
 # the cache fingerprint, so a bump invalidates every cached card for free.
-TEMPLATE_VERSION = "2"
+TEMPLATE_VERSION = "3"
 
 OG_WIDTH = 1200
 OG_HEIGHT = 630

--- a/wiki/api/og_image.py
+++ b/wiki/api/og_image.py
@@ -1,0 +1,152 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+
+"""Auto-generated Open Graph cards for Wiki Documents.
+
+A page with no uploaded ``meta_image`` still deserves a branded link preview, so
+we screenshot a hardcoded HTML card built from the page's own title, breadcrumb
+trail and space branding.
+
+Rendering goes through ``frappe.utils.preview``, which drives the same headless
+Chromium the PDF generator already runs -- no extra dependency and no
+microservice hop. That helper is deliberately *not* whitelisted (screenshotting
+arbitrary HTML server-side is an SSRF surface), so it is only ever called here
+with HTML we build ourselves.
+"""
+
+import frappe
+from frappe import _
+from frappe.utils.preview import get_preview_from_html
+from werkzeug.wrappers import Response
+
+# Bumped whenever the card template or its token block changes; it is part of
+# the cache fingerprint, so a bump invalidates every cached card for free.
+TEMPLATE_VERSION = "1"
+
+OG_WIDTH = 1200
+OG_HEIGHT = 630
+
+# Deepest ancestors shown in the card's breadcrumb trail.
+MAX_BREADCRUMB_SEGMENTS = 2
+
+
+def _resolve_doc(route: str):
+	"""Load the published, readable Wiki Document at ``route``.
+
+	Mirrors the ``download_pdf`` preamble: both access checks raise
+	``DoesNotExistError``, so a restricted page 404s instead of 403ing and we
+	never leak that it exists.
+	"""
+	doc_name = frappe.db.get_value(
+		"Wiki Document", {"route": route, "is_group": 0, "is_external_link": 0}, "name"
+	)
+	if not doc_name:
+		frappe.throw(_("Page not found"), frappe.DoesNotExistError)
+
+	doc = frappe.get_cached_doc("Wiki Document", doc_name)
+	doc.check_space_access("read")
+	doc.check_published()
+	return doc
+
+
+def _safe_asset_url(url: str | None) -> str:
+	"""Allow only site-local, Chromium-readable asset paths into the card.
+
+	The renderer fetches whatever the card's ``<img src>`` points at, so a
+	remote URL would turn it into an outbound request, and ``/private/files``
+	is unreadable to it anyway.
+	"""
+	if not url:
+		return ""
+	if url.startswith("/files/") or url.startswith("/assets/"):
+		return url
+	return ""
+
+
+def _breadcrumb_trail(doc) -> str:
+	"""Ancestor titles from the root group down to the page's parent.
+
+	The root group is dropped (it stands for the space, which the card already
+	names) and the trail is capped at the deepest few segments, ellipsized on
+	the left when there were more.
+	"""
+	if not doc.lft:
+		return ""
+
+	# get_ancestors() is ordered closest-first; reverse for root-to-parent.
+	ancestors = list(reversed(doc.get_ancestors() or []))[1:]
+	if not ancestors:
+		return ""
+
+	titles = [frappe.get_cached_value("Wiki Document", name, "title") for name in ancestors]
+	titles = [title for title in titles if title]
+
+	trail = titles[-MAX_BREADCRUMB_SEGMENTS:]
+	if len(titles) > len(trail):
+		trail.insert(0, "…")
+	return " / ".join(trail)
+
+
+def _title_font_size(title: str) -> int:
+	"""Pick the title size in Python so the card never depends on script
+	execution having finished before Chromium captures the frame."""
+	length = len(title or "")
+	if length <= 40:
+		return 76
+	if length <= 80:
+		return 60
+	return 48
+
+
+def _og_context(doc) -> dict:
+	"""The complete set of inputs the card template consumes."""
+	wiki_space = doc.get_wiki_space()
+	logo_url = ""
+	if wiki_space:
+		space_doc = frappe.get_cached_doc("Wiki Space", wiki_space["name"])
+		logo_url = _safe_asset_url(space_doc.light_mode_logo)
+
+	title = doc.meta_title or doc.title or ""
+	return {
+		"title": title,
+		"title_font_size": _title_font_size(title),
+		"breadcrumb_trail": _breadcrumb_trail(doc),
+		"space_name": (wiki_space.get("space_name") if wiki_space else "") or "",
+		"logo_url": logo_url,
+	}
+
+
+def render_og_html(ctx: dict) -> str:
+	"""Render the card markup.
+
+	``frappe.render_template`` runs a sandboxed Jinja environment built
+	*without* autoescape, so every interpolation in the template escapes
+	explicitly with ``| e``. Without it a page titled ``"><img src=http://evil>``
+	would make the screenshotter fetch an attacker-controlled URL.
+	"""
+	return frappe.render_template("templates/wiki/og_image.html", ctx)
+
+
+def generate_og_bytes(ctx: dict) -> bytes:
+	return get_preview_from_html(render_og_html(ctx), format="jpg", width=OG_WIDTH, height=OG_HEIGHT)
+
+
+@frappe.whitelist(allow_guest=True)  # nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method
+def og_image(route: str, v: str | None = None):
+	"""Serve the generated OG card for the page at ``route``.
+
+	``v`` is a cache-buster for scrapers and CDNs only -- the fingerprint is
+	always recomputed server-side, so a stale ``v`` still serves the current
+	card instead of 404ing, and a crafted one cannot reach a different file.
+
+	Returns a raw werkzeug Response (``frappe.handler`` passes those straight
+	through) because ``frappe.local.response`` would attach a
+	``Content-Disposition: attachment``, which no ``og:image`` consumer accepts.
+	"""
+	doc = _resolve_doc(route)
+	data = generate_og_bytes(_og_context(doc))
+
+	response = Response()
+	response.mimetype = "image/jpeg"
+	response.data = data
+	return response

--- a/wiki/api/og_image.py
+++ b/wiki/api/og_image.py
@@ -171,7 +171,11 @@ def og_fingerprint(ctx: dict) -> str:
 
 
 def _cache_dir() -> str:
-	path = frappe.get_site_path("public", "files", CACHE_DIR_NAME)
+	"""Private, not public: nothing needs these web-reachable — og:image points
+	at this endpoint, never at the file — and under public/files a card would
+	outlive the authorization that produced it, still served by nginx after the
+	page is unpublished or a space's roles change."""
+	path = frappe.get_site_path("private", "files", CACHE_DIR_NAME)
 	os.makedirs(path, exist_ok=True)
 	return path
 
@@ -190,10 +194,10 @@ def _cache_path(doc_key: str, fp: str) -> str:
 
 def _read_cached(path: str) -> bytes | None:
 	try:
-		# nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal
 		# `path` only ever comes from _cache_path, which pins the directory and
 		# validates doc_key against DOC_KEY_PATTERN. The endpoint's `v` param is
 		# never used to look a file up.
+		# nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal
 		with open(path, "rb") as f:
 			return f.read()
 	except FileNotFoundError:
@@ -203,9 +207,9 @@ def _read_cached(path: str) -> bytes | None:
 def _write_cached(path: str, data: bytes) -> None:
 	"""Write through a temp file so a concurrent reader never sees a torn image."""
 	tmp = f"{path}.tmp-{frappe.generate_hash(length=8)}"
-	# nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal
 	# Same as _read_cached: `path` is _cache_path output and the suffix is a
 	# generated hash.
+	# nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal
 	with open(tmp, "wb") as f:
 		f.write(data)
 	os.replace(tmp, path)
@@ -248,9 +252,9 @@ def render_og_html(ctx: dict) -> str:
 	explicitly with ``| e``. Without it a page titled ``"><img src=http://evil>``
 	would make the screenshotter fetch an attacker-controlled URL.
 	"""
-	# nosemgrep: frappe-semgrep-rules.rules.security.frappe-ssti
 	# The template path is a literal owned by this app; only `ctx` varies, and
 	# every value it carries is escaped in the template.
+	# nosemgrep: frappe-semgrep-rules.rules.security.frappe-ssti
 	return frappe.render_template("templates/wiki/og_image.html", ctx)
 
 

--- a/wiki/api/og_image.py
+++ b/wiki/api/og_image.py
@@ -42,16 +42,16 @@ CACHE_DIR_NAME = "wiki-og"
 # keeps whatever the caller supplied — so it is not trustworthy input here.
 DOC_KEY_PATTERN = re.compile(r"\A[a-zA-Z0-9]{1,32}\Z")
 
-# A day in the browser, a week of serving stale while we regenerate. Contains
-# "public" so frappe's process_response leaves it alone and skips flushing
-# cookies onto what is meant to be a CDN-cacheable response.
-CACHE_CONTROL = "public, max-age=86400, stale-while-revalidate=604800"
-
-# Only ever sent for a card whose page a Guest could read anyway. A restricted
-# space's card must not sit in a shared cache: the URL carries no identity, so a
-# CDN would keep serving the title and breadcrumbs after access is revoked or
-# the page is unpublished, without the request ever reaching _resolve_doc.
-PRIVATE_CACHE_CONTROL = "private, max-age=300, must-revalidate"
+# Exactly what frappe serves the wiki page itself (frappe/website/utils.py's
+# cache_html), so a card is never cacheable for longer, or by more parties, than
+# the page whose title it shows.
+#
+# Deliberately not "public": the URL carries no identity, so a shared cache
+# would keep serving a card — title, breadcrumb, space name — after the page is
+# unpublished or the space's roles change, without a request ever reaching
+# _resolve_doc again. A private cache is per-user, so it can only ever replay a
+# card to someone who was already allowed to see it.
+CACHE_CONTROL = "private, max-age=300, stale-while-revalidate=10800"
 
 # Long enough to cover a cold Chromium spin-up, short enough that a crashed
 # worker's lock frees itself quickly.
@@ -414,10 +414,9 @@ def og_image(route: str, v: str | None = None):
 	ctx = _og_context(doc)
 	fp = og_fingerprint(ctx)
 	etag = f'"{fp}"'
-	cache_control = CACHE_CONTROL if _is_anonymously_readable(doc) else PRIVATE_CACHE_CONTROL
 
 	if frappe.request and frappe.request.headers.get("If-None-Match") == etag:
-		return _cache_headers(Response(status=304), etag, cache_control)
+		return _cache_headers(Response(status=304), etag)
 
 	path = _cache_path(doc.doc_key, fp)
 	data = _read_cached(path)
@@ -435,21 +434,11 @@ def og_image(route: str, v: str | None = None):
 	response = Response()
 	response.mimetype = "image/jpeg"
 	response.data = data
-	return _cache_headers(response, etag, cache_control)
+	return _cache_headers(response, etag)
 
 
-def _is_anonymously_readable(doc) -> bool:
-	"""Whether a Guest could read this page, and so whether its card is safe to
-	hand to a shared cache."""
-	from wiki.permissions import can_read_space
-
-	space = doc.wiki_space or (doc.get_wiki_space() or {}).get("name")
-	# Orphan documents are readable by everyone (check_space_access returns early).
-	return True if not space else can_read_space(space, "Guest")
-
-
-def _cache_headers(response: Response, etag: str, cache_control: str) -> Response:
-	response.headers["Cache-Control"] = cache_control
+def _cache_headers(response: Response, etag: str) -> Response:
+	response.headers["Cache-Control"] = CACHE_CONTROL
 	response.headers["ETag"] = etag
 	return response
 

--- a/wiki/api/og_image.py
+++ b/wiki/api/og_image.py
@@ -362,6 +362,12 @@ def og_image(route: str, v: str | None = None):
 	``Content-Disposition: attachment``, which no ``og:image`` consumer accepts.
 	"""
 	doc = _resolve_doc(route)
+	if not _cards_enabled():
+		# The kill switch has to stop Chromium launching, not just stop the tag
+		# being emitted -- otherwise a site that turned cards off still pays for
+		# every crawler that remembers an old og:image URL.
+		frappe.throw(_("Page not found"), frappe.DoesNotExistError)
+
 	ctx = _og_context(doc)
 	fp = og_fingerprint(ctx)
 	etag = f'"{fp}"'

--- a/wiki/frappe_wiki/doctype/wiki_change_request/test_wiki_change_request.py
+++ b/wiki/frappe_wiki/doctype/wiki_change_request/test_wiki_change_request.py
@@ -1,6 +1,10 @@
 # Copyright (c) 2026, Frappe and Contributors
 # See license.txt
 
+import glob
+import os
+from unittest.mock import patch
+
 import frappe
 from frappe.core.doctype.user_permission.test_user_permission import create_user
 from frappe.tests.utils import FrappeTestCase
@@ -37,6 +41,13 @@ from wiki.frappe_wiki.doctype.wiki_change_request.wiki_change_request import (
 from wiki.frappe_wiki.doctype.wiki_revision.wiki_revision import (
 	create_revision_from_live_tree,
 )
+
+
+def _cached_cards(doc_key: str) -> list[str]:
+	"""Basenames of the generated OG cards currently on disk for a document."""
+	from wiki.api.og_image import _cache_dir
+
+	return sorted(os.path.basename(p) for p in glob.glob(os.path.join(_cache_dir(), f"{doc_key}-*.jpg")))
 
 
 def _approve_and_merge(name: str):
@@ -2246,6 +2257,77 @@ class TestWikiChangeRequest(FrappeTestCase):
 		)
 		tree2 = get_cr_tree(cr.name)
 		self.assertEqual(tree2.get("operation_version"), 1)
+
+
+class TestWikiChangeRequestOGWarmup(FrappeTestCase):
+	"""Merging is the main way a live page's title changes, so it is the main
+	way a generated OG card goes stale. No merge-specific code exists for this:
+	_classify_changes treats title/slug/route/parent_key/is_published as
+	metadata, so those merges go through a full doc.save() and reach the shared
+	on_update hook. Content-only merges take the raw db.set_value fast path,
+	which skips hooks -- correctly, since content is not a fingerprint input.
+	"""
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def _rename_via_merge(self, page, new_title):
+		space = frappe.get_value("Wiki Space", {"root_group": page.parent_wiki_document}, "name")
+		cr = create_change_request(space, f"CR OG {frappe.generate_hash(length=4)}")
+		page_key = frappe.get_value("Wiki Document", page.name, "doc_key")
+		update_cr_page(cr.name, page_key, {"title": new_title})
+		submit_change_request(cr.name)
+		_approve_and_merge(cr.name)
+
+	def test_merging_a_rename_enqueues_one_warmup(self):
+		space = create_test_wiki_space()
+		page = create_test_wiki_document(space.root_group, title="Old Title")
+
+		with patch("frappe.enqueue") as enqueue:
+			self._rename_via_merge(page, "New Title")
+
+		og_jobs = [
+			call for call in enqueue.call_args_list if call.args[0] == "wiki.api.og_image.warm_og_image"
+		]
+		self.assertEqual(len(og_jobs), 1)
+		self.assertEqual(og_jobs[0].kwargs["name"], page.name)
+
+	def test_merged_rename_lands_the_new_card_without_a_page_view(self):
+		from wiki.api.og_image import clear_cached_cards, warm_og_image
+
+		space = create_test_wiki_space()
+		page = create_test_wiki_document(space.root_group, title="Old Title")
+		doc_key = frappe.get_value("Wiki Document", page.name, "doc_key")
+		self.addCleanup(clear_cached_cards, doc_key)
+
+		with patch("wiki.api.og_image.get_preview_from_html", return_value=b"\xff\xd8\xff"):
+			warm_og_image(page.name)
+			stale = _cached_cards(doc_key)
+
+			self._rename_via_merge(page, "New Title")
+			# Run the job the merge queued, without ever rendering the page.
+			warm_og_image(page.name)
+
+		fresh = _cached_cards(doc_key)
+		self.assertEqual(len(stale), 1)
+		self.assertEqual(len(fresh), 1)
+		self.assertNotEqual(stale, fresh)
+
+	def test_content_only_merge_enqueues_no_warmup(self):
+		space = create_test_wiki_space()
+		page = create_test_wiki_document(space.root_group, title="Stable Title", content="v1")
+		cr = create_change_request(space.name, "CR OG content")
+		page_key = frappe.get_value("Wiki Document", page.name, "doc_key")
+		update_cr_page(cr.name, page_key, {"content": "v2"})
+		submit_change_request(cr.name)
+
+		with patch("frappe.enqueue") as enqueue:
+			_approve_and_merge(cr.name)
+
+		og_jobs = [
+			call for call in enqueue.call_args_list if call.args[0] == "wiki.api.og_image.warm_og_image"
+		]
+		self.assertEqual(og_jobs, [])
 
 
 class TestWikiChangeRequestTabs(FrappeTestCase):

--- a/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
@@ -2526,22 +2526,23 @@ class TestOGImageEndpoint(OGImageTestBase):
 		self.assertEqual(response.status_code, 404)
 		self.renderer.assert_not_called()
 
-	def test_restricted_space_card_is_not_shared_cacheable(self):
+	def test_cards_are_never_shared_cacheable(self):
 		"""The URL carries no identity, so a `public` Cache-Control would let a
-		CDN keep serving a restricted space's title and breadcrumbs after access
-		is revoked, without the request ever reaching _resolve_doc again."""
+		CDN keep serving a card — title, breadcrumb, space name — after the page
+		is unpublished or the space's roles change, without the request ever
+		reaching _resolve_doc again. Guest-readable pages included: a page that
+		is public today may not be tomorrow."""
 		from wiki.api.og_image import og_image
 
-		public_doc = self._published_page("og-cc-public")
-		private_doc = self._published_page("og-cc-private", guest_readable=False)
+		guest_doc = self._published_page("og-cc-guest")
+		restricted_doc = self._published_page("og-cc-restricted", guest_readable=False)
 
-		self.assertIn("public", self._get(public_doc.route).headers["Cache-Control"])
-
-		# Called in-process as a user who *can* read it: the bytes are served,
-		# but only the requesting browser may keep them.
-		cache_control = og_image(route=private_doc.route).headers["Cache-Control"]
-		self.assertIn("private", cache_control)
-		self.assertNotIn("public", cache_control)
+		for cache_control in (
+			self._get(guest_doc.route).headers["Cache-Control"],
+			og_image(route=restricted_doc.route).headers["Cache-Control"],
+		):
+			self.assertIn("private", cache_control)
+			self.assertNotIn("public", cache_control)
 
 	def test_published_page_returns_jpeg(self):
 		doc = self._published_page("og-served")

--- a/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
@@ -1,12 +1,17 @@
 # Copyright (c) 2025, Frappe and Contributors
 # See license.txt
 
+import functools
+import glob
 import json
+import os
 import re
+import typing
 import unittest
 from threading import Thread
 from types import SimpleNamespace
 from unittest.mock import patch
+from urllib.parse import quote
 
 import frappe
 from frappe.tests import IntegrationTestCase
@@ -392,7 +397,11 @@ class TestGetWebContextMetaTags(WikiDocumentTestBase):
 		self.assertEqual(context["canonical_url"], frappe.utils.get_url("/" + doc.route))
 
 	def test_metatags_fall_back_to_title_when_meta_fields_unset(self):
-		"""With no meta_title/description/image, metatags should fall back sensibly."""
+		"""With no meta_title/description, metatags should fall back sensibly.
+
+		og:image is the one field with a generated fallback, so it is asserted
+		with the cards turned off; TestOGImageMetaTags covers the on case.
+		"""
 		root_group = create_test_wiki_document(self, "Root Meta Fallback Group", is_group=True)
 		doc = create_test_wiki_document(
 			self, "Fallback Meta Doc", parent=root_group.name, slug="fallback-meta-doc"
@@ -400,7 +409,8 @@ class TestGetWebContextMetaTags(WikiDocumentTestBase):
 		create_test_wiki_space(self, "Fallback Meta Space", "fallback-meta-space", root_group.name)
 
 		doc.reload()
-		context = doc.get_web_context()
+		with self.change_settings("Wiki Settings", {"auto_generate_meta_images": 0}):
+			context = doc.get_web_context()
 		metatags = context["metatags"]
 
 		self.assertEqual(metatags["title"], "Fallback Meta Doc")
@@ -457,7 +467,7 @@ class TestRenderedPageMetaTags(WikiDocumentTestBase):
 		self.assertRegex(html, r'property="og:title"\s*content="Rendered Meta Title"')
 		self.assertRegex(html, rf'<link rel="canonical" href="[^"]*/{doc.route}">')
 
-	def test_rendered_head_omits_image_tags_when_no_meta_image(self):
+	def test_rendered_head_uses_generated_og_image_when_no_meta_image(self):
 		route = self._unique("meta-render-fallback")
 		space = create_test_wiki_space(
 			self, "Meta Render Fallback Space", route, None, roles=[("Guest", "Read")]
@@ -480,9 +490,37 @@ class TestRenderedPageMetaTags(WikiDocumentTestBase):
 		self.assertEqual(response.status_code, 200)
 		html = response.get_data(as_text=True)
 
+		self.assertRegex(html, r'name="twitter:card"\s*content="summary_large_image"')
+		self.assertIn("wiki.api.og_image.og_image", html)
+		self.assertRegex(html, rf'<link rel="canonical" href="[^"]*/{doc.route}">')
+
+	def test_rendered_head_omits_image_tags_when_cards_are_disabled(self):
+		"""With the Wiki Settings toggle off the emitted head is what it was
+		before generated cards existed."""
+		route = self._unique("meta-render-nocard")
+		space = create_test_wiki_space(
+			self, "Meta Render No Card Space", route, None, roles=[("Guest", "Read")]
+		)
+		doc = create_test_wiki_document(
+			self,
+			"Meta Render No Card Doc",
+			parent=space.root_group,
+			slug=self._unique("meta-render-nocard-doc"),
+		)
+
+		with self.change_settings("Wiki Settings", {"auto_generate_meta_images": 0}, commit=True):
+			response = _make_request(
+				self.TEST_CLIENT,
+				"get",
+				f"/{doc.route}",
+				headers={"Accept": "text/html"},
+			)
+
+		self.assertEqual(response.status_code, 200)
+		html = response.get_data(as_text=True)
+
 		self.assertRegex(html, r'name="twitter:card"\s*content="summary"')
 		self.assertNotIn('property="og:image"', html)
-		self.assertRegex(html, rf'<link rel="canonical" href="[^"]*/{doc.route}">')
 
 
 class TestGetWebContextBreadcrumbs(WikiDocumentTestBase):
@@ -2387,3 +2425,332 @@ class TestReaderRouteXSS(unittest.TestCase):
 		self.assertNotIn("&#39;", html)
 		self.assertNotIn("</script>", html)
 		self.assertIn("\\u003c/script", html)
+
+
+# A JPEG magic number is all the endpoint tests need from the renderer; CI
+# installs no server-side Chromium, so every test here patches
+# get_preview_from_html *at its point of use* in wiki.api.og_image -- patching
+# frappe.utils.preview would leave the already-bound import untouched.
+FAKE_JPEG = b"\xff\xd8\xff" + b"\x00" * 32
+
+
+class OGImageTestBase(WikiDocumentTestBase):
+	"""Shared setup for the generated-OG-card tests."""
+
+	def setUp(self):
+		self.og_doc_keys = []
+		self.enterContext(
+			self.change_settings("Wiki Settings", {"auto_generate_meta_images": 1}, commit=True)
+		)
+		self.renderer = self.enterContext(
+			patch("wiki.api.og_image.get_preview_from_html", return_value=FAKE_JPEG)
+		)
+		# Warm-up jobs would otherwise land on the real bench queue and render
+		# for real; the warm-up tests assert on this mock instead.
+		self.enqueue = self.enterContext(patch("frappe.enqueue"))
+
+	def tearDown(self):
+		from wiki.api.og_image import clear_cached_cards
+
+		for doc_key in self.og_doc_keys:
+			clear_cached_cards(doc_key)
+		super().tearDown()
+
+	def _unique(self, prefix):
+		return f"{prefix}-{frappe.generate_hash(length=6)}"
+
+	def _published_page(self, label, guest_readable=True, **kwargs):
+		"""A published page in its own space, tracked for card cleanup."""
+		route = self._unique(label)
+		space = create_test_wiki_space(
+			self,
+			f"{label} Space",
+			route,
+			None,
+			roles=[("Guest", "Read")] if guest_readable else [],
+		)
+		doc = create_test_wiki_document(
+			self, label, parent=space.root_group, slug=self._unique(label), **kwargs
+		)
+		doc.reload()
+		self.og_doc_keys.append(doc.doc_key)
+		return doc
+
+	def _cached_cards(self, doc_key):
+		from wiki.api.og_image import _cache_dir
+
+		return sorted(os.path.basename(p) for p in glob.glob(os.path.join(_cache_dir(), f"{doc_key}-*.jpg")))
+
+
+class TestOGImageEndpoint(OGImageTestBase):
+	"""The guest-facing endpoint that renders and serves the card."""
+
+	TEST_CLIENT = get_test_client()
+
+	def _get(self, route, **kwargs):
+		frappe.db.commit()  # nosemgrep: frappe-semgrep-rules.rules.frappe-manual-commit
+		return _make_request(
+			self.TEST_CLIENT,
+			"get",
+			f"/api/method/wiki.api.og_image.og_image?route={quote(route)}",
+			**kwargs,
+		)
+
+	def test_unknown_route_returns_404(self):
+		response = self._get("no-such-space/no-such-page")
+		self.assertEqual(response.status_code, 404)
+
+	def test_unpublished_document_returns_404(self):
+		doc = self._published_page("og-unpublished")
+		doc.is_published = 0
+		doc.save()
+
+		self.assertEqual(self._get(doc.route).status_code, 404)
+
+	def test_restricted_space_returns_404_for_guest(self):
+		"""A space with no Guest role is invisible to anonymous requests -- 404,
+		not 403, so the card endpoint leaks no more than the page itself."""
+		doc = self._published_page("og-restricted", guest_readable=False)
+
+		self.assertEqual(self._get(doc.route).status_code, 404)
+
+	def test_published_page_returns_jpeg(self):
+		doc = self._published_page("og-served")
+
+		response = self._get(doc.route)
+
+		self.assertEqual(response.status_code, 200)
+		self.assertEqual(response.headers["Content-Type"], "image/jpeg")
+		self.assertEqual(response.get_data(), FAKE_JPEG)
+
+	def test_repeat_request_serves_the_cached_file(self):
+		doc = self._published_page("og-cached")
+
+		self.assertEqual(self._get(doc.route).status_code, 200)
+		self.assertEqual(self._get(doc.route).status_code, 200)
+
+		self.assertEqual(self.renderer.call_count, 1)
+
+	def test_if_none_match_returns_304_with_empty_body(self):
+		doc = self._published_page("og-etag")
+		etag = self._get(doc.route).headers["ETag"]
+
+		response = self._get(doc.route, headers={"If-None-Match": etag})
+
+		self.assertEqual(response.status_code, 304)
+		self.assertEqual(response.get_data(), b"")
+
+	def test_rename_moves_the_fingerprint_and_prunes_the_old_card(self):
+		doc = self._published_page("og-renamed")
+		self._get(doc.route)
+		before = self._cached_cards(doc.doc_key)
+
+		doc.title = "Renamed For A New Fingerprint"
+		doc.save()
+		self._get(doc.route)
+
+		after = self._cached_cards(doc.doc_key)
+		self.assertEqual(len(before), 1)
+		self.assertEqual(len(after), 1)
+		self.assertNotEqual(before, after)
+
+
+class TestOGImageTemplate(unittest.TestCase):
+	"""frappe.render_template does not autoescape, so the card template carries
+	its own `| e` on every interpolation. Without it a crafted page title turns
+	the screenshotter into an outbound-fetch primitive."""
+
+	def test_hostile_title_is_escaped(self):
+		from wiki.api.og_image import render_og_html
+
+		html = render_og_html(
+			{
+				"title": '"><img src=http://evil.example/x>',
+				"title_font_size": 48,
+				"breadcrumb_trail": "",
+				"space_name": "",
+				"logo_url": "",
+			}
+		)
+
+		self.assertNotIn("<img src=http://evil.example/x>", html)
+		self.assertIn("&lt;img", html)
+
+	def test_remote_and_private_logo_urls_are_dropped(self):
+		from wiki.api.og_image import _safe_asset_url
+
+		self.assertEqual(_safe_asset_url("/files/logo.png"), "/files/logo.png")
+		self.assertEqual(_safe_asset_url("/assets/wiki/images/logo.svg"), "/assets/wiki/images/logo.svg")
+		self.assertEqual(_safe_asset_url("/private/files/logo.png"), "")
+		self.assertEqual(_safe_asset_url("https://evil.example/logo.png"), "")
+		self.assertEqual(_safe_asset_url(None), "")
+
+
+class TestOGImageWarmup(OGImageTestBase):
+	"""The background render that runs on document writes, so the first crawler
+	after a change is normally a cache hit. Serving never depends on it."""
+
+	def test_structural_save_enqueues_a_warmup(self):
+		doc = self._published_page("og-warm-enqueue")
+		self.enqueue.reset_mock()
+
+		doc.title = "A Title That Moves The Fingerprint"
+		doc.save()
+
+		self.enqueue.assert_called_once()
+		self.assertEqual(self.enqueue.call_args.args[0], "wiki.api.og_image.warm_og_image")
+		self.assertEqual(self.enqueue.call_args.kwargs["name"], doc.name)
+		self.assertTrue(self.enqueue.call_args.kwargs["deduplicate"])
+		self.assertTrue(self.enqueue.call_args.kwargs["enqueue_after_commit"])
+
+	def test_content_only_change_enqueues_nothing(self):
+		"""Content is not a fingerprint input, so a still-correct card is left
+		alone -- this is what keeps a busy wiki from re-rendering on every edit."""
+		from wiki.api.og_image import warm_og_image
+
+		doc = self._published_page("og-warm-content")
+		warm_og_image(doc.name)
+		self.enqueue.reset_mock()
+
+		doc.content = "Completely different body text."
+		doc.save()
+
+		self.enqueue.assert_not_called()
+
+	def test_warmup_renders_the_card_without_a_page_view(self):
+		from wiki.api.og_image import warm_og_image
+
+		doc = self._published_page("og-warm-render")
+		self.assertEqual(self._cached_cards(doc.doc_key), [])
+
+		warm_og_image(doc.name)
+
+		self.assertEqual(len(self._cached_cards(doc.doc_key)), 1)
+		self.assertEqual(self.renderer.call_count, 1)
+
+	def test_warmup_skips_when_the_card_is_already_on_disk(self):
+		from wiki.api.og_image import warm_og_image
+
+		doc = self._published_page("og-warm-skip")
+		warm_og_image(doc.name)
+		self.renderer.reset_mock()
+
+		warm_og_image(doc.name)
+
+		self.renderer.assert_not_called()
+
+	def test_toggle_off_enqueues_nothing_and_renders_nothing(self):
+		from wiki.api.og_image import warm_og_image
+
+		doc = self._published_page("og-warm-off")
+
+		with self.change_settings("Wiki Settings", {"auto_generate_meta_images": 0}):
+			self.enqueue.reset_mock()
+			doc.title = "Renamed While Cards Are Disabled"
+			doc.save()
+			warm_og_image(doc.name)
+
+		self.enqueue.assert_not_called()
+		self.renderer.assert_not_called()
+
+
+class TestOGImageMetaTags(OGImageTestBase):
+	"""get_web_context's fallback from meta_image to the generated card."""
+
+	def test_generated_card_is_used_when_no_meta_image(self):
+		doc = self._published_page("og-meta-generated")
+
+		metatags = doc.get_web_context()["metatags"]
+
+		self.assertIn("wiki.api.og_image.og_image", metatags["og:image"])
+		self.assertEqual(metatags["twitter:card"], "summary_large_image")
+		self.assertEqual(metatags["og:image:width"], "1200")
+		self.assertEqual(metatags["og:image:height"], "630")
+		self.assertEqual(metatags["og:image:type"], "image/jpeg")
+
+	def test_explicit_meta_image_wins_over_the_generated_card(self):
+		doc = self._published_page("og-meta-explicit")
+		doc.meta_image = "/files/hand-made.png"
+		doc.save()
+
+		metatags = doc.get_web_context()["metatags"]
+
+		self.assertEqual(metatags["og:image"], frappe.utils.get_url("/files/hand-made.png"))
+		self.assertNotIn("og:image:width", metatags)
+
+	def test_toggle_off_emits_no_image_tags(self):
+		doc = self._published_page("og-meta-toggle-off")
+
+		with self.change_settings("Wiki Settings", {"auto_generate_meta_images": 0}):
+			metatags = doc.get_web_context()["metatags"]
+
+		self.assertNotIn("og:image", metatags)
+		self.assertEqual(metatags["twitter:card"], "summary")
+
+	def test_group_external_link_and_orphan_pages_have_no_card(self):
+		space_doc = self._published_page("og-meta-kinds")
+		group = create_test_wiki_document(
+			self, "OG Group", parent=space_doc.parent_wiki_document, is_group=True
+		)
+		external = create_test_wiki_document(
+			self,
+			"OG External",
+			parent=space_doc.parent_wiki_document,
+			is_external_link=True,
+			external_url="https://example.com",
+		)
+		orphan = create_test_wiki_document(self, "OG Orphan", slug=self._unique("og-orphan"))
+
+		self.assertIsNone(group.get_og_image_url())
+		self.assertIsNone(external.get_og_image_url())
+		self.assertIsNone(orphan.get_og_image_url())
+
+
+class TestOGImageTokenDrift(unittest.TestCase):
+	"""The card inlines a snapshot of frappe-ui's light-mode tokens rather than
+	importing the built stylesheet, so a frappe-ui upgrade can move a value
+	silently. Same intent as frappe-ui's own tailwind/audit-token-drift.cjs."""
+
+	# Only the tokens the template actually declares, mapped to their
+	# themedVariables.light lookup.
+	TOKEN_REFS: typing.ClassVar[dict] = {
+		"--ink-gray-9": ("ink", "gray-9"),
+		"--ink-gray-7": ("ink", "gray-7"),
+		"--ink-gray-5": ("ink", "gray-5"),
+		"--outline-gray-2": ("outline", "gray-2"),
+		"--surface-gray-2": ("surface", "gray-2"),
+		"--surface-base": ("surface", "base"),
+	}
+
+	def test_template_tokens_match_frappe_ui(self):
+		# Built with os.path.join, not get_app_path's joins: those are scrubbed,
+		# which would turn "frappe-ui" into "frappe_ui".
+		colors_path = os.path.join(
+			frappe.get_app_path("wiki"),
+			"..",
+			"frontend",
+			"node_modules",
+			"frappe-ui",
+			"tailwind",
+			"generated",
+			"colors.json",
+		)
+		if not os.path.exists(colors_path):
+			# The Python CI job installs no frontend dependencies.
+			raise unittest.SkipTest("frappe-ui is not installed")
+
+		with open(colors_path) as f:
+			colors = json.load(f)
+
+		template = frappe.get_app_path("wiki", "templates", "wiki", "og_image.html")
+		with open(template) as f:
+			declared = dict(re.findall(r"(--[a-z0-9-]+):\s*(#[0-9a-fA-F]{6});", f.read()))
+
+		for var, (group, name) in self.TOKEN_REFS.items():
+			ref = colors["themedVariables"]["light"][group][name]
+			expected = functools.reduce(lambda node, key: node[key], ref.split("/"), colors)
+			self.assertEqual(
+				declared.get(var),
+				expected,
+				f"{var} drifted from frappe-ui's {ref}; update the template and bump TEMPLATE_VERSION",
+			)

--- a/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
@@ -2514,6 +2514,18 @@ class TestOGImageEndpoint(OGImageTestBase):
 
 		self.assertEqual(self._get(doc.route).status_code, 404)
 
+	def test_toggle_off_returns_404(self):
+		"""The kill switch stops Chromium launching, not just the tag being
+		emitted -- otherwise crawlers holding an old og:image URL keep paying
+		for renders on a site that turned cards off."""
+		doc = self._published_page("og-endpoint-off")
+
+		with self.change_settings("Wiki Settings", {"auto_generate_meta_images": 0}, commit=True):
+			response = self._get(doc.route)
+
+		self.assertEqual(response.status_code, 404)
+		self.renderer.assert_not_called()
+
 	def test_published_page_returns_jpeg(self):
 		doc = self._published_page("og-served")
 

--- a/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
@@ -2526,6 +2526,23 @@ class TestOGImageEndpoint(OGImageTestBase):
 		self.assertEqual(response.status_code, 404)
 		self.renderer.assert_not_called()
 
+	def test_restricted_space_card_is_not_shared_cacheable(self):
+		"""The URL carries no identity, so a `public` Cache-Control would let a
+		CDN keep serving a restricted space's title and breadcrumbs after access
+		is revoked, without the request ever reaching _resolve_doc again."""
+		from wiki.api.og_image import og_image
+
+		public_doc = self._published_page("og-cc-public")
+		private_doc = self._published_page("og-cc-private", guest_readable=False)
+
+		self.assertIn("public", self._get(public_doc.route).headers["Cache-Control"])
+
+		# Called in-process as a user who *can* read it: the bytes are served,
+		# but only the requesting browser may keep them.
+		cache_control = og_image(route=private_doc.route).headers["Cache-Control"]
+		self.assertIn("private", cache_control)
+		self.assertNotIn("public", cache_control)
+
 	def test_published_page_returns_jpeg(self):
 		doc = self._published_page("og-served")
 
@@ -2587,6 +2604,21 @@ class TestOGImageTemplate(unittest.TestCase):
 
 		self.assertNotIn("<img src=http://evil.example/x>", html)
 		self.assertIn("&lt;img", html)
+
+	def test_traversing_doc_key_cannot_escape_the_cache_directory(self):
+		"""doc_key names the cache file, and WikiDocument.set_doc_key only makes
+		it immutable on update -- an insert keeps whatever the caller passed. A
+		key with path separators must never reach open()/unlink()."""
+		from wiki.api.og_image import _cache_dir, _cache_path, clear_cached_cards
+
+		for hostile in ("../../evil", "a/b", "..", "with space", ""):
+			with self.assertRaises(frappe.DoesNotExistError):
+				_cache_path(hostile, "0123456789ab")
+			# The delete path must not raise (it runs after commit), just do nothing.
+			clear_cached_cards(hostile)
+
+		path = _cache_path("abc123DEF456", "0123456789ab")
+		self.assertEqual(os.path.dirname(path), _cache_dir())
 
 	def test_logo_prefers_the_switcher_logo_the_reader_renders(self):
 		"""app_switcher_logo is the mark the reader header shows, so the card

--- a/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
@@ -2588,6 +2588,26 @@ class TestOGImageTemplate(unittest.TestCase):
 		self.assertNotIn("<img src=http://evil.example/x>", html)
 		self.assertIn("&lt;img", html)
 
+	def test_logo_prefers_the_switcher_logo_the_reader_renders(self):
+		"""app_switcher_logo is the mark the reader header shows, so the card
+		must use it; light_mode_logo is only a fallback for v2 spaces."""
+		from wiki.api.og_image import _og_context
+
+		space = SimpleNamespace(app_switcher_logo="/files/new.png", light_mode_logo="/files/old.png")
+		doc = SimpleNamespace(
+			meta_title=None,
+			title="Doc",
+			lft=None,
+			get_wiki_space=lambda: {"name": "sp", "space_name": "Space"},
+		)
+
+		with patch("frappe.get_cached_doc", return_value=space):
+			self.assertEqual(_og_context(doc)["logo_url"], "/files/new.png")
+
+		space.app_switcher_logo = None
+		with patch("frappe.get_cached_doc", return_value=space):
+			self.assertEqual(_og_context(doc)["logo_url"], "/files/old.png")
+
 	def test_remote_and_private_logo_urls_are_dropped(self):
 		from wiki.api.og_image import _safe_asset_url
 

--- a/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
@@ -988,6 +988,21 @@ def on_wiki_document_trash(doc, method):
 	_clear_stale_website_cache(doc, deleted=True)
 	clear_wiki_tree_cache()
 	clear_wiki_content_cache(doc.name)
+	_drop_generated_og_cards(doc)
+
+
+def _drop_generated_og_cards(doc):
+	"""Unlink this document's generated OG cards from public/files.
+
+	Deferred like the search-index drop: the files live outside the
+	transaction, so a rollback must not take live cards with it.
+	"""
+	from wiki.api.og_image import clear_cached_cards
+
+	doc_key = doc.doc_key
+	if not doc_key:
+		return
+	frappe.db.after_commit.add(lambda: clear_cached_cards(doc_key))
 
 
 def _clear_stale_website_cache(doc, deleted=False):

--- a/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
@@ -2,7 +2,7 @@
 # For license information, please see license.txt
 
 import json
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 import frappe
 from frappe import _
@@ -434,8 +434,20 @@ class WikiDocument(NestedSet):
 		}
 		if self.meta_description:
 			metatags["description"] = self.meta_description
-		if self.meta_image:
-			metatags["image"] = self.meta_image
+
+		# An explicit upload always wins; the generated card is the fallback.
+		image = self.meta_image or self.get_og_image_url()
+		if image:
+			metatags["image"] = image
+		if not self.meta_image and image:
+			from wiki.api.og_image import OG_HEIGHT, OG_WIDTH
+
+			# MetaTags leaves unknown keys alone and meta_block.html emits any
+			# "og:"-prefixed key as a property, so these need no framework change.
+			metatags["og:image:width"] = str(OG_WIDTH)
+			metatags["og:image:height"] = str(OG_HEIGHT)
+			metatags["og:image:type"] = "image/jpeg"
+
 		context["metatags"] = {key: value for key, value in metatags.items() if value}
 		context["metatags"] = MetaTags(self.route, context).tags
 		context["canonical_url"] = frappe.utils.get_url("/" + self.route) if self.route else None
@@ -471,6 +483,26 @@ class WikiDocument(NestedSet):
 		)
 
 		return context
+
+	def get_og_image_url(self) -> str | None:
+		"""Path to this page's auto-generated OG card, or None when it has none.
+
+		Returns a path rather than an absolute URL so MetaTags absolutizes it
+		through get_url() -- that is what keeps it right on custom domains.
+		"""
+		from wiki.api.og_image import _og_context, og_fingerprint
+
+		if self.is_group or self.is_external_link or not self.is_published or not self.route:
+			return None
+		if not frappe.get_cached_value("Wiki Settings", "Wiki Settings", "auto_generate_meta_images"):
+			return None
+		if not self.get_wiki_space():
+			return None
+
+		# `v` only busts scraper/CDN caches; the endpoint recomputes the
+		# fingerprint and ignores the param when looking the file up.
+		fingerprint = og_fingerprint(_og_context(self))
+		return f"/api/method/wiki.api.og_image.og_image?route={quote(self.route)}&v={fingerprint}"
 
 	def get_breadcrumb_list(self, wiki_space: dict) -> dict:
 		"""Build a BreadcrumbList JSON-LD payload mirroring the visible reader UI.
@@ -937,6 +969,8 @@ def download_pdf(route: str):
 
 def on_wiki_document_update(doc, method):
 	"""Stamp the owning Wiki Space and sync desk edits to the revision system."""
+	from wiki.api.og_image import enqueue_og_warmup
+
 	stamp_wiki_space(doc)
 	_sync_document_to_revision(doc)
 	_clear_stale_website_cache(doc)
@@ -944,6 +978,7 @@ def on_wiki_document_update(doc, method):
 	if doc.has_value_changed("content"):
 		clear_wiki_content_cache(doc.name)
 	_drop_from_search_index_on_unpublish(doc)
+	enqueue_og_warmup(doc)
 
 
 def _drop_from_search_index_on_unpublish(doc):

--- a/wiki/patches.txt
+++ b/wiki/patches.txt
@@ -22,3 +22,4 @@ wiki.wiki.doctype.wiki_space.patches.seed_space_roles_from_published
 wiki.frappe_wiki.doctype.wiki_change_request.patches.drop_reviewer_participant_tables
 wiki.wiki.doctype.wiki_space.patches.set_allow_contributions_default
 wiki.frappe_wiki.doctype.wiki_revision.patches.mark_hashes_stale_for_metadata_hashing
+execute:frappe.db.set_single_value('Wiki Settings', 'auto_generate_meta_images', 1) #2026-07-25

--- a/wiki/templates/wiki/og_image.html
+++ b/wiki/templates/wiki/og_image.html
@@ -18,6 +18,10 @@
 <head>
 <meta charset="utf-8">
 <style>
+	/* The card's palette, not just the rules it currently applies:
+	   outline-gray-2 (a footer hairline) and surface-gray-2 (the space accent
+	   bar) are both design decisions that have been on and off, and keeping
+	   them declared keeps the drift test guarding their values. */
 	:root {
 		--ink-gray-9: #0f0f0f;      /* lightMode/gray/950 */
 		--ink-gray-7: #383838;      /* lightMode/gray/800 */
@@ -55,21 +59,12 @@
 		-webkit-font-smoothing: antialiased;
 	}
 
-	.accent-bar {
-		position: fixed;
-		top: 0;
-		left: 0;
-		right: 0;
-		height: 12px;
-		background: var(--surface-gray-2);
-	}
-
 	.logo {
 		/* Sized against the 1200x630 card, not a page header — anything under
 		   ~72px reads as an afterthought at feed scale. The generous max-width
 		   is for wordmark logos, which are wide rather than square; contain
 		   keeps those from being cropped or stretched. */
-		height: 88px;
+		height: 100px;
 		width: auto;
 		max-width: 520px;
 		object-fit: contain;
@@ -77,8 +72,8 @@
 	}
 
 	.breadcrumb {
-		font-size: 26px;
-		font-weight: var(--font-weight-medium);
+		font-size: 32px;
+		font-weight: var(--font-weight-semibold);
 		letter-spacing: 0.01em;
 		color: var(--ink-gray-5);
 		margin-bottom: 20px;
@@ -100,8 +95,6 @@
 	}
 
 	.footer {
-		padding-top: 28px;
-		border-top: 1px solid var(--outline-gray-2);
 		font-size: 28px;
 		font-weight: var(--font-weight-medium);
 		letter-spacing: 0.01em;
@@ -110,8 +103,6 @@
 </style>
 </head>
 <body>
-	<div class="accent-bar"></div>
-
 	<div class="header">
 		{% if logo_url %}<img class="logo" src="{{ logo_url | e }}" alt="">{% endif %}
 	</div>

--- a/wiki/templates/wiki/og_image.html
+++ b/wiki/templates/wiki/og_image.html
@@ -1,0 +1,122 @@
+{#
+	Open Graph card, screenshotted at 1200x630 by wiki/api/og_image.py.
+
+	Self-contained on purpose: the Tailwind build is purged against reader
+	markup, lives behind a content-hashed filename and carries dark-mode
+	variables -- none of which a deterministic screenshot wants. So the colours
+	below are the *light-mode* frappe-ui design tokens, inlined under their real
+	token names and resolved from
+	frontend/node_modules/frappe-ui/tailwind/generated/{colors,typography}.json.
+	A drift test in test_wiki_document.py re-resolves them and fails if
+	frappe-ui moves a value. Bump TEMPLATE_VERSION whenever this file changes.
+
+	frappe.render_template does NOT autoescape: every interpolation here must
+	keep its `| e`, or a crafted page title becomes an SSRF vector.
+#}
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<style>
+	:root {
+		--ink-gray-9: #0f0f0f;      /* lightMode/gray/950 */
+		--ink-gray-7: #383838;      /* lightMode/gray/800 */
+		--ink-gray-5: #7c7c7c;      /* lightMode/gray/600 */
+		--outline-gray-2: #e2e2e2;  /* lightMode/gray/300 */
+		--surface-gray-2: #f3f3f3;  /* lightMode/gray/100 */
+		--surface-base: #ffffff;    /* neutral/white */
+		--font-weight-semibold: 600;
+		--font-weight-medium: 500;
+	}
+
+	@font-face {
+		font-family: "Inter";
+		font-weight: 100 900;
+		font-style: normal;
+		/* `block` rather than `swap`: the capture is a single frame, so a
+		   fallback-then-swap would be baked in permanently. */
+		font-display: block;
+		src: url("/assets/wiki/fonts/Inter.var.woff2") format("woff2");
+	}
+
+	* { box-sizing: border-box; }
+
+	body {
+		width: 1200px;
+		height: 630px;
+		margin: 0;
+		padding: 72px;
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		background: var(--surface-base);
+		font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+		font-synthesis-weight: none;
+		-webkit-font-smoothing: antialiased;
+	}
+
+	.accent-bar {
+		position: fixed;
+		top: 0;
+		left: 0;
+		right: 0;
+		height: 12px;
+		background: var(--surface-gray-2);
+	}
+
+	.logo {
+		height: 48px;
+		width: auto;
+		max-width: 420px;
+		object-fit: contain;
+		object-position: left center;
+	}
+
+	.breadcrumb {
+		font-size: 26px;
+		font-weight: var(--font-weight-medium);
+		letter-spacing: 0.01em;
+		color: var(--ink-gray-5);
+		margin-bottom: 20px;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.title {
+		font-weight: var(--font-weight-semibold);
+		letter-spacing: 0em;
+		line-height: 1.15;
+		color: var(--ink-gray-9);
+		margin: 0;
+		display: -webkit-box;
+		-webkit-box-orient: vertical;
+		-webkit-line-clamp: 3;
+		overflow: hidden;
+	}
+
+	.footer {
+		padding-top: 28px;
+		border-top: 1px solid var(--outline-gray-2);
+		font-size: 28px;
+		font-weight: var(--font-weight-medium);
+		letter-spacing: 0.01em;
+		color: var(--ink-gray-7);
+	}
+</style>
+</head>
+<body>
+	<div class="accent-bar"></div>
+
+	<div class="header">
+		{% if logo_url %}<img class="logo" src="{{ logo_url | e }}" alt="">{% endif %}
+	</div>
+
+	<div class="main">
+		{% if breadcrumb_trail %}<div class="breadcrumb">{{ breadcrumb_trail | e }}</div>{% endif %}
+		<div class="title" style="font-size: {{ title_font_size | int }}px">{{ title | e }}</div>
+	</div>
+
+	<div class="footer">{{ space_name | e }}</div>
+</body>
+</html>

--- a/wiki/templates/wiki/og_image.html
+++ b/wiki/templates/wiki/og_image.html
@@ -65,9 +65,13 @@
 	}
 
 	.logo {
-		height: 48px;
+		/* Sized against the 1200x630 card, not a page header — anything under
+		   ~72px reads as an afterthought at feed scale. The generous max-width
+		   is for wordmark logos, which are wide rather than square; contain
+		   keeps those from being cropped or stretched. */
+		height: 88px;
 		width: auto;
-		max-width: 420px;
+		max-width: 520px;
 		object-fit: contain;
 		object-position: left center;
 	}

--- a/wiki/wiki/doctype/wiki_settings/wiki_settings.json
+++ b/wiki/wiki/doctype/wiki_settings/wiki_settings.json
@@ -11,6 +11,7 @@
   "table_of_contents_section",
   "enable_table_of_contents",
   "auto_convert_images_to_webp",
+  "auto_generate_meta_images",
   "feedback_tab",
   "feedback_section",
   "enable_feedback",
@@ -74,6 +75,13 @@
    "fieldname": "auto_convert_images_to_webp",
    "fieldtype": "Check",
    "label": "Convert Uploaded Images to WebP"
+  },
+  {
+   "default": "1",
+   "description": "Generate a branded social preview image for pages that have no Meta Image uploaded.",
+   "fieldname": "auto_generate_meta_images",
+   "fieldtype": "Check",
+   "label": "Auto Generate Meta Images"
   },
   {
    "fieldname": "feedback_section",


### PR DESCRIPTION
<img width="1200" height="630" alt="image" src="https://github.com/user-attachments/assets/e9041410-e404-47c1-9a41-ed81e9a7844f" />


The template is not customisable for now.

## Why?

`Wiki Document.meta_image` is a manual upload. If nobody sets one, the page ships no `og:image` at all, so every wiki page looks identical when shared on Slack / X / LinkedIn.

Closes #713.

## What?

A branded 1200×630 card generated from the page's own title, breadcrumb trail and space logo, used as `og:image` whenever no Meta Image is uploaded. An explicit upload still wins.

- `Wiki Settings → Auto Generate Meta Images` kill switch, default on.
- Space Settings → General gains a **Space Logo** row, so the logo the card uses is settable from the app instead of only Desk.
- Page Settings' social preview now shows the real card.

## How?

Screenshots a self-contained HTML template with the headless Chromium that already powers PDF export (`frappe.utils.preview`) — no new dependency, no microservice.

Serving is lazy: the first request renders and writes a jpg under `public/files/wiki-og/`, every later request streams it. The filename embeds a fingerprint of every input the template consumes, so a rename or a logo change invalidates on its own and no invalidation hook is needed anywhere; a content-only edit leaves a still-correct card alone.

A background job on document update warms the card whenever a write moves that fingerprint, so the first crawler after a change is normally a cache hit. Serving never depends on the job.

Generation is rate-limited, guarded by a redis lock (the loser gets a 503 rather than queueing behind Chromium) and negatively cached on failure, so a broken Chromium degrades to "no preview image" and can never reach a page render.

Colours and type come from the frappe-ui light-mode tokens, inlined and guarded by a drift test.
