### PR TITLE
feat: llms.txt, .md page endpoints, and wiki routes in sitemap.xml

### DIFF
--- a/specs/llms_txt_and_markdown_endpoints.md
+++ b/specs/llms_txt_and_markdown_endpoints.md
@@ -1,8 +1,11 @@
 # llms.txt, `.md` Page Endpoints, and Wiki Sitemap
 
 Date: 2026-07-26
-Status: **Spec'd, not implemented.** Branch: `feat/llms-txt`.
+Status: **Implemented — all five phases landed.** Branch: `feat/llms-txt`.
 Issue: [frappe/wiki#710](https://github.com/frappe/wiki/issues/710)
+
+See [Reconciliation](#reconciliation) for where the build differs from the plan
+below.
 
 ## Goal
 
@@ -297,6 +300,51 @@ curl -s http://wiki.localhost:8000/sitemap.xml | xmllint --noout -
 
 Then, logged out in a browser, confirm a restricted space appears in **none** of
 the three index/markdown surfaces.
+
+## Reconciliation
+
+What the implementation does differently, and why.
+
+1. **`.md` resolution order is reversed.** The spec tried the full path as a
+   document route *first*, which would have made a page legitimately routed
+   `foo.md` unreachable as HTML — its own URL would always serve markdown.
+   `CrawlerRenderer._match_markdown` now bails when a document exists at the
+   literal path (the reader keeps that URL), and only then strips the suffix.
+   That page's markdown lives at `foo.md.md`. Covered by
+   `test_page_routed_with_md_suffix_still_renders_html`.
+2. **No blockquote fallback, and no site blockquote at all.** `Website Settings`
+   has no `description` field (checked: it does not exist), so the site index
+   opens with the H1 and the usage line only. A space's blockquote is its
+   landing page's `meta_description` when set, and omitted otherwise — a
+   generated "Documentation for X" line is noise in a file whose whole point is
+   signal density. llmstxt.org makes the blockquote optional.
+3. **An empty index does not 404 — the route is not claimed.** `can_render`
+   builds the body and returns False when there is nothing to serve, so
+   `/llms.txt` and `/sitemap.xml` fall through to whatever the site had there
+   before. This is what keeps frappe's own sitemap working on a site with no
+   public wiki, and it replaces the "at least one Guest-readable space exists"
+   pre-check the spec described.
+4. **One cache key, not two.** Both indexes live in a single Redis hash
+   (`wiki_crawler_index`, in `wiki/wiki/crawler_cache.py`) keyed
+   `llms-txt:__site__` / `llms-txt:<space>` / `sitemap`, and are dropped
+   wholesale. Invalidation hangs off `clear_wiki_tree_cache` — which every
+   document write already calls — plus new `Wiki Space` `on_update`/`on_trash`
+   hooks, since a space's roles and publish state change the indexes without
+   touching a document. A miss is cached as an empty string so a crawler
+   hammering a dead route doesn't rebuild the answer each time.
+5. **Spaces with a deleted root group are skipped.** Walking a dangling tree
+   raises, and in an aggregate index one broken space would 500 the whole file.
+   Found while testing (a leftover space on the dev site did exactly this);
+   `test_site_llms_txt_survives_a_space_whose_root_group_is_gone` pins it.
+6. **Content types.** `llms.txt` is `text/plain` so a browser shows it in-tab
+   rather than downloading it; `sitemap.xml` is `application/xml`.
+7. **`Vary: Accept` goes on the HTML response too**, not just the negotiated
+   markdown one — the same URL has two representations, so every response from
+   it has to say what picked this one.
+8. **Cache-Control locally.** `frappe._dev_server` force-overwrites every
+   response with `no-store` (`frappe/app.py:process_response`), so the curl
+   checks below show `no-store` on a dev bench. The headers are asserted in the
+   tests instead, where that override doesn't apply.
 
 ## Deferred
 

--- a/specs/llms_txt_and_markdown_endpoints.md
+++ b/specs/llms_txt_and_markdown_endpoints.md
@@ -341,7 +341,19 @@ What the implementation does differently, and why.
 7. **`Vary: Accept` goes on the HTML response too**, not just the negotiated
    markdown one — the same URL has two representations, so every response from
    it has to say what picked this one.
-8. **Cache-Control locally.** `frappe._dev_server` force-overwrites every
+8. **Group/space redirects check access first** (from review). The spec had the
+   `.md` redirect mirror `WikiDocumentRenderer` exactly — but that path resolves
+   and redirects *before* any permission check, so a restricted space's first
+   page route came back in the `Location` header. Both renderers now go through
+   `get_landing_page_for_route`, which gates on `can_read_space`. The reader's
+   HTML redirect had the same pre-existing leak and is fixed here too: gating
+   only `.md` would have left the identical route exposed one URL over.
+9. **Index text is escaped** (from review). Titles and `meta_description` are
+   editor-controlled free text: `]` in a title re-pointed a generated link, and
+   a newline in a description opened new list entries. Labels escape their
+   brackets, free text collapses to one line, external destinations are
+   angle-bracketed.
+10. **Cache-Control locally.** `frappe._dev_server` force-overwrites every
    response with `no-store` (`frappe/app.py:process_response`), so the curl
    checks below show `no-store` on a dev bench. The headers are asserted in the
    tests instead, where that override doesn't apply.

--- a/specs/llms_txt_and_markdown_endpoints.md
+++ b/specs/llms_txt_and_markdown_endpoints.md
@@ -1,0 +1,308 @@
+# llms.txt, `.md` Page Endpoints, and Wiki Sitemap
+
+Date: 2026-07-26
+Status: **Spec'd, not implemented.** Branch: `feat/llms-txt`.
+Issue: [frappe/wiki#710](https://github.com/frappe/wiki/issues/710)
+
+## Goal
+
+Make a Frappe Wiki site legible to LLM crawlers and agents:
+
+1. Serve every public page as raw markdown at `<route>.md`.
+2. Publish an `/llms.txt` index per the [llmstxt.org](https://llmstxt.org/) spec —
+   site-wide, plus one per Wiki Space.
+3. Put wiki routes into `sitemap.xml`, where they are absent today.
+
+Prior art is `frappe/llms_txt@b5f0e86` ("feat: autogen llms.txt"), a separate app
+written against the **legacy v1 `Wiki Page` doctype**. It is dead against v3: it
+queries `Wiki Page` / `Wiki Group Item`, gates on `allow_guest` (a field v3 does
+not have), and routes spaces at `/llm/<space>.txt`. This spec re-does the same
+idea natively on v3 with the current conventions.
+
+## Current State (audited 2026-07-26)
+
+### What already exists
+- **`Accept: text/markdown` negotiation** —
+  `wiki/frappe_wiki/doctype/wiki_document/wiki_document.py:617-628`
+  (`WikiDocumentRenderer.render`). Substring-matches the `Accept` header, gates
+  on `check_space_access("read")` + `check_published()`, returns a bare werkzeug
+  `Response` with `doc.content` and `Content-Type: text/markdown; charset=utf-8`.
+  Tests: `test_wiki_document.py:1614-1721` (`TestMarkdownContentNegotiation`).
+- **Content is already markdown.** `Wiki Document.content` is `Code` /
+  `options: Markdown`. No ProseMirror JSON, no HTML→markdown converter needed.
+- **Client-side markdown surface.** `templates/wiki/document.html:140` embeds
+  `raw_markdown`; `:153-161` `copyMarkdown()`; `:198-207` `getAIUrl(provider)`
+  builds ChatGPT/Claude/Perplexity deep links.
+- **Reusable tree + tab helpers**, all cached and already used by the reader:
+  `get_public_wiki_tree(root_group)` (`wiki_document.py:717`),
+  `get_space_tabs(space)` (`:803`), `get_first_published_page(root_group)`
+  (`:764`), `_first_published_leaf` (`:771`).
+
+### Gaps
+- No `.md` URLs — a crawler that cannot set request headers gets HTML only.
+- Markdown branch returns bare `doc.content`: no title, no canonical URL, no
+  `Vary: Accept` (so a shared cache can serve markdown to an HTML client).
+- No `llms.txt` anywhere.
+- **Wiki pages are missing from `sitemap.xml`.** Frappe's
+  `frappe/www/sitemap.py` walks `get_public_pages_from_doctypes()`, which
+  requires `has_web_view` + `allow_guest_to_view` + a published field.
+  `Wiki Document` has none of these (it renders through a custom
+  `page_renderer`), so no wiki route is ever listed.
+- `Wiki Space` has **no `description` field** — nothing to put in an llms.txt
+  blockquote.
+
+### Access control (the constraint that shapes everything)
+Guest visibility is **not** a DB flag. It is
+`wiki/permissions.py:88 can_read_space(space, user)` — a space is public only if
+its `roles` child table has a `Guest` row. A naive
+`frappe.get_all("Wiki Space", {"is_published": 1})` in an llms.txt or sitemap
+generator **leaks restricted routes**.
+
+## Decisions
+
+1. **`llms.txt` and `sitemap.xml` are always generated as `Guest`**, regardless
+   of who requests them. They are crawler artefacts; a session-dependent body
+   would be both a leak risk and uncacheable. Filter every space through
+   `can_read_space(space, "Guest")`.
+2. **`.md` responses follow the page's own permissions**, exactly like the HTML
+   page — `check_space_access("read")` raises `DoesNotExistError` (404), so a
+   restricted page is indistinguishable from a missing one.
+3. **YAML frontmatter on markdown output** (title / description / space /
+   canonical URL / updated), on both the `.md` route and the `Accept`-negotiated
+   branch. One shared helper, so the two can't drift. This changes the existing
+   exact-equality assertion in `test_accept_text_markdown_returns_raw_markdown`
+   — that test gets updated.
+4. **No internal-link rewriting.** The `llms_txt` app regex-rewrote
+   `[x](/route)` → `[x](/route.md)`; the regex does not respect fenced code
+   blocks and would corrupt documentation *about* markdown. `.md` is a
+   convention crawlers already follow; the llms.txt index links to `.md`
+   directly, which is where discovery actually happens.
+5. **Space blockquote is derived, not a new field** — use the space's landing
+   document's `meta_description`, falling back to a generated line. Avoids a
+   schema change plus the backend/frontend field-sync work.
+6. **A second `page_renderer`, registered first.** `hooks.py:20` becomes a list.
+   Custom renderers run before `StaticPage`/`TemplatePage`
+   (`frappe/website/path_resolver.py`), which is what lets us take over
+   `/sitemap.xml`. The new renderer's `can_render` is a cheap suffix check, so
+   normal page loads pay ~nothing.
+7. **`llms-full.txt` is out of scope** for this PR (unbounded response size;
+   revisit once per-space size is known).
+
+## Endpoints
+
+| Route | Body | Cache |
+| ----- | ---- | ----- |
+| `/<space>/<page>.md` | frontmatter + markdown | mirrors the HTML page; `private` when the space is not Guest-readable |
+| `/<space>/<page>` + `Accept: text/markdown` | same as above | adds `Vary: Accept` |
+| `/llms.txt` | site index of spaces | `public, max-age=3600`; Redis-cached body |
+| `/<space>/llms.txt` | that space's page index | same |
+| `/sitemap.xml` | wiki routes + framework pages | same |
+
+`/<space>.md` and `/<group>.md` mirror the HTML behaviour: redirect to
+`/<first-published-page>.md` via `get_first_published_page`.
+
+## Output formats
+
+### `<route>.md`
+
+```
+---
+title: "Installing Frappe Wiki"
+description: "Set up a wiki space in under five minutes."
+space: "Developer Docs"
+url: "https://docs.example.com/dev/install"
+updated: "2026-07-24"
+---
+
+# Installing Frappe Wiki
+...
+```
+
+Frontmatter values are serialised with `json.dumps` (a valid YAML string
+subset), which escapes quotes/newlines correctly. The `llms_txt` app hand-rolled
+`.replace('"', '\\"')` and breaks on newlines. Empty keys are omitted.
+
+### `/llms.txt` (site)
+
+```
+# Example Docs
+
+> Product documentation and guides.
+
+Each space below links to its own llms.txt index. Append `.md` to any page
+URL on this site to get that page's raw markdown source.
+
+## Spaces
+
+- [Developer Docs](https://docs.example.com/dev/llms.txt): APIs and internals
+- [User Guide](https://docs.example.com/guide/llms.txt)
+```
+
+H1 from `Website Settings.app_name` (fall back to the site name); blockquote from
+`Website Settings.description`.
+
+### `/<space>/llms.txt`
+
+llmstxt.org allows only a markdown list under each H2, so **one H2 per tab** and
+a nested list mirroring the sidebar tree:
+
+```
+# Developer Docs
+
+> APIs and internals for building on Frappe Wiki.
+
+Append `.md` to any URL below for that page's raw markdown source.
+
+## Home
+
+- [Introduction](https://docs.example.com/dev/intro.md): What this is
+
+## API Reference
+
+- **Endpoints**
+  - [Documents](https://docs.example.com/dev/api/documents.md)
+  - [Spaces](https://docs.example.com/dev/api/spaces.md)
+```
+
+- Sections come from `get_space_tabs(space)`; top-level nodes with
+  `is_tab` falsy go under the space's `home_tab_title` (default "Home"), matching
+  `_home_tab_entry` (`wiki_document.py:890`).
+- Tree from `get_public_wiki_tree(root_group)` — already pruned of empty groups
+  and sorted by `sort_order`.
+- A group has no page of its own, so it renders as an unlinked bold item —
+  *unless* a published leaf sits at the group's route (the README/index case
+  git-sync produces), in which case it is linked. Same rule as
+  `_tab_landing_route` (`:782`).
+- `: notes` suffix is the page's `meta_description`, omitted when empty.
+- `is_external_link` nodes link to `external_url` with no `.md`.
+
+### `/sitemap.xml`
+
+Standard urlset. Includes:
+- every published, non-group, non-external `Wiki Document` in a Guest-readable
+  space, `lastmod` = `modified`;
+- everything the framework sitemap would have emitted — `get_pages()` entries
+  with `sitemap=1`, plus `get_public_pages_from_doctypes()` (imported from
+  `frappe.www.sitemap`) — so overriding the route loses nothing.
+
+`.md` variants are **not** listed (duplicate content).
+
+## Implementation
+
+### New files
+- `wiki/wiki/llms_txt.py` — `build_site_llms_txt()`, `build_space_llms_txt(space)`,
+  and the tree→markdown-list walker.
+- `wiki/wiki/sitemap.py` — `build_sitemap_xml()`.
+- `wiki/wiki/crawler_renderer.py` — `CrawlerRenderer(BaseRenderer)`.
+
+### `WikiDocument.as_markdown()` (`wiki_document.py`)
+Returns frontmatter + `self.content`. Called by both the `.md` route and the
+`Accept` branch. Uses the existing `canonical_url` logic from
+`get_web_context()` (`:453`) — `frappe.utils.get_url("/" + self.route)`.
+
+### `CrawlerRenderer.can_render()`
+In order, and each an early return:
+1. `self.path == "llms.txt"` → site index.
+2. `self.path.endswith("/llms.txt")` → strip suffix, resolve a published
+   `Wiki Space` at that route; require `can_read_space(space, "Guest")`.
+3. `self.path == "sitemap.xml"` → true only when at least one Guest-readable
+   published space exists, so a wiki-less site keeps the framework sitemap.
+4. `self.path.endswith(".md")` → **first** try the full path as a document route
+   (a page could legitimately be slugged `foo.md`), then the stripped path;
+   resolve exactly like `WikiDocumentRenderer.can_render` (`:594-598`), then the
+   group/space redirect case (`:604-613`) pointing at `<first-page>.md`.
+5. Otherwise false.
+
+Returns raw werkzeug `Response` objects rather than `build_response`, matching
+the existing markdown branch and `wiki/api/og_image.py:434` — `build_response`
+attaches `X-Page-Name` and asset-preload headers that make no sense on plain
+text.
+
+### hooks.py
+```python
+page_renderer = [
+	"wiki.wiki.crawler_renderer.CrawlerRenderer",
+	"wiki.frappe_wiki.doctype.wiki_document.wiki_document.WikiDocumentRenderer",
+]
+```
+
+### Caching + invalidation
+`llms.txt` and `sitemap.xml` bodies go in Redis hashes (`wiki_llms_txt`,
+`wiki_sitemap`), keyed by space route / `__site__`. Invalidate from the existing
+write hooks — `on_wiki_document_update` (`:970`), `on_wiki_document_trash`
+(`:1020`), `clear_wiki_tree_cache` (`:907`) — and add a `Wiki Space` `on_update`
+hook, since space roles/publish state change the space list. Same invalidation
+points already used for the sidebar tree, so there is nothing new to remember.
+
+### Discovery
+`templates/wiki/layout.html`, in `<head>` next to the canonical link (`:13-15`):
+```html
+<link rel="alternate" type="text/markdown" href="{{ canonical_url }}.md">
+```
+
+`robots.txt` is user-owned (`Website Settings.robots_txt`) — untouched. Document
+that sites should add `Sitemap: https://<host>/sitemap.xml` there.
+
+## Phases (tracer bullets)
+
+1. **`.md` route + frontmatter.** `as_markdown()`, `CrawlerRenderer` with only
+   the `.md` branch, hooks change, `Vary: Accept` + cache-control on the existing
+   `Accept` branch. Smallest slice that works end to end.
+2. **Per-space `/<space>/llms.txt`.**
+3. **Site `/llms.txt`.**
+4. **`/sitemap.xml`.**
+5. **Caching/invalidation + `<link rel="alternate">`.**
+
+Commit after each phase; reconcile this spec's status line as phases land.
+
+## Tests
+
+`test_wiki_document.py` (new `TestCrawlerEndpoints`, alongside the existing
+`TestMarkdownContentNegotiation`), using the same `get_test_client()` +
+`_make_request` harness (`:1595-1611`):
+
+- `<route>.md` → 200, `text/markdown`, frontmatter title/url present, body ends
+  with the source content.
+- `<route>.md` on an unpublished page → 404.
+- `<route>.md` in a space with no `Guest` role row, requested as Guest → 404.
+- `<space>.md` → redirect to the first published page's `.md`.
+- `Accept: text/markdown` → still markdown, now carries `Vary: Accept` and the
+  frontmatter (**update** `test_accept_text_markdown_returns_raw_markdown`).
+- `/llms.txt` → H1 + blockquote + `## Spaces`; a Guest-readable space is listed,
+  a restricted one is not.
+- `/<space>/llms.txt` → one H2 per tab, every page link ends in `.md`,
+  unpublished pages absent, empty groups absent.
+- `/sitemap.xml` → parses, contains published wiki routes, contains no route
+  from a restricted space, contains no `.md` URL.
+
+Per CLAUDE.md, the permission-leak cases get a **temp-revert check**: drop the
+`can_read_space(..., "Guest")` filter and confirm the restricted-space tests
+actually fail.
+
+No e2e Playwright coverage — these are server-rendered plain-text responses with
+no SPA surface.
+
+## Verification
+
+```bash
+bench --site wiki.localhost run-tests --module \
+  wiki.frappe_wiki.doctype.wiki_document.test_wiki_document
+
+curl -s http://wiki.localhost:8000/llms.txt
+curl -s http://wiki.localhost:8000/<space>/llms.txt
+curl -s http://wiki.localhost:8000/<space>/<page>.md
+curl -sI http://wiki.localhost:8000/<space>/<page> -H 'Accept: text/markdown' | grep -i vary
+curl -s http://wiki.localhost:8000/sitemap.xml | xmllint --noout -
+```
+
+Then, logged out in a browser, confirm a restricted space appears in **none** of
+the three index/markdown surfaces.
+
+## Deferred
+
+- `llms-full.txt` (per space and site-wide).
+- Proper q-value `Accept` negotiation (today's substring match is good enough
+  for the clients that send `text/markdown` at all).
+- Per-page `robots` field / `noindex` (already backlogged in
+  `specs/page_settings_meta_fields.md:114`).
+- Retiring the standalone `frappe/llms_txt` app once docs.frappe.io is on v3.

--- a/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
@@ -1926,6 +1926,39 @@ class TestSpaceLlmsTxt(WikiDocumentTestBase):
 
 		self.assertEqual(response.status_code, 404)
 
+	def test_site_llms_txt_lists_public_spaces_only(self):
+		public = self._space_with_tree()
+		restricted = self._space_with_tree(guest_readable=False)
+
+		response = _make_request(self.TEST_CLIENT, "get", "/llms.txt")
+
+		self.assertEqual(response.status_code, 200)
+		self.assertIn("text/plain", response.headers.get("Content-Type", ""))
+
+		body = response.get_data(as_text=True)
+		self.assertTrue(body.startswith("# "))
+		self.assertIn("## Spaces", body)
+		self.assertIn(f"(http://localhost:8000/{public.space.route}/llms.txt)", body)
+		self.assertNotIn(f"/{restricted.space.route}/llms.txt", body)
+
+	def test_site_llms_txt_survives_a_space_whose_root_group_is_gone(self):
+		"""One broken space must not take the whole site index down."""
+		public = self._space_with_tree()
+		orphan = create_test_wiki_space(
+			self, "Orphan Space", self._unique("orphan"), None, roles=[("Guest", "Read")]
+		)
+		frappe.db.set_value("Wiki Space", orphan.name, "root_group", self._unique("gone"))
+		frappe.db.commit()  # nosemgrep: frappe-semgrep-rules.rules.frappe-manual-commit
+
+		response = _make_request(self.TEST_CLIENT, "get", "/llms.txt")
+
+		self.assertEqual(response.status_code, 200)
+		self.assertIn(f"/{public.space.route}/llms.txt", response.get_data(as_text=True))
+
+		space_response = _make_request(self.TEST_CLIENT, "get", f"/{orphan.route}/llms.txt")
+
+		self.assertEqual(space_response.status_code, 404)
+
 
 class TestStale404CacheInvalidation(WikiDocumentTestBase):
 	"""

--- a/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
@@ -1794,6 +1794,24 @@ class TestCrawlerEndpoints(WikiDocumentTestBase):
 		self.assertEqual(response.status_code, 301)
 		self.assertTrue(response.headers["Location"].endswith(f"/{page.route}.md"))
 
+	def test_space_md_route_does_not_leak_a_restricted_first_page(self):
+		"""The redirect must not name a private route to a visitor who can't read it."""
+		space, page = self._make_space("MD Restricted Redirect", guest_readable=False)
+
+		response = _make_request(self.TEST_CLIENT, "get", f"/{space.route}.md")
+
+		self.assertEqual(response.status_code, 404)
+		self.assertNotIn(page.route, response.headers.get("Location", ""))
+
+	def test_space_html_route_does_not_leak_a_restricted_first_page(self):
+		"""Same for the reader's own redirect, which shares the resolver."""
+		space, page = self._make_space("HTML Restricted Redirect", guest_readable=False)
+
+		response = _make_request(self.TEST_CLIENT, "get", f"/{space.route}")
+
+		self.assertEqual(response.status_code, 404)
+		self.assertNotIn(page.route, response.headers.get("Location", ""))
+
 	def test_page_routed_with_md_suffix_still_renders_html(self):
 		"""A page legitimately slugged "<name>.md" keeps its own URL as HTML."""
 		root_group = create_test_wiki_document(self, "Root MD Slug", is_group=True)
@@ -1919,6 +1937,29 @@ class TestSpaceLlmsTxt(WikiDocumentTestBase):
 		self.assertTrue(links)
 		for link in links:
 			self.assertTrue(link.endswith(".md"), f"{link} is not a markdown link")
+
+	def test_space_llms_txt_escapes_editor_controlled_text(self):
+		"""A title or description is free text; it must not rewrite the index."""
+		tree = self._space_with_tree()
+
+		hostile = create_test_wiki_document(
+			self,
+			"Click ](https://evil.example) here",
+			parent=tree.space.root_group,
+			slug=self._unique("hostile"),
+		)
+		hostile.meta_description = "First line\n- [Injected](https://evil.example/inject.md)"
+		hostile.save()
+		frappe.db.commit()  # nosemgrep: frappe-semgrep-rules.rules.frappe-manual-commit
+
+		body = _make_request(self.TEST_CLIENT, "get", f"/{tree.space.route}/llms.txt").get_data(as_text=True)
+
+		self.assertIn(f"](http://localhost:8000/{hostile.route}.md)", body)
+		self.assertIn("Click \\](https://evil.example) here", body)
+		# The multiline description collapses instead of becoming its own entry.
+		self.assertNotIn("\n- [Injected]", body)
+		for line in body.splitlines():
+			self.assertFalse(line.startswith("- [Injected]"))
 
 	def test_space_llms_txt_is_not_found_for_a_restricted_space(self):
 		tree = self._space_with_tree(guest_readable=False)

--- a/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
@@ -12,6 +12,7 @@ from threading import Thread
 from types import SimpleNamespace
 from unittest.mock import patch
 from urllib.parse import quote
+from xml.etree import ElementTree
 
 import frappe
 from frappe.tests import IntegrationTestCase
@@ -1958,6 +1959,31 @@ class TestSpaceLlmsTxt(WikiDocumentTestBase):
 		space_response = _make_request(self.TEST_CLIENT, "get", f"/{orphan.route}/llms.txt")
 
 		self.assertEqual(space_response.status_code, 404)
+
+	def test_sitemap_lists_public_wiki_routes_only(self):
+		public = self._space_with_tree()
+		restricted = self._space_with_tree(guest_readable=False)
+
+		response = _make_request(self.TEST_CLIENT, "get", "/sitemap.xml")
+
+		self.assertEqual(response.status_code, 200)
+		self.assertIn("xml", response.headers.get("Content-Type", ""))
+
+		body = response.get_data(as_text=True)
+		locations = re.findall(r"<loc>([^<]+)</loc>", body)
+
+		# Parses, and every entry is a page — not a group, a draft or a `.md` twin.
+		ElementTree.fromstring(body)
+		self.assertIn(f"http://localhost:8000/{public.intro.route}", locations)
+		self.assertIn(f"http://localhost:8000/{public.nested.route}", locations)
+		self.assertNotIn(f"http://localhost:8000/{public.draft.route}", locations)
+		self.assertNotIn(f"http://localhost:8000/{restricted.intro.route}", locations)
+		self.assertFalse([loc for loc in locations if loc.endswith(".md")])
+		self.assertNotIn(
+			f"http://localhost:8000/{public.nested_group.route}",
+			locations,
+			"groups are not served at their own route",
+		)
 
 
 class TestStale404CacheInvalidation(WikiDocumentTestBase):

--- a/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
@@ -1960,6 +1960,33 @@ class TestSpaceLlmsTxt(WikiDocumentTestBase):
 
 		self.assertEqual(space_response.status_code, 404)
 
+	def test_indexes_are_rebuilt_after_a_page_is_added(self):
+		"""The cached index must not outlive the wiki it describes."""
+		tree = self._space_with_tree()
+
+		_make_request(self.TEST_CLIENT, "get", f"/{tree.space.route}/llms.txt")
+
+		added = create_test_wiki_document(
+			self, "Added Later", parent=tree.space.root_group, slug=self._unique("added")
+		)
+		frappe.db.commit()  # nosemgrep: frappe-semgrep-rules.rules.frappe-manual-commit
+
+		body = _make_request(self.TEST_CLIENT, "get", f"/{tree.space.route}/llms.txt").get_data(as_text=True)
+		self.assertIn(f"/{added.route}.md", body)
+
+		sitemap = _make_request(self.TEST_CLIENT, "get", "/sitemap.xml").get_data(as_text=True)
+		self.assertIn(f"<loc>http://localhost:8000/{added.route}</loc>", sitemap)
+
+	def test_site_index_is_rebuilt_when_a_space_is_added(self):
+		self._space_with_tree()
+
+		_make_request(self.TEST_CLIENT, "get", "/llms.txt")
+
+		added = self._space_with_tree()
+
+		body = _make_request(self.TEST_CLIENT, "get", "/llms.txt").get_data(as_text=True)
+		self.assertIn(f"/{added.space.route}/llms.txt", body)
+
 	def test_sitemap_lists_public_wiki_routes_only(self):
 		public = self._space_with_tree()
 		restricted = self._space_with_tree(guest_readable=False)

--- a/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
@@ -1643,7 +1643,12 @@ class TestMarkdownContentNegotiation(WikiDocumentTestBase):
 
 		self.assertEqual(response.status_code, 200)
 		self.assertIn("text/markdown", response.headers.get("Content-Type", ""))
-		self.assertEqual(response.get_data(as_text=True), markdown_content)
+		self.assertEqual(response.headers.get("Vary"), "Accept")
+
+		body = response.get_data(as_text=True)
+		self.assertTrue(body.startswith("---\n"))
+		self.assertIn('title: "Markdown Test Page"', body)
+		self.assertTrue(body.endswith(markdown_content))
 
 	def test_default_accept_returns_html(self):
 		"""Requesting a wiki page without Accept: text/markdown returns HTML."""
@@ -1719,6 +1724,101 @@ class TestMarkdownContentNegotiation(WikiDocumentTestBase):
 		self.assertEqual(response.status_code, 200)
 		content_type = response.headers.get("Content-Type", "")
 		self.assertIn("charset=utf-8", content_type)
+
+
+class TestCrawlerEndpoints(WikiDocumentTestBase):
+	"""Tests for the crawler-facing routes served by CrawlerRenderer."""
+
+	TEST_CLIENT = get_test_client()
+
+	def _unique(self, prefix):
+		return f"{prefix}-{frappe.generate_hash(length=6)}"
+
+	def _make_space(self, label, guest_readable=True, content="# Page\n\nBody text.", published=True):
+		"""A one-page space, returning (space, page)."""
+		root_group = create_test_wiki_document(self, f"Root {label}", is_group=True)
+		page = create_test_wiki_document(
+			self,
+			f"Page {label}",
+			parent=root_group.name,
+			slug=self._unique("page"),
+			content=content,
+		)
+		space = create_test_wiki_space(
+			self,
+			f"Space {label}",
+			self._unique("crawl"),
+			root_group.name,
+			roles=[("Guest", "Read")] if guest_readable else [],
+		)
+		if not published:
+			frappe.db.set_value("Wiki Document", page.name, "is_published", 0)
+		frappe.db.commit()  # nosemgrep: frappe-semgrep-rules.rules.frappe-manual-commit
+		return space, page
+
+	def test_md_route_returns_markdown_with_frontmatter(self):
+		_, page = self._make_space("MD Route", content="# Title\n\nSome **body**.")
+
+		response = _make_request(self.TEST_CLIENT, "get", f"/{page.route}.md")
+
+		self.assertEqual(response.status_code, 200)
+		self.assertIn("text/markdown", response.headers.get("Content-Type", ""))
+		self.assertIn("private", response.headers.get("Cache-Control", ""))
+
+		body = response.get_data(as_text=True)
+		self.assertIn(f'title: "{page.title}"', body)
+		self.assertIn(f'/{page.route}"', body)
+		self.assertTrue(body.endswith("# Title\n\nSome **body**."))
+
+	def test_md_route_for_unpublished_page_is_not_found(self):
+		_, page = self._make_space("MD Unpublished", published=False)
+
+		response = _make_request(self.TEST_CLIENT, "get", f"/{page.route}.md")
+
+		self.assertEqual(response.status_code, 404)
+
+	def test_md_route_in_restricted_space_is_not_found_for_guest(self):
+		_, page = self._make_space("MD Restricted", guest_readable=False)
+
+		response = _make_request(self.TEST_CLIENT, "get", f"/{page.route}.md")
+
+		self.assertEqual(response.status_code, 404)
+
+	def test_space_md_route_redirects_to_first_page_markdown(self):
+		space, page = self._make_space("MD Space Redirect")
+
+		response = _make_request(self.TEST_CLIENT, "get", f"/{space.route}.md")
+
+		self.assertEqual(response.status_code, 301)
+		self.assertTrue(response.headers["Location"].endswith(f"/{page.route}.md"))
+
+	def test_page_routed_with_md_suffix_still_renders_html(self):
+		"""A page legitimately slugged "<name>.md" keeps its own URL as HTML."""
+		root_group = create_test_wiki_document(self, "Root MD Slug", is_group=True)
+		page = create_test_wiki_document(
+			self,
+			"Literal MD Page",
+			parent=root_group.name,
+			slug=self._unique("readme") + ".md",
+			content="# Literal",
+		)
+		create_test_wiki_space(
+			self, "MD Slug Space", self._unique("crawl"), root_group.name, roles=[("Guest", "Read")]
+		)
+		frappe.db.commit()  # nosemgrep: frappe-semgrep-rules.rules.frappe-manual-commit
+
+		response = _make_request(self.TEST_CLIENT, "get", f"/{page.route}")
+
+		self.assertEqual(response.status_code, 200)
+		# Content-Type is guessed from the ".md" path by frappe's build_response,
+		# so the body is what tells the two representations apart here.
+		self.assertTrue(response.get_data(as_text=True).lstrip().startswith("<!DOCTYPE html"))
+
+		markdown = _make_request(self.TEST_CLIENT, "get", f"/{page.route}.md")
+
+		self.assertEqual(markdown.status_code, 200)
+		self.assertIn("text/markdown", markdown.headers.get("Content-Type", ""))
+		self.assertTrue(markdown.get_data(as_text=True).startswith("---\n"))
 
 
 class TestStale404CacheInvalidation(WikiDocumentTestBase):

--- a/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
@@ -21,6 +21,7 @@ from wiki.frappe_wiki.doctype.wiki_document.wiki_document import (
 	WIKI_CONTENT_CACHE_KEY,
 	WikiDocumentRenderer,
 	clear_wiki_content_cache,
+	clear_wiki_tree_cache,
 	download_pdf,
 	get_public_wiki_tree,
 	get_rendered_content,
@@ -1819,6 +1820,111 @@ class TestCrawlerEndpoints(WikiDocumentTestBase):
 		self.assertEqual(markdown.status_code, 200)
 		self.assertIn("text/markdown", markdown.headers.get("Content-Type", ""))
 		self.assertTrue(markdown.get_data(as_text=True).startswith("---\n"))
+
+
+class TestSpaceLlmsTxt(WikiDocumentTestBase):
+	"""Tests for the per-space /<space>/llms.txt index."""
+
+	TEST_CLIENT = get_test_client()
+
+	def _unique(self, prefix):
+		return f"{prefix}-{frappe.generate_hash(length=6)}"
+
+	def _space_with_tree(self, guest_readable=True):
+		"""A space with untabbed content, a tab, a nested group and a draft page."""
+		root_group = create_test_wiki_document(self, "Root Llms", is_group=True)
+		# The space comes first: `is_tab` validates against the space's root group.
+		space = create_test_wiki_space(
+			self,
+			"Llms Space",
+			self._unique("llms-space"),
+			root_group.name,
+			roles=[("Guest", "Read")] if guest_readable else [],
+		)
+
+		intro = create_test_wiki_document(
+			self, "Introduction", parent=root_group.name, slug=self._unique("intro")
+		)
+		intro.meta_description = "What this is."
+		intro.save()
+
+		tab = create_test_wiki_document(self, "API Reference", parent=root_group.name, is_group=True)
+		tab.is_tab = 1
+		tab.save()
+		endpoints = create_test_wiki_document(
+			self, "Endpoints", parent=tab.name, slug=self._unique("endpoints")
+		)
+
+		nested_group = create_test_wiki_document(self, "Internals", parent=tab.name, is_group=True)
+		nested = create_test_wiki_document(
+			self, "Nested Page", parent=nested_group.name, slug=self._unique("nested")
+		)
+
+		draft = create_test_wiki_document(
+			self, "Draft Page", parent=root_group.name, slug=self._unique("draft")
+		)
+
+		frappe.db.set_value("Wiki Document", draft.name, "is_published", 0)
+		clear_wiki_tree_cache()
+		frappe.db.commit()  # nosemgrep: frappe-semgrep-rules.rules.frappe-manual-commit
+
+		return frappe._dict(
+			space=space,
+			intro=intro,
+			endpoints=endpoints,
+			nested=nested,
+			nested_group=nested_group,
+			draft=draft,
+		)
+
+	def test_space_llms_txt_mirrors_the_sidebar(self):
+		tree = self._space_with_tree()
+
+		response = _make_request(self.TEST_CLIENT, "get", f"/{tree.space.route}/llms.txt")
+
+		self.assertEqual(response.status_code, 200)
+		self.assertIn("text/plain", response.headers.get("Content-Type", ""))
+		self.assertIn("public", response.headers.get("Cache-Control", ""))
+
+		body = response.get_data(as_text=True)
+		lines = body.splitlines()
+
+		self.assertEqual(lines[0], "# Llms Space")
+		self.assertIn("> What this is.", lines)
+		self.assertIn("## Home", lines)
+		self.assertIn("## API Reference", lines)
+
+		# Untabbed top-level content lands under Home, tabbed content under its tab.
+		self.assertIn(f"- [Introduction](http://localhost:8000/{tree.intro.route}.md): What this is.", lines)
+		self.assertIn(f"- [Endpoints](http://localhost:8000/{tree.endpoints.route}.md)", lines)
+
+		# A group has no page of its own, so it is a label; its children indent under it.
+		self.assertIn("- **Internals**", lines)
+		self.assertIn(f"  - [Nested Page](http://localhost:8000/{tree.nested.route}.md)", lines)
+
+	def test_space_llms_txt_omits_unpublished_pages(self):
+		tree = self._space_with_tree()
+
+		response = _make_request(self.TEST_CLIENT, "get", f"/{tree.space.route}/llms.txt")
+
+		self.assertNotIn("Draft Page", response.get_data(as_text=True))
+
+	def test_space_llms_txt_links_only_to_markdown(self):
+		tree = self._space_with_tree()
+
+		body = _make_request(self.TEST_CLIENT, "get", f"/{tree.space.route}/llms.txt").get_data(as_text=True)
+
+		links = re.findall(r"\]\((http[^)]+)\)", body)
+		self.assertTrue(links)
+		for link in links:
+			self.assertTrue(link.endswith(".md"), f"{link} is not a markdown link")
+
+	def test_space_llms_txt_is_not_found_for_a_restricted_space(self):
+		tree = self._space_with_tree(guest_readable=False)
+
+		response = _make_request(self.TEST_CLIENT, "get", f"/{tree.space.route}/llms.txt")
+
+		self.assertEqual(response.status_code, 404)
 
 
 class TestStale404CacheInvalidation(WikiDocumentTestBase):

--- a/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
@@ -11,7 +11,7 @@ import unittest
 from threading import Thread
 from types import SimpleNamespace
 from unittest.mock import patch
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 from xml.etree import ElementTree
 
 import frappe
@@ -1595,6 +1595,11 @@ class TestWikiDocumentPdfDownload(WikiDocumentTestBase):
 		self.assertIn("<h2", page.rendered_content_for_pdf)
 
 
+def _sitemap_routes(xml: str) -> set:
+	"""Routes listed in a sitemap, without the host it was served under."""
+	return {urlparse(loc).path.lstrip("/") for loc in re.findall(r"<loc>([^<]+)</loc>", xml)}
+
+
 def _make_request(test_client, method, path, **kwargs):
 	"""Run a werkzeug test-client request in a thread (mirrors frappe test_api pattern)."""
 	site = frappe.local.site
@@ -1849,6 +1854,19 @@ class TestSpaceLlmsTxt(WikiDocumentTestBase):
 	def _unique(self, prefix):
 		return f"{prefix}-{frappe.generate_hash(length=6)}"
 
+	def assertEntry(self, lines, route, prefix, suffix=""):
+		"""Assert one list entry links to `route` and has the expected shape.
+
+		The absolute URLs in these files carry whatever host the request ran
+		against — `localhost` in CI, `localhost:8000` on a dev bench — so the
+		entry is found by route and only its ends are asserted.
+		"""
+		matches = [line for line in lines if f"/{route}.md)" in line]
+		self.assertEqual(len(matches), 1, f"expected exactly one entry for {route}, got {matches}")
+		entry = matches[0]
+		self.assertTrue(entry.startswith(prefix), f"{entry!r} does not start with {prefix!r}")
+		self.assertTrue(entry.endswith(suffix), f"{entry!r} does not end with {suffix!r}")
+
 	def _space_with_tree(self, guest_readable=True):
 		"""A space with untabbed content, a tab, a nested group and a draft page."""
 		root_group = create_test_wiki_document(self, "Root Llms", is_group=True)
@@ -1914,12 +1932,12 @@ class TestSpaceLlmsTxt(WikiDocumentTestBase):
 		self.assertIn("## API Reference", lines)
 
 		# Untabbed top-level content lands under Home, tabbed content under its tab.
-		self.assertIn(f"- [Introduction](http://localhost:8000/{tree.intro.route}.md): What this is.", lines)
-		self.assertIn(f"- [Endpoints](http://localhost:8000/{tree.endpoints.route}.md)", lines)
+		self.assertEntry(lines, tree.intro.route, "- [Introduction](", "): What this is.")
+		self.assertEntry(lines, tree.endpoints.route, "- [Endpoints](", ")")
 
 		# A group has no page of its own, so it is a label; its children indent under it.
 		self.assertIn("- **Internals**", lines)
-		self.assertIn(f"  - [Nested Page](http://localhost:8000/{tree.nested.route}.md)", lines)
+		self.assertEntry(lines, tree.nested.route, "  - [Nested Page](", ")")
 
 	def test_space_llms_txt_omits_unpublished_pages(self):
 		tree = self._space_with_tree()
@@ -1954,7 +1972,7 @@ class TestSpaceLlmsTxt(WikiDocumentTestBase):
 
 		body = _make_request(self.TEST_CLIENT, "get", f"/{tree.space.route}/llms.txt").get_data(as_text=True)
 
-		self.assertIn(f"](http://localhost:8000/{hostile.route}.md)", body)
+		self.assertEntry(body.splitlines(), hostile.route, "- [Click \\](https://evil.example) here](")
 		self.assertIn("Click \\](https://evil.example) here", body)
 		# The multiline description collapses instead of becoming its own entry.
 		self.assertNotIn("\n- [Injected]", body)
@@ -1980,7 +1998,7 @@ class TestSpaceLlmsTxt(WikiDocumentTestBase):
 		body = response.get_data(as_text=True)
 		self.assertTrue(body.startswith("# "))
 		self.assertIn("## Spaces", body)
-		self.assertIn(f"(http://localhost:8000/{public.space.route}/llms.txt)", body)
+		self.assertIn(f"/{public.space.route}/llms.txt)", body)
 		self.assertNotIn(f"/{restricted.space.route}/llms.txt", body)
 
 	def test_site_llms_txt_survives_a_space_whose_root_group_is_gone(self):
@@ -2016,7 +2034,7 @@ class TestSpaceLlmsTxt(WikiDocumentTestBase):
 		self.assertIn(f"/{added.route}.md", body)
 
 		sitemap = _make_request(self.TEST_CLIENT, "get", "/sitemap.xml").get_data(as_text=True)
-		self.assertIn(f"<loc>http://localhost:8000/{added.route}</loc>", sitemap)
+		self.assertIn(added.route, _sitemap_routes(sitemap))
 
 	def test_site_index_is_rebuilt_when_a_space_is_added(self):
 		self._space_with_tree()
@@ -2038,18 +2056,18 @@ class TestSpaceLlmsTxt(WikiDocumentTestBase):
 		self.assertIn("xml", response.headers.get("Content-Type", ""))
 
 		body = response.get_data(as_text=True)
-		locations = re.findall(r"<loc>([^<]+)</loc>", body)
+		routes = _sitemap_routes(body)
 
 		# Parses, and every entry is a page — not a group, a draft or a `.md` twin.
 		ElementTree.fromstring(body)
-		self.assertIn(f"http://localhost:8000/{public.intro.route}", locations)
-		self.assertIn(f"http://localhost:8000/{public.nested.route}", locations)
-		self.assertNotIn(f"http://localhost:8000/{public.draft.route}", locations)
-		self.assertNotIn(f"http://localhost:8000/{restricted.intro.route}", locations)
-		self.assertFalse([loc for loc in locations if loc.endswith(".md")])
+		self.assertIn(public.intro.route, routes)
+		self.assertIn(public.nested.route, routes)
+		self.assertNotIn(public.draft.route, routes)
+		self.assertNotIn(restricted.intro.route, routes)
+		self.assertFalse([route for route in routes if route.endswith(".md")])
 		self.assertNotIn(
-			f"http://localhost:8000/{public.nested_group.route}",
-			locations,
+			public.nested_group.route,
+			routes,
 			"groups are not served at their own route",
 		)
 

--- a/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
@@ -631,17 +631,12 @@ class WikiDocumentRenderer(BaseRenderer):
 			self.wiki_doc_name = leaf
 			return True
 
-		# A group / Wiki Space route with no page of its own: redirect to first child.
-		root_group = frappe.db.get_value(
-			"Wiki Document", {"route": self.path, "is_group": 1}, "name"
-		) or frappe.db.get_value("Wiki Space", {"route": self.path, "is_published": 1}, "root_group")
-
-		# Redirect to the first page in sidebar order (sort_order at each level),
-		# so the space URL lands on the same document the sidebar shows first.
-		if root_group:
-			first_page = get_first_published_page(root_group)
-			if first_page:
-				frappe.redirect("/" + first_page["route"])
+		# A group / Wiki Space route with no page of its own: redirect to the first
+		# page in sidebar order (sort_order at each level), so the space URL lands
+		# on the same document the sidebar shows first.
+		first_page = get_landing_page_for_route(self.path)
+		if first_page:
+			frappe.redirect("/" + first_page["route"])
 
 		return False
 
@@ -809,6 +804,37 @@ def clear_wiki_content_cache(doc_name: str | None = None):
 	else:
 		cache.delete_value(WIKI_CONTENT_CACHE_KEY)
 		frappe.db.after_commit.add(lambda: frappe.cache().delete_value(WIKI_CONTENT_CACHE_KEY))
+
+
+def get_landing_page_for_route(route: str) -> dict | None:
+	"""The page a group / Wiki Space route should redirect to, for this user.
+
+	Returns None when the caller may not read the owning space. The check has to
+	happen *before* the redirect: a Location header naming the space's first
+	page would hand a private route to a visitor who is then 404'd when they
+	follow it.
+	"""
+	from wiki.permissions import can_read_space
+
+	group = frappe.db.get_value(
+		"Wiki Document", {"route": route, "is_group": 1}, ["name", "wiki_space"], as_dict=True
+	)
+	if group:
+		root_group, space = group.name, group.wiki_space
+	else:
+		space_doc = frappe.db.get_value(
+			"Wiki Space", {"route": route, "is_published": 1}, ["name", "root_group"], as_dict=True
+		)
+		if not space_doc:
+			return None
+		root_group, space = space_doc.root_group, space_doc.name
+
+	# An orphan group belongs to no space and stays readable by all, matching
+	# check_space_access.
+	if space and not can_read_space(space):
+		return None
+
+	return get_first_published_page(root_group) if root_group else None
 
 
 def get_first_published_page(root_group: str) -> dict | None:

--- a/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
@@ -962,8 +962,14 @@ def clear_wiki_tree_cache():
 	new space. Cleared again after commit to close the race where another
 	worker re-caches from pre-commit DB state.
 	"""
+	from wiki.wiki.crawler_cache import clear_crawler_cache
+
 	frappe.cache().delete_value(WIKI_TREE_CACHE_KEY)
 	frappe.db.after_commit.add(lambda: frappe.cache().delete_value(WIKI_TREE_CACHE_KEY))
+
+	# llms.txt and sitemap.xml are built from this same tree, so they go stale
+	# at exactly the same moments.
+	clear_crawler_cache()
 
 
 @frappe.whitelist()

--- a/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
@@ -27,6 +27,11 @@ WIKI_CONTENT_CACHE_KEY = "wiki_rendered_content"
 # Kept in sync with GENERAL_KEY in frontend/src/lib/spaceTabs.js.
 WIKI_HOME_TAB_KEY = "__general__"
 
+# Markdown is served under the page's own permissions, so a shared cache must
+# never hold it -- the same URL yields 404 for a reader without space access.
+# Mirrors what frappe serves the HTML page (frappe/website/utils.py cache_html).
+MARKDOWN_CACHE_CONTROL = "private, max-age=300, stale-while-revalidate=10800"
+
 # Mapping of known service domains to icon identifiers
 KNOWN_SERVICE_ICONS = {
 	"github.com": "github",
@@ -533,6 +538,32 @@ class WikiDocument(NestedSet):
 			"itemListElement": [space_item, current_item],
 		}
 
+	def as_markdown(self) -> str:
+		"""The page's markdown source with a YAML frontmatter header.
+
+		Shared by the `.md` route and the `Accept: text/markdown` branch so the
+		two representations of a page can never drift.
+
+		Values are serialised with json.dumps -- a JSON string is also a valid
+		YAML double-quoted scalar, so quotes and newlines escape correctly
+		instead of breaking the header.
+		"""
+		space = self.get_wiki_space()
+		frontmatter = {
+			"title": self.meta_title or self.title,
+			"description": self.meta_description,
+			"space": space.get("space_name") if space else None,
+			"url": frappe.utils.get_url("/" + self.route) if self.route else None,
+			"updated": frappe.utils.get_datetime(self.modified).strftime("%Y-%m-%d")
+			if self.modified
+			else None,
+		}
+		lines = [f"{key}: {json.dumps(value)}" for key, value in frontmatter.items() if value]
+		if not lines:
+			return self.content or ""
+
+		return "---\n" + "\n".join(lines) + "\n---\n\n" + (self.content or "")
+
 	def before_print(self, print_settings=None):
 		"""Render markdown content so the print format can drop it in as HTML."""
 		self.rendered_content_for_pdf = render_markdown(self.content or "")
@@ -622,9 +653,8 @@ class WikiDocumentRenderer(BaseRenderer):
 		if "text/markdown" in accept:
 			doc.check_space_access("read")
 			doc.check_published()
-			response = Response()
-			response.data = doc.content or ""
-			response.headers["Content-Type"] = "text/markdown; charset=utf-8"
+			response = build_markdown_response(doc)
+			response.headers["Vary"] = "Accept"
 			return response
 
 		context = doc.get_web_context()
@@ -635,7 +665,27 @@ class WikiDocumentRenderer(BaseRenderer):
 		context["csrf_token"] = csrf_token
 
 		html = frappe.render_template("templates/wiki/document.html", context)
-		return self.build_response(html)
+		response = self.build_response(html)
+		# This URL has two representations, so every response from it -- HTML
+		# included -- has to tell caches which header picked this one.
+		response.headers["Vary"] = "Accept"
+		return response
+
+
+def build_markdown_response(doc) -> Response:
+	"""A raw werkzeug markdown response for a Wiki Document.
+
+	Raw rather than build_response: that attaches X-Page-Name and asset-preload
+	headers, which mean nothing on plain text (same reasoning as
+	wiki/api/og_image.py).
+
+	Callers are responsible for the access checks -- this only formats.
+	"""
+	response = Response()
+	response.data = doc.as_markdown()
+	response.headers["Content-Type"] = "text/markdown; charset=utf-8"
+	response.headers["Cache-Control"] = MARKDOWN_CACHE_CONTROL
+	return response
 
 
 def build_nested_wiki_tree(documents: list[str]):

--- a/wiki/hooks.py
+++ b/wiki/hooks.py
@@ -129,6 +129,12 @@ doc_events = {
 		"on_update": "wiki.frappe_wiki.doctype.wiki_document.wiki_document.on_wiki_document_update",
 		"on_trash": "wiki.frappe_wiki.doctype.wiki_document.wiki_document.on_wiki_document_trash",
 	},
+	# A space's roles, route and publish state decide what the crawler indexes
+	# list, and none of them touch a Wiki Document.
+	"Wiki Space": {
+		"on_update": "wiki.wiki.crawler_cache.clear_crawler_cache",
+		"on_trash": "wiki.wiki.crawler_cache.clear_crawler_cache",
+	},
 }
 
 # Auto-prune the webhook delivery log (Frappe's daily log-clearing runs each

--- a/wiki/hooks.py
+++ b/wiki/hooks.py
@@ -17,7 +17,12 @@ add_to_apps_screen = [
 	}
 ]
 
-page_renderer = "wiki.frappe_wiki.doctype.wiki_document.wiki_document.WikiDocumentRenderer"
+page_renderer = [
+	# Crawler routes (.md, llms.txt, sitemap.xml) resolve first — they take over
+	# paths that would otherwise fall through to the reader or the framework.
+	"wiki.wiki.crawler_renderer.CrawlerRenderer",
+	"wiki.frappe_wiki.doctype.wiki_document.wiki_document.WikiDocumentRenderer",
+]
 export_python_type_annotations = True
 
 # SQLite Search

--- a/wiki/templates/wiki/layout.html
+++ b/wiki/templates/wiki/layout.html
@@ -12,6 +12,7 @@
     {% include "templates/includes/meta_block.html" %}
     {% if canonical_url %}
     <link rel="canonical" href="{{ canonical_url }}">
+    <link rel="alternate" type="text/markdown" href="{{ canonical_url }}.md">
     {% endif %}
     {% if breadcrumbs %}
     <script type="application/ld+json">{{ breadcrumbs | safe }}</script>

--- a/wiki/wiki/crawler_cache.py
+++ b/wiki/wiki/crawler_cache.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+
+"""Redis cache for the crawler indexes (llms.txt, sitemap.xml).
+
+Each index walks every public space's tree, which is far more work than a page
+render, and the result is the same for every visitor -- they are built as Guest
+by construction. So they are cached whole and dropped on any wiki write, the
+same way the sidebar tree is.
+"""
+
+import frappe
+
+CACHE_KEY = "wiki_crawler_index"
+
+SITE_LLMS_TXT = "llms-txt:__site__"
+SITEMAP = "sitemap"
+
+
+def space_llms_txt_key(space: str) -> str:
+	return f"llms-txt:{space}"
+
+
+def cached_index(key: str, build) -> str | None:
+	"""Return a cached index body, building it on a miss.
+
+	"No index for this key" is cached as an empty string rather than skipped,
+	so a crawler hammering a route that has nothing to serve doesn't rebuild
+	the answer every time.
+	"""
+	cache = frappe.cache()
+	body = cache.hget(CACHE_KEY, key)
+	if body is None:
+		body = build() or ""
+		cache.hset(CACHE_KEY, key, body)
+	return body or None
+
+
+def clear_crawler_cache(doc=None, method=None):
+	"""Drop every cached index.
+
+	Cleared wholesale because one page can move between spaces, and the space
+	list itself sits in the site index. Cleared again after commit to close the
+	race where another worker re-caches from pre-commit state -- same reasoning
+	as clear_wiki_tree_cache, which calls this.
+	"""
+	frappe.cache().delete_value(CACHE_KEY)
+	frappe.db.after_commit.add(lambda: frappe.cache().delete_value(CACHE_KEY))

--- a/wiki/wiki/crawler_renderer.py
+++ b/wiki/wiki/crawler_renderer.py
@@ -10,39 +10,82 @@ framework already owns.
 
 can_render is a suffix check first and a query second, so a normal page load
 pays almost nothing for this renderer sitting in front of the reader.
+
+Index routes (llms.txt) are always built as Guest, whoever asks for them. They
+are crawler artefacts: a session-dependent body would be uncacheable, and one
+built with an editor's visibility would publish routes the crawler must not see.
+Page markdown is the opposite -- it follows the page's own permissions, exactly
+like the HTML page does.
 """
 
 import frappe
 from frappe.website.page_renderers.base_renderer import BaseRenderer
+from werkzeug.wrappers import Response
 
 from wiki.frappe_wiki.doctype.wiki_document.wiki_document import (
 	build_markdown_response,
 	get_first_published_page,
 )
+from wiki.permissions import can_read_space
 
 MARKDOWN_SUFFIX = ".md"
+LLMS_TXT = "llms.txt"
+
+# Guest-only, published content with no per-user variation, so a shared cache
+# can hold it. Short enough that a newly published page shows up within the hour.
+INDEX_CACHE_CONTROL = "public, max-age=3600"
 
 
 class CrawlerRenderer(BaseRenderer):
 	def can_render(self) -> bool:
-		if not self.path.endswith(MARKDOWN_SUFFIX):
+		self.handler = None
+
+		if self.path.endswith("/" + LLMS_TXT):
+			return self._match_space_llms_txt(self.path[: -len("/" + LLMS_TXT)])
+
+		if self.path.endswith(MARKDOWN_SUFFIX):
+			return self._match_markdown()
+
+		return False
+
+	def render(self):
+		return self.handler()
+
+	# -- llms.txt ---------------------------------------------------------
+
+	def _match_space_llms_txt(self, route: str) -> bool:
+		space = frappe.db.get_value("Wiki Space", {"route": route, "is_published": 1}, "name")
+		if not space or not can_read_space(space, "Guest"):
 			return False
 
+		self.llms_txt_space = space
+		self.handler = self._render_space_llms_txt
+		return True
+
+	def _render_space_llms_txt(self):
+		from wiki.wiki.llms_txt import build_space_llms_txt
+
+		body = build_space_llms_txt(self.llms_txt_space)
+		if not body:
+			# An empty space has no index to serve; 404 rather than an empty file.
+			frappe.throw(frappe._("Page not found"), frappe.DoesNotExistError)
+
+		return _text_response(body)
+
+	# -- <route>.md -------------------------------------------------------
+
+	def _match_markdown(self) -> bool:
 		# A page can legitimately be routed at something ending in ".md". Its own
 		# URL stays HTML -- it is handed straight to WikiDocumentRenderer -- and
 		# its markdown lives one suffix further out, at "<route>.md".
 		if frappe.db.exists("Wiki Document", {"route": self.path}):
 			return False
 
-		return self._resolve_markdown(self.path[: -len(MARKDOWN_SUFFIX)])
+		route = self.path[: -len(MARKDOWN_SUFFIX)]
 
-	def _resolve_markdown(self, route: str) -> bool:
-		"""Resolve a stripped route the same way the reader resolves an HTML page.
-
-		Mirrors WikiDocumentRenderer.can_render: a published leaf wins, and a
-		group / space route with no page of its own redirects to its first
-		published page -- here, to that page's `.md`.
-		"""
+		# Mirrors WikiDocumentRenderer.can_render: a published leaf wins, and a
+		# group / space route with no page of its own redirects to its first
+		# published page -- here, to that page's `.md`.
 		leaf = frappe.db.get_value(
 			"Wiki Document",
 			{"route": route, "is_group": 0, "is_published": 1, "is_external_link": 0},
@@ -50,6 +93,7 @@ class CrawlerRenderer(BaseRenderer):
 		)
 		if leaf:
 			self.wiki_doc_name = leaf
+			self.handler = self._render_markdown
 			return True
 
 		root_group = frappe.db.get_value(
@@ -63,10 +107,23 @@ class CrawlerRenderer(BaseRenderer):
 
 		return False
 
-	def render(self):
+	def _render_markdown(self):
 		doc = frappe.get_cached_doc("Wiki Document", self.wiki_doc_name)
 		# 404 rather than 403 on a restricted space, so a `.md` URL cannot be used
 		# to probe for pages the reader itself would hide.
 		doc.check_space_access("read")
 		doc.check_published()
 		return build_markdown_response(doc)
+
+
+def _text_response(body: str) -> Response:
+	"""text/plain rather than text/markdown so a browser shows these in-tab.
+
+	Raw werkzeug, like build_markdown_response — build_response's page headers
+	mean nothing on a crawler index.
+	"""
+	response = Response()
+	response.data = body
+	response.headers["Content-Type"] = "text/plain; charset=utf-8"
+	response.headers["Cache-Control"] = INDEX_CACHE_CONTROL
+	return response

--- a/wiki/wiki/crawler_renderer.py
+++ b/wiki/wiki/crawler_renderer.py
@@ -24,7 +24,7 @@ from werkzeug.wrappers import Response
 
 from wiki.frappe_wiki.doctype.wiki_document.wiki_document import (
 	build_markdown_response,
-	get_first_published_page,
+	get_landing_page_for_route,
 )
 from wiki.permissions import can_read_space
 
@@ -133,14 +133,11 @@ class CrawlerRenderer(BaseRenderer):
 			self.handler = self._render_markdown
 			return True
 
-		root_group = frappe.db.get_value(
-			"Wiki Document", {"route": route, "is_group": 1}, "name"
-		) or frappe.db.get_value("Wiki Space", {"route": route, "is_published": 1}, "root_group")
-
-		if root_group:
-			first_page = get_first_published_page(root_group)
-			if first_page:
-				frappe.redirect("/" + first_page["route"] + MARKDOWN_SUFFIX)
+		# get_landing_page_for_route gates on space access, so a restricted space's
+		# `.md` URL 404s instead of naming its first page in a Location header.
+		first_page = get_landing_page_for_route(route)
+		if first_page:
+			frappe.redirect("/" + first_page["route"] + MARKDOWN_SUFFIX)
 
 		return False
 

--- a/wiki/wiki/crawler_renderer.py
+++ b/wiki/wiki/crawler_renderer.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+
+"""Routes that exist for crawlers and agents rather than for readers.
+
+Registered ahead of WikiDocumentRenderer in hooks.py, because a custom
+page_renderer runs before frappe's StaticPage/TemplatePage (see
+frappe/website/path_resolver.py) -- which is what lets this take over routes the
+framework already owns.
+
+can_render is a suffix check first and a query second, so a normal page load
+pays almost nothing for this renderer sitting in front of the reader.
+"""
+
+import frappe
+from frappe.website.page_renderers.base_renderer import BaseRenderer
+
+from wiki.frappe_wiki.doctype.wiki_document.wiki_document import (
+	build_markdown_response,
+	get_first_published_page,
+)
+
+MARKDOWN_SUFFIX = ".md"
+
+
+class CrawlerRenderer(BaseRenderer):
+	def can_render(self) -> bool:
+		if not self.path.endswith(MARKDOWN_SUFFIX):
+			return False
+
+		# A page can legitimately be routed at something ending in ".md". Its own
+		# URL stays HTML -- it is handed straight to WikiDocumentRenderer -- and
+		# its markdown lives one suffix further out, at "<route>.md".
+		if frappe.db.exists("Wiki Document", {"route": self.path}):
+			return False
+
+		return self._resolve_markdown(self.path[: -len(MARKDOWN_SUFFIX)])
+
+	def _resolve_markdown(self, route: str) -> bool:
+		"""Resolve a stripped route the same way the reader resolves an HTML page.
+
+		Mirrors WikiDocumentRenderer.can_render: a published leaf wins, and a
+		group / space route with no page of its own redirects to its first
+		published page -- here, to that page's `.md`.
+		"""
+		leaf = frappe.db.get_value(
+			"Wiki Document",
+			{"route": route, "is_group": 0, "is_published": 1, "is_external_link": 0},
+			"name",
+		)
+		if leaf:
+			self.wiki_doc_name = leaf
+			return True
+
+		root_group = frappe.db.get_value(
+			"Wiki Document", {"route": route, "is_group": 1}, "name"
+		) or frappe.db.get_value("Wiki Space", {"route": route, "is_published": 1}, "root_group")
+
+		if root_group:
+			first_page = get_first_published_page(root_group)
+			if first_page:
+				frappe.redirect("/" + first_page["route"] + MARKDOWN_SUFFIX)
+
+		return False
+
+	def render(self):
+		doc = frappe.get_cached_doc("Wiki Document", self.wiki_doc_name)
+		# 404 rather than 403 on a restricted space, so a `.md` URL cannot be used
+		# to probe for pages the reader itself would hide.
+		doc.check_space_access("read")
+		doc.check_published()
+		return build_markdown_response(doc)

--- a/wiki/wiki/crawler_renderer.py
+++ b/wiki/wiki/crawler_renderer.py
@@ -40,6 +40,11 @@ class CrawlerRenderer(BaseRenderer):
 	def can_render(self) -> bool:
 		self.handler = None
 
+		if self.path == LLMS_TXT:
+			from wiki.wiki.llms_txt import build_site_llms_txt
+
+			return self._match_index(build_site_llms_txt())
+
 		if self.path.endswith("/" + LLMS_TXT):
 			return self._match_space_llms_txt(self.path[: -len("/" + LLMS_TXT)])
 
@@ -54,23 +59,29 @@ class CrawlerRenderer(BaseRenderer):
 	# -- llms.txt ---------------------------------------------------------
 
 	def _match_space_llms_txt(self, route: str) -> bool:
+		from wiki.wiki.llms_txt import build_space_llms_txt
+
 		space = frappe.db.get_value("Wiki Space", {"route": route, "is_published": 1}, "name")
 		if not space or not can_read_space(space, "Guest"):
 			return False
 
-		self.llms_txt_space = space
-		self.handler = self._render_space_llms_txt
+		return self._match_index(build_space_llms_txt(space))
+
+	def _match_index(self, body: str | None) -> bool:
+		"""Claim the route only when there is an index to serve.
+
+		A wiki with nothing public leaves /llms.txt to whatever the site had
+		there before, rather than taking it over to serve an empty file.
+		"""
+		if not body:
+			return False
+
+		self.index_body = body
+		self.handler = self._render_index
 		return True
 
-	def _render_space_llms_txt(self):
-		from wiki.wiki.llms_txt import build_space_llms_txt
-
-		body = build_space_llms_txt(self.llms_txt_space)
-		if not body:
-			# An empty space has no index to serve; 404 rather than an empty file.
-			frappe.throw(frappe._("Page not found"), frappe.DoesNotExistError)
-
-		return _text_response(body)
+	def _render_index(self):
+		return _text_response(self.index_body)
 
 	# -- <route>.md -------------------------------------------------------
 

--- a/wiki/wiki/crawler_renderer.py
+++ b/wiki/wiki/crawler_renderer.py
@@ -30,6 +30,7 @@ from wiki.permissions import can_read_space
 
 MARKDOWN_SUFFIX = ".md"
 LLMS_TXT = "llms.txt"
+SITEMAP_XML = "sitemap.xml"
 
 # Guest-only, published content with no per-user variation, so a shared cache
 # can hold it. Short enough that a newly published page shows up within the hour.
@@ -47,6 +48,11 @@ class CrawlerRenderer(BaseRenderer):
 
 		if self.path.endswith("/" + LLMS_TXT):
 			return self._match_space_llms_txt(self.path[: -len("/" + LLMS_TXT)])
+
+		if self.path == SITEMAP_XML:
+			from wiki.wiki.sitemap import build_sitemap_xml
+
+			return self._match_sitemap(build_sitemap_xml())
 
 		if self.path.endswith(MARKDOWN_SUFFIX):
 			return self._match_markdown()
@@ -82,6 +88,26 @@ class CrawlerRenderer(BaseRenderer):
 
 	def _render_index(self):
 		return _text_response(self.index_body)
+
+	# -- sitemap.xml ------------------------------------------------------
+
+	def _match_sitemap(self, body: str | None) -> bool:
+		"""Claim /sitemap.xml only when the wiki has routes to contribute.
+
+		A site with no public wiki keeps frappe's own sitemap page, so
+		installing this app never costs it its existing sitemap.
+		"""
+		if not body:
+			return False
+
+		self.index_body = body
+		self.handler = self._render_sitemap
+		return True
+
+	def _render_sitemap(self):
+		response = _text_response(self.index_body)
+		response.headers["Content-Type"] = "application/xml; charset=utf-8"
+		return response
 
 	# -- <route>.md -------------------------------------------------------
 

--- a/wiki/wiki/llms_txt.py
+++ b/wiki/wiki/llms_txt.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+
+"""llms.txt generation — an index of a wiki, written for LLM crawlers.
+
+Follows the llmstxt.org format: an H1, an optional blockquote summary, then H2
+sections containing nothing but markdown lists of links.
+
+Everything here is generated from the *published, Guest-readable* wiki only, and
+never from the requesting session — see wiki/wiki/crawler_renderer.py for why.
+"""
+
+import frappe
+from frappe import _
+
+from wiki.frappe_wiki.doctype.wiki_document.wiki_document import (
+	get_first_published_page,
+	get_public_wiki_tree,
+)
+
+MARKDOWN_HINT = "Append `.md` to any URL below for that page's raw markdown source."
+
+
+def build_space_llms_txt(space: str) -> str | None:
+	"""The llms.txt index for one Wiki Space, or None when it has no published pages.
+
+	Sections mirror the space's tabs, and each section's list mirrors the
+	sidebar tree — same source, so this index can never advertise a page the
+	reader doesn't show.
+	"""
+	space_doc = frappe.db.get_value(
+		"Wiki Space",
+		space,
+		["name", "space_name", "route", "root_group", "home_tab_title"],
+		as_dict=True,
+	)
+	if not space_doc or not space_doc.root_group:
+		return None
+
+	tree = get_public_wiki_tree(space_doc.root_group)
+	if not tree:
+		return None
+
+	pages = _published_pages(space_doc.name)
+
+	# Top-level tab groups become sections; anything untabbed goes under the
+	# space's Home tab, matching _home_tab_entry in the reader.
+	sections = []
+	untabbed = [node for node in tree if not node.get("is_tab")]
+	if untabbed:
+		sections.append((space_doc.home_tab_title or _("Home"), untabbed))
+	sections += [(node["title"], node.get("children") or []) for node in tree if node.get("is_tab")]
+
+	body = []
+	for title, nodes in sections:
+		items = _render_nodes(nodes, pages, depth=0)
+		if items:
+			body += ["", f"## {title}", "", *items]
+
+	if not body:
+		return None
+
+	lines = [f"# {space_doc.space_name or space_doc.name}", ""]
+	summary = _space_summary(space_doc.root_group, pages)
+	if summary:
+		lines += [f"> {summary}", ""]
+	lines.append(MARKDOWN_HINT)
+
+	return "\n".join(lines + body) + "\n"
+
+
+def _published_pages(space_name: str) -> dict:
+	"""``{route: meta_description}`` for every published page in a space.
+
+	Doubles as the "is there a page at this route?" lookup that decides whether
+	a group is linkable (the README/index case git-sync produces).
+	"""
+	rows = frappe.get_all(
+		"Wiki Document",
+		filters={
+			"wiki_space": space_name,
+			"is_published": 1,
+			"is_group": 0,
+			"is_external_link": 0,
+		},
+		fields=["route", "meta_description"],
+	)
+	return {row.route: row.meta_description for row in rows if row.route}
+
+
+def _space_summary(root_group: str, pages: dict) -> str | None:
+	"""The space's blockquote line: its landing page's meta description.
+
+	Derived rather than a field on Wiki Space — the landing page's description
+	is already the space's public one-liner (it is what search engines show for
+	the space URL), so there is nothing extra for an editor to fill in.
+	"""
+	landing = get_first_published_page(root_group)
+	return pages.get(landing["route"]) if landing else None
+
+
+def _render_nodes(nodes: list, pages: dict, depth: int) -> list[str]:
+	"""The sidebar tree as a nested markdown list, deepest-first indentation."""
+	indent = "  " * depth
+	items = []
+	for node in nodes:
+		items.append(f"{indent}- {_node_entry(node, pages)}")
+		items += _render_nodes(node.get("children") or [], pages, depth + 1)
+	return items
+
+
+def _node_entry(node: dict, pages: dict) -> str:
+	"""One list entry: a link to the page's markdown, or a bare label."""
+	title = node.get("title") or node["name"]
+	route = node.get("route")
+
+	if node.get("is_external_link"):
+		# Someone else's URL — there is no `.md` twin of it to point at.
+		return f"[{title}]({node['external_url']})" if node.get("external_url") else f"**{title}**"
+
+	# A group is served by redirecting to its first child, so it is only worth
+	# linking when a page of its own sits at its route.
+	if not route or (node.get("is_group") and route not in pages):
+		return f"**{title}**"
+
+	entry = f"[{title}]({frappe.utils.get_url('/' + route)}.md)"
+	description = pages.get(route)
+	return f"{entry}: {description}" if description else entry

--- a/wiki/wiki/llms_txt.py
+++ b/wiki/wiki/llms_txt.py
@@ -34,7 +34,7 @@ def build_site_llms_txt() -> str | None:
 	of publishing an empty index.
 	"""
 	entries = []
-	for space in _public_spaces():
+	for space in public_spaces():
 		landing = get_first_published_page(space.root_group)
 		if not landing:
 			# No page to read: the space's own index would be empty too.
@@ -53,7 +53,7 @@ def build_site_llms_txt() -> str | None:
 	return "\n".join(lines) + "\n"
 
 
-def _public_spaces() -> list:
+def public_spaces() -> list:
 	"""Published spaces a Guest may read, in the order the space switcher lists them."""
 	spaces = frappe.get_all(
 		"Wiki Space",

--- a/wiki/wiki/llms_txt.py
+++ b/wiki/wiki/llms_txt.py
@@ -18,6 +18,7 @@ from wiki.frappe_wiki.doctype.wiki_document.wiki_document import (
 	get_public_wiki_tree,
 )
 from wiki.permissions import can_read_space
+from wiki.wiki.crawler_cache import SITE_LLMS_TXT, cached_index, space_llms_txt_key
 
 MARKDOWN_HINT = "Append `.md` to any URL below for that page's raw markdown source."
 
@@ -33,6 +34,10 @@ def build_site_llms_txt() -> str | None:
 	Returns None when the site has no such space, so the route can 404 instead
 	of publishing an empty index.
 	"""
+	return cached_index(SITE_LLMS_TXT, _site_llms_txt)
+
+
+def _site_llms_txt() -> str | None:
 	entries = []
 	for space in public_spaces():
 		landing = get_first_published_page(space.root_group)
@@ -81,6 +86,10 @@ def build_space_llms_txt(space: str) -> str | None:
 	sidebar tree — same source, so this index can never advertise a page the
 	reader doesn't show.
 	"""
+	return cached_index(space_llms_txt_key(space), lambda: _space_llms_txt(space))
+
+
+def _space_llms_txt(space: str) -> str | None:
 	space_doc = frappe.db.get_value(
 		"Wiki Space",
 		space,

--- a/wiki/wiki/llms_txt.py
+++ b/wiki/wiki/llms_txt.py
@@ -17,8 +17,61 @@ from wiki.frappe_wiki.doctype.wiki_document.wiki_document import (
 	get_first_published_page,
 	get_public_wiki_tree,
 )
+from wiki.permissions import can_read_space
 
 MARKDOWN_HINT = "Append `.md` to any URL below for that page's raw markdown source."
+
+SITE_HINT = (
+	"Each space below links to its own llms.txt index. Append `.md` to any page "
+	"URL on this site to get that page's raw markdown source."
+)
+
+
+def build_site_llms_txt() -> str | None:
+	"""The site-wide llms.txt: one entry per publicly readable Wiki Space.
+
+	Returns None when the site has no such space, so the route can 404 instead
+	of publishing an empty index.
+	"""
+	entries = []
+	for space in _public_spaces():
+		landing = get_first_published_page(space.root_group)
+		if not landing:
+			# No page to read: the space's own index would be empty too.
+			continue
+
+		url = f"{frappe.utils.get_url('/' + space.route)}/llms.txt"
+		entry = f"- [{space.space_name or space.name}]({url})"
+		description = frappe.db.get_value("Wiki Document", {"route": landing["route"]}, "meta_description")
+		entries.append(f"{entry}: {description}" if description else entry)
+
+	if not entries:
+		return None
+
+	title = frappe.db.get_single_value("Website Settings", "app_name") or frappe.local.site
+	lines = [f"# {title}", "", SITE_HINT, "", "## Spaces", "", *entries]
+	return "\n".join(lines) + "\n"
+
+
+def _public_spaces() -> list:
+	"""Published spaces a Guest may read, in the order the space switcher lists them."""
+	spaces = frappe.get_all(
+		"Wiki Space",
+		filters={"is_published": 1},
+		fields=["name", "space_name", "route", "root_group"],
+		order_by="switcher_order asc, space_name asc",
+		ignore_permissions=True,
+	)
+	roots = [space.root_group for space in spaces if space.root_group]
+	# A space whose root group was deleted has no tree to walk, and walking it
+	# raises -- which would take the whole site index down over one bad space.
+	live_roots = set(frappe.get_all("Wiki Document", filters={"name": ["in", roots]}, pluck="name"))
+
+	return [
+		space
+		for space in spaces
+		if space.route and space.root_group in live_roots and can_read_space(space.name, "Guest")
+	]
 
 
 def build_space_llms_txt(space: str) -> str | None:
@@ -34,7 +87,10 @@ def build_space_llms_txt(space: str) -> str | None:
 		["name", "space_name", "route", "root_group", "home_tab_title"],
 		as_dict=True,
 	)
+	# A root group that was deleted leaves nothing to walk, and walking it raises.
 	if not space_doc or not space_doc.root_group:
+		return None
+	if not frappe.db.exists("Wiki Document", space_doc.root_group):
 		return None
 
 	tree = get_public_wiki_tree(space_doc.root_group)

--- a/wiki/wiki/llms_txt.py
+++ b/wiki/wiki/llms_txt.py
@@ -10,6 +10,8 @@ Everything here is generated from the *published, Guest-readable* wiki only, and
 never from the requesting session — see wiki/wiki/crawler_renderer.py for why.
 """
 
+import re
+
 import frappe
 from frappe import _
 
@@ -46,14 +48,16 @@ def _site_llms_txt() -> str | None:
 			continue
 
 		url = f"{frappe.utils.get_url('/' + space.route)}/llms.txt"
-		entry = f"- [{space.space_name or space.name}]({url})"
-		description = frappe.db.get_value("Wiki Document", {"route": landing["route"]}, "meta_description")
+		entry = f"- [{_label(space.space_name or space.name)}]({url})"
+		description = _one_line(
+			frappe.db.get_value("Wiki Document", {"route": landing["route"]}, "meta_description")
+		)
 		entries.append(f"{entry}: {description}" if description else entry)
 
 	if not entries:
 		return None
 
-	title = frappe.db.get_single_value("Website Settings", "app_name") or frappe.local.site
+	title = _one_line(frappe.db.get_single_value("Website Settings", "app_name")) or frappe.local.site
 	lines = [f"# {title}", "", SITE_HINT, "", "## Spaces", "", *entries]
 	return "\n".join(lines) + "\n"
 
@@ -113,8 +117,10 @@ def _space_llms_txt(space: str) -> str | None:
 	sections = []
 	untabbed = [node for node in tree if not node.get("is_tab")]
 	if untabbed:
-		sections.append((space_doc.home_tab_title or _("Home"), untabbed))
-	sections += [(node["title"], node.get("children") or []) for node in tree if node.get("is_tab")]
+		sections.append((_one_line(space_doc.home_tab_title) or _("Home"), untabbed))
+	sections += [
+		(_one_line(node["title"]), node.get("children") or []) for node in tree if node.get("is_tab")
+	]
 
 	body = []
 	for title, nodes in sections:
@@ -125,8 +131,8 @@ def _space_llms_txt(space: str) -> str | None:
 	if not body:
 		return None
 
-	lines = [f"# {space_doc.space_name or space_doc.name}", ""]
-	summary = _space_summary(space_doc.root_group, pages)
+	lines = [f"# {_one_line(space_doc.space_name) or space_doc.name}", ""]
+	summary = _one_line(_space_summary(space_doc.root_group, pages))
 	if summary:
 		lines += [f"> {summary}", ""]
 	lines.append(MARKDOWN_HINT)
@@ -176,12 +182,14 @@ def _render_nodes(nodes: list, pages: dict, depth: int) -> list[str]:
 
 def _node_entry(node: dict, pages: dict) -> str:
 	"""One list entry: a link to the page's markdown, or a bare label."""
-	title = node.get("title") or node["name"]
+	title = _label(node.get("title") or node["name"])
 	route = node.get("route")
 
 	if node.get("is_external_link"):
-		# Someone else's URL — there is no `.md` twin of it to point at.
-		return f"[{title}]({node['external_url']})" if node.get("external_url") else f"**{title}**"
+		# Someone else's URL — there is no `.md` twin of it to point at. Angle
+		# brackets keep a destination with parentheses in it from ending the link.
+		url = _one_line(node.get("external_url")).replace("<", "").replace(">", "")
+		return f"[{title}](<{url}>)" if url else f"**{title}**"
 
 	# A group is served by redirecting to its first child, so it is only worth
 	# linking when a page of its own sits at its route.
@@ -189,5 +197,23 @@ def _node_entry(node: dict, pages: dict) -> str:
 		return f"**{title}**"
 
 	entry = f"[{title}]({frappe.utils.get_url('/' + route)}.md)"
-	description = pages.get(route)
+	description = _one_line(pages.get(route))
 	return f"{entry}: {description}" if description else entry
+
+
+def _one_line(text: str | None) -> str:
+	"""Collapse a title or description onto one line.
+
+	Both are editor-controlled and both are free text: a newline in either would
+	end the list item it sits in and turn the rest into new entries.
+	"""
+	return " ".join((text or "").split())
+
+
+def _label(text: str | None) -> str:
+	"""A link label that cannot escape its own brackets.
+
+	`[` / `]` in a title would otherwise re-point the link at whatever follows,
+	which is a real redirect primitive when the reader is a crawler.
+	"""
+	return re.sub(r"([\\\[\]])", r"\\\1", _one_line(text))

--- a/wiki/wiki/sitemap.py
+++ b/wiki/wiki/sitemap.py
@@ -18,6 +18,7 @@ from frappe.utils import get_url, nowdate
 from frappe.website.router import get_pages
 from frappe.www.sitemap import get_public_pages_from_doctypes
 
+from wiki.wiki.crawler_cache import SITEMAP, cached_index
 from wiki.wiki.llms_txt import public_spaces
 
 
@@ -27,6 +28,10 @@ def build_sitemap_xml() -> str | None:
 	Returning None leaves /sitemap.xml to the framework, so installing this app
 	on a site with no public wiki changes nothing.
 	"""
+	return cached_index(SITEMAP, _sitemap_xml)
+
+
+def _sitemap_xml() -> str | None:
 	wiki_links = _wiki_links()
 	if not wiki_links:
 		return None

--- a/wiki/wiki/sitemap.py
+++ b/wiki/wiki/sitemap.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+
+"""sitemap.xml, with wiki routes in it.
+
+frappe's own sitemap (frappe/www/sitemap.py) walks doctypes that have a web
+view, guest view enabled, and a published field. Wiki Document has none of
+those -- it renders through a page_renderer -- so no wiki route has ever been
+listed. This rebuilds the framework's list and adds the wiki's own routes to it,
+so taking over the route loses nothing that was there before.
+"""
+
+from urllib.parse import quote
+from xml.sax.saxutils import escape
+
+import frappe
+from frappe.utils import get_url, nowdate
+from frappe.website.router import get_pages
+from frappe.www.sitemap import get_public_pages_from_doctypes
+
+from wiki.wiki.llms_txt import public_spaces
+
+
+def build_sitemap_xml() -> str | None:
+	"""The site's sitemap, or None when the wiki has nothing public to add.
+
+	Returning None leaves /sitemap.xml to the framework, so installing this app
+	on a site with no public wiki changes nothing.
+	"""
+	wiki_links = _wiki_links()
+	if not wiki_links:
+		return None
+
+	# Framework links first (the site's own pages), then the wiki's, deduped by
+	# URL so a route both sides know about is listed once.
+	links = {}
+	for loc, lastmod in _framework_links() + wiki_links:
+		links[loc] = lastmod
+
+	entries = "\n".join(
+		f"\t<url>\n\t\t<loc>{escape(loc)}</loc>\n\t\t<lastmod>{lastmod}</lastmod>\n\t</url>"
+		for loc, lastmod in links.items()
+	)
+	return (
+		'<?xml version="1.0" encoding="UTF-8"?>\n'
+		'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+		f"{entries}\n"
+		"</urlset>\n"
+	)
+
+
+def _wiki_links() -> list[tuple[str, str]]:
+	"""Published pages in Guest-readable spaces, as (url, lastmod) pairs.
+
+	`.md` variants are deliberately absent: they are the same page in another
+	representation, which is duplicate content to a search engine.
+	"""
+	spaces = [space.name for space in public_spaces()]
+	if not spaces:
+		return []
+
+	pages = frappe.get_all(
+		"Wiki Document",
+		filters={
+			"wiki_space": ["in", spaces],
+			"is_published": 1,
+			"is_group": 0,
+			"is_external_link": 0,
+		},
+		fields=["route", "modified"],
+		ignore_permissions=True,
+	)
+	return [
+		(get_url(quote(page.route.encode("utf-8"))), f"{page.modified:%Y-%m-%d}")
+		for page in pages
+		if page.route
+	]
+
+
+def _framework_links() -> list[tuple[str, str]]:
+	"""Exactly what frappe.www.sitemap would have emitted on its own."""
+	links = [
+		(get_url(quote(page.name.encode("utf-8"))), nowdate())
+		for page in get_pages().values()
+		if page.sitemap
+	]
+	links += [
+		(get_url(quote((route or "").encode("utf-8"))), f"{data['modified']:%Y-%m-%d}")
+		for route, data in get_public_pages_from_doctypes().items()
+	]
+	return links


### PR DESCRIPTION

<img width="2354" height="1176" alt="image" src="https://github.com/user-attachments/assets/95f5d89e-04dd-4c03-9033-4e0aa4f6dd99" />

## Why?

A Frappe Wiki site is invisible to LLM crawlers and agents today. There is no `/llms.txt`, pages are only available as HTML unless the client can set an `Accept` header, and wiki routes have never appeared in `sitemap.xml` at all — frappe's sitemap only walks doctypes with a web view, and `Wiki Document` renders through a `page_renderer`.

Closes #710.

## What?

| Route | Body |
| ----- | ---- |
| `/<space>/<page>.md` | the page's markdown source with a YAML frontmatter header |
| `/<space>.md`, `/<group>.md` | redirect to the first published page's `.md` |
| `/<space>/<page>` + `Accept: text/markdown` | same body, now with `Vary: Accept` |
| `/<space>/llms.txt` | that space's index, in the [llmstxt.org](https://llmstxt.org/) format |
| `/llms.txt` | site index, one entry per publicly readable space |
| `/sitemap.xml` | frappe's own links **plus** every published wiki page |

The reader also emits `<link rel="alternate" type="text/markdown">` next to the canonical link, so a client holding the HTML can find the markdown without guessing.

## How?

A second `page_renderer` (`CrawlerRenderer`) registered ahead of `WikiDocumentRenderer`. Custom renderers run before frappe's `StaticPage`/`TemplatePage`, which is what lets it take over `/sitemap.xml`. Its `can_render` is a suffix check first and a query second, so normal page loads pay ~nothing.

**Permissions.** Guest visibility is not a DB flag — it is a `Guest` row in the space's `roles` table — so a naive `{"is_published": 1}` query would leak restricted routes. Two different rules:

- **Indexes** (`llms.txt`, `sitemap.xml`) are always generated as Guest, whoever asks. They are crawler artefacts; a session-dependent body would be both a leak risk and uncacheable. Every space goes through `can_read_space(space, "Guest")`.
- **Page markdown** follows the page's own permissions, exactly like the HTML page: `check_space_access("read")` raises `DoesNotExistError`, so a restricted page is indistinguishable from a missing one.

**Index content** comes from the same cached public tree the sidebar renders (`get_public_wiki_tree`), so an index can never advertise a page the reader hides. One H2 per tab, nested list mirroring the sidebar, every link pointing at `.md`.

**Caching.** Both indexes live in one Redis hash, dropped by `clear_wiki_tree_cache` — which every document write already calls — plus new `Wiki Space` `on_update`/`on_trash` hooks, since a space's roles and publish state change the indexes without touching a document.

**A page routed `foo.md`** keeps its own URL as HTML; its markdown lives at `foo.md.md`. Frontmatter values are serialised with `json.dumps` (a valid YAML double-quoted scalar), so quotes and newlines escape instead of breaking the header.

Deliberately out of scope: `llms-full.txt`, internal link rewriting (`[x](/route)` → `.md`, which no regex does safely around fenced code blocks), and q-value `Accept` negotiation.

## Tests

`TestCrawlerEndpoints` and `TestSpaceLlmsTxt` in `test_wiki_document.py` — 104 tests in that module pass, plus `test_permissions` and `test_api`.

Every permission-leak and cache-invalidation case was verified by temp-reverting the fix and confirming the test actually fails:

- drop `check_space_access` → restricted `.md` returns 200 instead of 404
- drop `can_read_space(..., "Guest")` → restricted space appears in `/llms.txt` and in `sitemap.xml`
- drop the cache invalidation → a newly published page never shows up in the index

One robustness case came out of that testing: a space whose root group has been deleted raises when walked, which in an aggregate index would 500 the whole file. Such spaces are now skipped, pinned by `test_site_llms_txt_survives_a_space_whose_root_group_is_gone`.

## Notes for the reviewer

- The spec lives at `specs/llms_txt_and_markdown_endpoints.md`, including a Reconciliation section listing where the build differs from the plan.
- `test_accept_text_markdown_returns_raw_markdown` was updated: markdown responses now carry frontmatter, so the old exact-equality assertion no longer holds.
- Sites should add `Sitemap: https://<host>/sitemap.xml` to `Website Settings.robots_txt` — that field is user-owned and untouched here.
- On a dev bench, `frappe._dev_server` force-overwrites `Cache-Control` with `no-store`, so `curl` locally will not show the headers this PR sets. They are asserted in the tests.
