### PR TITLE
fix(og): title generated cards with the page title, not meta_title

### DIFF
--- a/specs/generated_meta_images.md
+++ b/specs/generated_meta_images.md
@@ -66,7 +66,7 @@ of an existing wiki is out of scope.
 Fingerprint every input the template consumes, and nothing else:
 
 ```
-fp   = sha256("\x1f".join([TEMPLATE_VERSION, meta_title or title, breadcrumb_trail,
+fp   = sha256("\x1f".join([TEMPLATE_VERSION, title, breadcrumb_trail,
                            space_name or "", logo_url or "", str(W), str(H)])).hexdigest()[:12]
 
 path      = <site>/private/files/wiki-og/<doc_key>-<fp>.jpg
@@ -138,7 +138,8 @@ Tailwind build (`wiki.css` is purged against reader markup, not this):
   than breaks.
 - `body` fixed at `1200x630`, `box-sizing: border-box`, `padding: 72px`, flex column,
   `justify-content: space-between`. 12px accent bar pinned to the top.
-- Top: `<img class="logo">` (~48px tall), rendered only when `logo_url` survived validation.
+- Top: `<img class="logo">` (132px tall, max-width 520px, `object-fit: contain`), rendered only when
+  `logo_url` survived validation.
 - Middle: breadcrumb trail, muted, small (`Guides / Integrations`), then the title — 600 weight,
   `-0.02em` tracking, `-webkit-line-clamp: 3`. Font size is picked **in Python** by title length
   (≤40 chars → 76px, ≤80 → 60px, else 48px) so nothing depends on script execution before capture.

--- a/wiki/api/og_image.py
+++ b/wiki/api/og_image.py
@@ -27,7 +27,7 @@ from werkzeug.wrappers import Response
 
 # Bumped whenever the card template or its token block changes; it is part of
 # the cache fingerprint, so a bump invalidates every cached card for free.
-TEMPLATE_VERSION = "3"
+TEMPLATE_VERSION = "4"
 
 OG_WIDTH = 1200
 OG_HEIGHT = 630
@@ -141,7 +141,10 @@ def _og_context(doc) -> dict:
 		# a fallback for spaces that only ever set that one.
 		logo_url = _safe_asset_url(space_doc.app_switcher_logo or space_doc.light_mode_logo)
 
-	title = doc.meta_title or doc.title or ""
+	# The page's own title, not meta_title: the card is a visual object where
+	# the title reads as a label for the page you are about to open, while
+	# meta_title is written for search-result copy and is often keyword-padded.
+	title = doc.title or ""
 	return {
 		"title": title,
 		"title_font_size": _title_font_size(title),

--- a/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
@@ -2992,6 +2992,22 @@ class TestOGImageTemplate(unittest.TestCase):
 		with patch("frappe.get_cached_doc", return_value=space):
 			self.assertEqual(_og_context(doc)["logo_url"], "/files/old.png")
 
+	def test_card_title_ignores_meta_title(self):
+		"""The card shows the page's own title; meta_title is SEO copy for the
+		search result, not a label for the page."""
+		from wiki.api.og_image import _og_context
+
+		space = SimpleNamespace(app_switcher_logo="", light_mode_logo="")
+		doc = SimpleNamespace(
+			meta_title="Keyword Padded Meta Title | Docs",
+			title="Doc",
+			lft=None,
+			get_wiki_space=lambda: {"name": "sp", "space_name": "Space"},
+		)
+
+		with patch("frappe.get_cached_doc", return_value=space):
+			self.assertEqual(_og_context(doc)["title"], "Doc")
+
 	def test_remote_and_private_logo_urls_are_dropped(self):
 		from wiki.api.og_image import _safe_asset_url
 

--- a/wiki/templates/wiki/og_image.html
+++ b/wiki/templates/wiki/og_image.html
@@ -64,7 +64,7 @@
 		   ~72px reads as an afterthought at feed scale. The generous max-width
 		   is for wordmark logos, which are wide rather than square; contain
 		   keeps those from being cropped or stretched. */
-		height: 100px;
+		height: 132px;
 		width: auto;
 		max-width: 520px;
 		object-fit: contain;


### PR DESCRIPTION
## Problem

The auto-generated OG card titled itself with `meta_title or title`. `meta_title` is SEO copy written for the search-result snippet — usually keyword-padded and suffixed with a site name — so the card read wrong as a visual label for the page.

## Solution

- Card title is now the page's own `title`.
- Space logo grown from 100px to 132px, so it holds its weight at feed scale.
- `TEMPLATE_VERSION` bumped to 4 — it is a fingerprint input, so every cached card invalidates itself. No manual purge needed.

Unit test added (`test_card_title_ignores_meta_title`), verified against a temp revert of the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dn1ETNV7ufoM8xA6FCLnnE