### PR TITLE
perf(reader): stop blocking first paint on scripts, images and fonts

### DIFF
--- a/e2e/tests/code-blocks.spec.ts
+++ b/e2e/tests/code-blocks.spec.ts
@@ -1,0 +1,150 @@
+import { expect, test } from '@playwright/test';
+import { updateDoc } from '../helpers/frappe';
+import {
+	createTestWikiDocument,
+	createTestWikiSpace,
+	deleteTestWikiDocument,
+	deleteTestWikiSpace,
+} from '../helpers/wiki';
+
+/**
+ * highlight.js is ~160 KB and most doc pages carry no code at all, so the reader
+ * only fetches it once a page actually has a code block — including after SPA
+ * navigation, which swaps #wiki-content without a document load.
+ */
+const CODE_MARKDOWN = '```python\nprint("hello")\n```\n';
+
+test.describe('Code blocks', () => {
+	test('fetches the highlighter only for pages that contain code', async ({
+		page,
+		request,
+	}) => {
+		const spaceRoute = `code-blocks-${Date.now()}`;
+		const space = await createTestWikiSpace(request, {
+			route: spaceRoute,
+			is_published: true,
+		});
+		const rootGroup = await createTestWikiDocument(request, {
+			title: 'Root',
+			route: `${spaceRoute}/root`,
+			is_group: true,
+			is_published: true,
+		});
+		await updateDoc(request, 'Wiki Space', space.name, {
+			root_group: rootGroup.name,
+		});
+		const proseDoc = await createTestWikiDocument(request, {
+			title: 'Prose Page',
+			route: `${spaceRoute}/prose`,
+			content: 'Just words, no code here.\n',
+			is_published: true,
+			parent_wiki_document: rootGroup.name,
+		});
+		const codeDoc = await createTestWikiDocument(request, {
+			title: 'Code Page',
+			route: `${spaceRoute}/code`,
+			content: CODE_MARKDOWN,
+			is_published: true,
+			parent_wiki_document: rootGroup.name,
+		});
+
+		const highlightRequests: string[] = [];
+		page.on('request', (req) => {
+			if (req.url().includes('wiki-highlight.bundle.js')) {
+				highlightRequests.push(req.url());
+			}
+		});
+
+		try {
+			await page.goto(`/${proseDoc.route}`);
+			await page.waitForLoadState('networkidle');
+			expect(await page.locator('#wiki-content pre > code').count()).toBe(0);
+			expect(highlightRequests).toHaveLength(0);
+
+			await page.goto(`/${codeDoc.route}`);
+			await page.waitForLoadState('networkidle');
+			expect(highlightRequests).toHaveLength(1);
+
+			// Loaded is not enough — the gutter and toolbar only attach to blocks
+			// highlight.js has already marked with .hljs.
+			await expect(
+				page.locator('#wiki-content pre code.hljs').first(),
+			).toBeVisible();
+			await expect(
+				page.locator('#wiki-content pre.code-block-enhanced').first(),
+			).toBeVisible();
+		} finally {
+			await deleteTestWikiDocument(request, codeDoc.name).catch(() => {});
+			await deleteTestWikiDocument(request, proseDoc.name).catch(() => {});
+			await deleteTestWikiDocument(request, rootGroup.name).catch(() => {});
+			await deleteTestWikiSpace(request, space.name).catch(() => {});
+		}
+	});
+
+	test('loads the highlighter on SPA navigation into a code page', async ({
+		page,
+		request,
+	}) => {
+		const spaceRoute = `code-blocks-spa-${Date.now()}`;
+		const space = await createTestWikiSpace(request, {
+			route: spaceRoute,
+			is_published: true,
+		});
+		const rootGroup = await createTestWikiDocument(request, {
+			title: 'Root',
+			route: `${spaceRoute}/root`,
+			is_group: true,
+			is_published: true,
+		});
+		await updateDoc(request, 'Wiki Space', space.name, {
+			root_group: rootGroup.name,
+		});
+		const proseDoc = await createTestWikiDocument(request, {
+			title: 'Prose First',
+			route: `${spaceRoute}/prose-first`,
+			content: 'Nothing but prose.\n',
+			is_published: true,
+			parent_wiki_document: rootGroup.name,
+		});
+		const codeDoc = await createTestWikiDocument(request, {
+			title: 'Code Second',
+			route: `${spaceRoute}/code-second`,
+			content: CODE_MARKDOWN,
+			is_published: true,
+			parent_wiki_document: rootGroup.name,
+		});
+
+		try {
+			// The reader sidebar is desktop-only; below lg it collapses to a sheet.
+			await page.setViewportSize({ width: 1100, height: 900 });
+			await page.goto(`/${proseDoc.route}`);
+			await page.waitForLoadState('networkidle');
+
+			// Sidebar click swaps #wiki-content in place; no document request, so
+			// the bundle has to arrive via initCodeBlocks().
+			await page
+				.locator(`.wiki-sidebar a[href="/${codeDoc.route}"]`)
+				.first()
+				.click();
+			await expect(
+				page.locator('#wiki-content pre > code').first(),
+			).toBeAttached({
+				timeout: 10000,
+			});
+
+			await expect(
+				page.locator('#wiki-content pre code.hljs').first(),
+			).toBeVisible({
+				timeout: 10000,
+			});
+			await expect(
+				page.locator('#wiki-content pre.code-block-enhanced').first(),
+			).toBeVisible();
+		} finally {
+			await deleteTestWikiDocument(request, codeDoc.name).catch(() => {});
+			await deleteTestWikiDocument(request, proseDoc.name).catch(() => {});
+			await deleteTestWikiDocument(request, rootGroup.name).catch(() => {});
+			await deleteTestWikiSpace(request, space.name).catch(() => {});
+		}
+	});
+});

--- a/e2e/tests/sidebar-row-events.spec.ts
+++ b/e2e/tests/sidebar-row-events.spec.ts
@@ -1,0 +1,145 @@
+import { expect, test } from '@playwright/test';
+import { updateDoc } from '../helpers/frappe';
+import {
+	createTestWikiDocument,
+	createTestWikiSpace,
+	deleteTestWikiDocument,
+	deleteTestWikiSpace,
+} from '../helpers/wiki';
+
+/**
+ * Sidebar rows carry no per-node Alpine: navigation and prefetch are delegated
+ * off `data-route` from the navigation store. Delegation uses `mouseover`,
+ * which fires far more often than the `mouseenter` it replaced, so prefetch
+ * has to deduplicate in-flight requests as well as cached ones.
+ */
+async function buildSpace(
+	request: import('@playwright/test').APIRequestContext,
+	prefix: string,
+) {
+	const spaceRoute = `${prefix}-${Date.now()}`;
+	const space = await createTestWikiSpace(request, {
+		route: spaceRoute,
+		is_published: true,
+	});
+	const rootGroup = await createTestWikiDocument(request, {
+		title: 'Root',
+		route: `${spaceRoute}/root`,
+		is_group: true,
+		is_published: true,
+	});
+	await updateDoc(request, 'Wiki Space', space.name, {
+		root_group: rootGroup.name,
+	});
+
+	const group = await createTestWikiDocument(request, {
+		title: 'A Group',
+		route: `${spaceRoute}/a-group`,
+		is_group: true,
+		is_published: true,
+		parent_wiki_document: rootGroup.name,
+	});
+	const nested = await createTestWikiDocument(request, {
+		title: 'Nested Page',
+		route: `${spaceRoute}/a-group/nested`,
+		content: 'Nested.\n',
+		is_published: true,
+		parent_wiki_document: group.name,
+	});
+	const landing = await createTestWikiDocument(request, {
+		title: 'Landing',
+		route: `${spaceRoute}/landing`,
+		content: 'Landing.\n',
+		is_published: true,
+		parent_wiki_document: rootGroup.name,
+	});
+	const sibling = await createTestWikiDocument(request, {
+		title: 'Sibling',
+		route: `${spaceRoute}/sibling`,
+		content: 'Sibling.\n',
+		is_published: true,
+		parent_wiki_document: rootGroup.name,
+	});
+
+	return {
+		space,
+		cleanup: [sibling, landing, nested, group, rootGroup],
+		landing,
+		sibling,
+	};
+}
+
+test.describe('Sidebar row events', () => {
+	test('hovering a row prefetches it exactly once', async ({
+		page,
+		request,
+	}) => {
+		const built = await buildSpace(request, 'row-events');
+
+		const prefetches: string[] = [];
+		page.on('request', (r) => {
+			if (r.url().includes('get_page_data') && r.method() === 'POST') {
+				prefetches.push(r.postData() || '');
+			}
+		});
+
+		try {
+			await page.setViewportSize({ width: 1440, height: 900 });
+			await page.goto(`/${built.landing.route}`);
+			await page.waitForLoadState('networkidle');
+
+			const row = page.locator(
+				`.wiki-sidebar .wiki-link[data-route="${built.sibling.route}"]`,
+			);
+			// Several pointer moves within the same row must still be one request:
+			// mouseover repeats where mouseenter would not.
+			await row.hover();
+			await row.hover({ position: { x: 5, y: 5 } });
+			await row.hover({ position: { x: 60, y: 12 } });
+			await page.waitForTimeout(500);
+
+			const forSibling = prefetches.filter((body) =>
+				body.includes(`"${built.sibling.route}"`),
+			);
+			expect(forSibling).toHaveLength(1);
+		} finally {
+			for (const doc of built.cleanup) {
+				await deleteTestWikiDocument(request, doc.name).catch(() => {});
+			}
+			await deleteTestWikiSpace(request, built.space.name).catch(() => {});
+		}
+	});
+
+	test('clicking a group toggle expands it instead of navigating', async ({
+		page,
+		request,
+	}) => {
+		const built = await buildSpace(request, 'row-events-group');
+
+		try {
+			await page.setViewportSize({ width: 1440, height: 900 });
+			await page.goto(`/${built.landing.route}`);
+			await page.waitForLoadState('networkidle');
+
+			// A group toggle carries data-route too, but it is a <button> without
+			// .wiki-link -- the delegated click handler must skip it.
+			const group = page
+				.locator('.wiki-sidebar button.wiki-item-content')
+				.first();
+			const expandedBefore = await group.getAttribute('aria-expanded');
+			const urlBefore = page.url();
+
+			await group.click();
+			await expect(group).not.toHaveAttribute(
+				'aria-expanded',
+				expandedBefore ?? '',
+			);
+			expect(page.url()).toBe(urlBefore);
+		} finally {
+			for (const doc of built.cleanup) {
+				await deleteTestWikiDocument(request, doc.name).catch(() => {});
+			}
+			await deleteTestWikiSpace(request, built.space.name).catch(() => {});
+		}
+	});
+});

--- a/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
@@ -17,8 +17,10 @@ from xml.etree import ElementTree
 import frappe
 from frappe.tests import IntegrationTestCase
 from frappe.utils import get_test_client
+from frappe.website.utils import WEBSITE_PAGE_CACHE_PREFIX, delete_page_cache
 
 from wiki.frappe_wiki.doctype.wiki_document.wiki_document import (
+	CSRF_TOKEN_PLACEHOLDER,
 	WIKI_CONTENT_CACHE_KEY,
 	WikiDocumentRenderer,
 	clear_wiki_content_cache,
@@ -416,7 +418,9 @@ class TestGetWebContextMetaTags(WikiDocumentTestBase):
 		metatags = context["metatags"]
 
 		self.assertEqual(metatags["title"], "Fallback Meta Doc")
-		self.assertNotIn("description", metatags)
+		# No meta_description, so the body stands in for one rather than the page
+		# shipping without any description at all.
+		self.assertEqual(metatags["description"], "Content for Fallback Meta Doc")
 		self.assertNotIn("image", metatags)
 		self.assertNotIn("og:image", metatags)
 		self.assertEqual(metatags["twitter:card"], "summary")
@@ -1593,6 +1597,105 @@ class TestWikiDocumentPdfDownload(WikiDocumentTestBase):
 		page.before_print()
 
 		self.assertIn("<h2", page.rendered_content_for_pdf)
+
+
+class TestReaderPageCache(WikiDocumentTestBase):
+	"""The reader's HTML cache -- what gets stored, who it's served to, when it drops.
+
+	can_cache() is patched on throughout: it refuses to cache under
+	developer_mode, which is exactly how a test bench runs.
+	"""
+
+	TEST_CLIENT = get_test_client()
+	CACHE_MODULE = "wiki.frappe_wiki.doctype.wiki_document.wiki_document.can_cache"
+
+	def _unique(self, prefix):
+		return f"{prefix}-{frappe.generate_hash(length=6)}"
+
+	def setUp(self):
+		delete_page_cache()
+
+	def _guest_readable_doc(self, prefix):
+		route = self._unique(prefix)
+		space = create_test_wiki_space(self, "Page Cache Space", route, None, roles=[("Guest", "Read")])
+		doc = create_test_wiki_document(
+			self,
+			"Page Cache Doc",
+			parent=space.root_group,
+			slug=self._unique("page-cache-doc"),
+		)
+		frappe.db.commit()  # nosemgrep: frappe-semgrep-rules.rules.frappe-manual-commit
+		return doc
+
+	def _get(self, route):
+		return _make_request(self.TEST_CLIENT, "get", f"/{route}", headers={"Accept": "text/html"})
+
+	def _cache_entry(self, route):
+		return frappe.cache.get_value(f"{WEBSITE_PAGE_CACHE_PREFIX}{route}")
+
+	def test_second_guest_request_is_served_from_cache(self):
+		doc = self._guest_readable_doc("page-cache")
+
+		with patch(self.CACHE_MODULE, return_value=True):
+			first = self._get(doc.route)
+			second = self._get(doc.route)
+
+		self.assertEqual(first.status_code, 200)
+		self.assertEqual(first.headers.get("X-From-Cache"), "False")
+		self.assertEqual(second.headers.get("X-From-Cache"), "True")
+		self.assertEqual(
+			second.headers.get("Cache-Control"),
+			"private,max-age=300,stale-while-revalidate=10800",
+		)
+		# Byte-identical except the CSRF token, which is substituted per request
+		# precisely so the cached copy can be shared.
+		token = re.compile(r"window\.CSRF_TOKEN = '[^']*'")
+		self.assertEqual(
+			token.sub("", first.get_data(as_text=True)),
+			token.sub("", second.get_data(as_text=True)),
+		)
+		self.assertNotEqual(first.get_data(as_text=True), second.get_data(as_text=True))
+
+	def test_cache_holds_a_placeholder_never_a_real_csrf_token(self):
+		doc = self._guest_readable_doc("page-cache-csrf")
+
+		with patch(self.CACHE_MODULE, return_value=True):
+			response = self._get(doc.route)
+
+		stored = self._cache_entry(doc.route)
+		self.assertIsNotNone(stored, "guest render should have been cached")
+		self.assertIn(CSRF_TOKEN_PLACEHOLDER, next(iter(stored.values())))
+
+		# The visitor gets a substituted token, not the placeholder.
+		html = response.get_data(as_text=True)
+		self.assertNotIn(CSRF_TOKEN_PLACEHOLDER, html)
+		self.assertRegex(html, r"window\.CSRF_TOKEN = '[^']+'")
+
+	def test_signed_in_render_is_never_stored(self):
+		"""The page carries the viewer's Edit button, so only anonymous renders are shared."""
+		doc = self._guest_readable_doc("page-cache-user")
+		renderer = WikiDocumentRenderer(path=doc.route)
+
+		frappe.set_user("Administrator")
+		try:
+			with patch(self.CACHE_MODULE, return_value=True):
+				html = renderer.get_html(frappe.get_cached_doc("Wiki Document", doc.name))
+		finally:
+			frappe.set_user("Administrator")
+
+		self.assertIn(CSRF_TOKEN_PLACEHOLDER, html)
+		self.assertIsNone(self._cache_entry(doc.route))
+
+	def test_tree_change_drops_every_cached_page(self):
+		"""Each cached page embeds the sidebar tree, so a tree change stales all of them."""
+		doc = self._guest_readable_doc("page-cache-tree")
+
+		with patch(self.CACHE_MODULE, return_value=True):
+			self._get(doc.route)
+
+		self.assertIsNotNone(self._cache_entry(doc.route))
+		clear_wiki_tree_cache()
+		self.assertIsNone(self._cache_entry(doc.route))
 
 
 def _sitemap_routes(xml: str) -> set:

--- a/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
@@ -10,6 +10,7 @@ from frappe.utils import pretty_date
 from frappe.utils.nestedset import NestedSet, get_descendants_of
 from frappe.utils.print_utils import get_print
 from frappe.website.page_renderers.base_renderer import BaseRenderer
+from frappe.website.utils import WEBSITE_PAGE_CACHE_PREFIX, can_cache, delete_page_cache
 from frappe.website.utils import clear_cache as clear_website_cache
 from frappe.website.website_components.metatags import MetaTags
 from werkzeug.wrappers import Response
@@ -31,6 +32,15 @@ WIKI_HOME_TAB_KEY = "__general__"
 # never hold it -- the same URL yields 404 for a reader without space access.
 # Mirrors what frappe serves the HTML page (frappe/website/utils.py cache_html).
 MARKDOWN_CACHE_CONTROL = "private, max-age=300, stale-while-revalidate=10800"
+
+# Opting the reader page out of frappe's blanket no-store default (see
+# process_response in frappe/app.py) -- the same value cache_html sets.
+PAGE_CACHE_HEADERS = {"Cache-Control": "private,max-age=300,stale-while-revalidate=10800"}
+
+# Stands in for the visitor's CSRF token inside cached HTML. Deliberately not an
+# HTML comment: it lands inside a <script> string literal, where `<!--` would be
+# parsed as a comment opener.
+CSRF_TOKEN_PLACEHOLDER = "__wiki_csrf_token__"
 
 # Mapping of known service domains to icon identifiers
 KNOWN_SERVICE_ICONS = {
@@ -672,19 +682,59 @@ class WikiDocumentRenderer(BaseRenderer):
 			response.headers["Vary"] = "Accept"
 			return response
 
-		context = doc.get_web_context()
+		html = self.get_html(doc)
 
+		# Substituted after the cache lookup, never rendered into the cached HTML:
+		# the token belongs to this visitor's session, so a stored copy would hand
+		# it to everyone else who hits the same route.
 		csrf_token = frappe.sessions.get_csrf_token()
 		frappe.db.commit()  # nosemgrep
+		html = html.replace(CSRF_TOKEN_PLACEHOLDER, csrf_token)
 
-		context["csrf_token"] = csrf_token
-
-		html = frappe.render_template("templates/wiki/document.html", context)
 		response = self.build_response(html)
 		# This URL has two representations, so every response from it -- HTML
 		# included -- has to tell caches which header picked this one.
 		response.headers["Vary"] = "Accept"
 		return response
+
+	def get_html(self, doc) -> str:
+		"""Render the reader page, reading from and writing to frappe's page cache.
+
+		Without this every request rebuilds the whole page -- sidebar tree, space
+		switcher, TOC -- and frappe's default `no-store` header (see
+		process_response in frappe/app.py) stops the browser from reusing it,
+		which also disqualifies the page from the back/forward cache.
+
+		Only anonymous renders are stored. The key is the route alone, and the
+		page carries the visitor's Edit button, so caching a signed-in render
+		would show one editor's chrome to every reader. Guests are safe to share:
+		they all resolve the same space permissions, and an unauthorized Guest
+		throws out of get_web_context before anything is written.
+
+		The key format matches frappe's own, so delete_page_cache and
+		clear_cache(route) drop these entries too.
+		"""
+		cache_key = f"{WEBSITE_PAGE_CACHE_PREFIX}{self.path}"
+		cacheable = frappe.session.user == "Guest" and can_cache()
+
+		if cacheable:
+			cached = (frappe.cache.get_value(cache_key) or {}).get(frappe.local.lang)
+			if cached:
+				frappe.local.response.from_cache = True
+				frappe.local.response_headers.update(PAGE_CACHE_HEADERS)
+				return cached
+
+		context = doc.get_web_context()
+		context["csrf_token"] = CSRF_TOKEN_PLACEHOLDER
+		html = frappe.render_template("templates/wiki/document.html", context)
+
+		if cacheable:
+			page_cache = frappe.cache.get_value(cache_key) or {}
+			page_cache[frappe.local.lang] = html
+			frappe.cache.set_value(cache_key, page_cache, expires_in_sec=30 * 60)
+			frappe.local.response_headers.update(PAGE_CACHE_HEADERS)
+
+		return html
 
 
 def build_markdown_response(doc) -> Response:
@@ -1012,6 +1062,13 @@ def clear_wiki_tree_cache():
 
 	frappe.cache().delete_value(WIKI_TREE_CACHE_KEY)
 	frappe.db.after_commit.add(lambda: frappe.cache().delete_value(WIKI_TREE_CACHE_KEY))
+
+	# Every cached reader page embeds a copy of the tree in its sidebar, so a
+	# stale tree means stale pages. Dropped wholesale for the same reason the
+	# tree itself is: a title change or a move restyles pages this document has
+	# no way to enumerate.
+	delete_page_cache()
+	frappe.db.after_commit.add(delete_page_cache)
 
 	# llms.txt and sitemap.xml are built from this same tree, so they go stale
 	# at exactly the same moments.

--- a/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
@@ -14,7 +14,7 @@ from frappe.website.utils import clear_cache as clear_website_cache
 from frappe.website.website_components.metatags import MetaTags
 from werkzeug.wrappers import Response
 
-from wiki.wiki.markdown import render_markdown, render_markdown_with_toc
+from wiki.wiki.markdown import markdown_excerpt, render_markdown, render_markdown_with_toc
 
 WIKI_DOCUMENT_PRINT_FORMAT = "Standard Wiki Document"
 
@@ -456,8 +456,9 @@ class WikiDocument(NestedSet):
 			"title": self.meta_title or self.title,
 			"og:site_name": wiki_space.get("space_name") if wiki_space else None,
 		}
-		if self.meta_description:
-			metatags["description"] = self.meta_description
+		# An author-written description always wins; the excerpt keeps the page
+		# from shipping without one at all.
+		metatags["description"] = self.meta_description or markdown_excerpt(self.content or "")
 
 		# An explicit upload always wins; the generated card is the fallback.
 		image = self.meta_image or self.get_og_image_url()

--- a/wiki/public/css/main.css
+++ b/wiki/public/css/main.css
@@ -77,6 +77,66 @@ body {
   }
 }
 
+/* ---------- Sidebar tree rows ----------
+   One row of the reader's navigation tree. The tree is rendered twice per page
+   (mobile sheet, then desktop rail) and a large space runs to hundreds of
+   nodes, so on docs.frappe.io the repeated utility string alone came to ~105 KB
+   of markup. Presentation lives here; the template keeps only the class names.
+
+   @layer components, not @utility: these are multi-property component classes,
+   so utilities still win when a caller needs to override one. */
+@layer components {
+  .wiki-row {
+    @apply w-full flex items-center px-2 text-[var(--ink-gray-7)] transition-colors duration-200;
+  }
+
+  /* Row geometry. `dense` is the desktop rail; the mobile sheet uses the taller
+     variant so each row is a real touch target rather than a 28px line. */
+  .wiki-row-dense {
+    @apply h-7 rounded;
+  }
+
+  .wiki-row-roomy {
+    @apply h-11 rounded-md;
+  }
+
+  /* Keyed off the element rather than an extra class -- a row is a <button>
+     when it toggles a group and an <a> when it navigates. */
+  .wiki-row:where(a) {
+    @apply no-underline;
+  }
+
+  .wiki-row:where(button) {
+    @apply cursor-pointer;
+  }
+
+  /* Opt-in: leaf links still take their hover from an Alpine binding, which
+     has to stay off while the row is the current page. */
+  .wiki-row-hover:hover {
+    @apply bg-[var(--surface-gray-2)] text-[var(--ink-gray-8)];
+  }
+
+  .wiki-row .wiki-title {
+    @apply truncate;
+  }
+
+  .wiki-row-dense .wiki-title {
+    @apply text-sm;
+  }
+
+  .wiki-row-roomy .wiki-title {
+    @apply text-md;
+  }
+
+  .wiki-row-dense:where(button) .wiki-title {
+    @apply text-sm-medium;
+  }
+
+  .wiki-row-roomy:where(button) .wiki-title {
+    @apply text-md font-medium;
+  }
+}
+
 /* Reader-specific prose tweaks. Typography itself (sizes, headings, links,
    inline code, blockquotes, hr) comes from frappe-ui-prose.css. */
 .prose {

--- a/wiki/public/css/main.css
+++ b/wiki/public/css/main.css
@@ -110,9 +110,15 @@ body {
     @apply cursor-pointer;
   }
 
-  /* Opt-in: leaf links still take their hover from an Alpine binding, which
-     has to stay off while the row is the current page. */
-  .wiki-row-hover:hover {
+  /* The current page. Server-rendered on first paint, then moved by the
+     navigation store on SPA nav -- see markActiveRow in sidebar.html. */
+  .wiki-row[aria-current='page'] {
+    @apply bg-[var(--surface-gray-2)] text-[var(--ink-gray-8)];
+  }
+
+  /* Everything but the current row highlights on hover, which is what the old
+     per-node :class ternary encoded. */
+  .wiki-row:not([aria-current='page']):hover {
     @apply bg-[var(--surface-gray-2)] text-[var(--ink-gray-8)];
   }
 

--- a/wiki/public/js/code-blocks.js
+++ b/wiki/public/js/code-blocks.js
@@ -1,5 +1,36 @@
+// highlight.js is ~160 KB and most doc pages have no code at all, so the bundle
+// is fetched the first time a page actually contains a code block rather than on
+// every page load. The URL (hashed for cache-busting) rides in on this script's
+// own data attribute; it has to be read at load time, because document.currentScript
+// is null by the time SPA navigation calls initCodeBlocks() again.
+const HIGHLIGHT_SRC = document.currentScript && document.currentScript.dataset.highlightSrc;
+let highlightLoad = null;
+
+function loadHighlighter() {
+    if (window.hljs || !HIGHLIGHT_SRC) return Promise.resolve();
+
+    if (!highlightLoad) {
+        highlightLoad = new Promise(function(resolve) {
+            const script = document.createElement('script');
+            script.src = HIGHLIGHT_SRC;
+            // Resolve either way: a failed highlighter should leave plain,
+            // readable <pre> blocks, not an unenhanced page.
+            script.onload = resolve;
+            script.onerror = resolve;
+            document.head.appendChild(script);
+        });
+    }
+
+    return highlightLoad;
+}
+
 // Initialize syntax highlighting and code block enhancements
 function initCodeBlocks() {
+    if (!document.querySelector('pre > code')) return;
+    return loadHighlighter().then(enhanceCodeBlocks);
+}
+
+function enhanceCodeBlocks() {
     // Record the authored language before highlight.js auto-detection adds its
     // own language-* class, so the label mirrors the editor ("auto" when unset).
     document.querySelectorAll('pre > code').forEach(function(codeBlock) {

--- a/wiki/templates/wiki/includes/mobile_header.html
+++ b/wiki/templates/wiki/includes/mobile_header.html
@@ -29,11 +29,13 @@
                 {% endfor %}
                 <button @click="$dispatch('open-search')"
                         data-testid="mobile-search-button"
+                        aria-label="{{ _('Search') }}"
                         class="p-2 text-[var(--ink-gray-5)] hover:text-[var(--ink-gray-9)] hover:bg-[var(--surface-gray-2)] rounded-md transition-colors duration-200">
                     {{ render_icon("search") }}
                 </button>
                 <button @click="$store.theme.toggle()"
                         data-testid="mobile-theme-toggle"
+                        aria-label="{{ _('Toggle theme') }}"
                         class="p-2 text-[var(--ink-gray-5)] hover:text-[var(--ink-gray-9)] hover:bg-[var(--surface-gray-2)] rounded-md transition-colors duration-200">
                     <template x-if="$store.theme.isDark">
                         {{ render_icon("sun") }}

--- a/wiki/templates/wiki/includes/sidebar.html
+++ b/wiki/templates/wiki/includes/sidebar.html
@@ -136,6 +136,26 @@
                 history.replaceState({ route: this.currentRoute }, '', window.location.pathname + window.location.hash);
             },
 
+            // Move the active-row marker. The server renders aria-current on the
+            // matching row for the first paint; binding it per node instead
+            // meant one Alpine effect per row -- on a large space that is
+            // hundreds of expressions all recomputing the same comparison, in
+            // both copies of the tree. Styling hangs off the attribute in CSS.
+            markActiveRow(route) {
+                document.querySelectorAll('.wiki-link[data-route]').forEach((el) => {
+                    if (el.dataset.route === route) {
+                        el.setAttribute('aria-current', 'page');
+                    } else {
+                        el.removeAttribute('aria-current');
+                    }
+                });
+            },
+
+            setCurrentRoute(route) {
+                this.currentRoute = route;
+                this.markActiveRow(route);
+            },
+
             // Whether the current page lives under a tab. A tab's slug is
             // always an ancestor segment of its pages' routes, so this is a
             // prefix test — and because it reads currentRoute, both the tab
@@ -182,7 +202,7 @@
                 // Check prefetch cache first
                 if (this.prefetchCache[route]) {
                     this.updateContent(this.prefetchCache[route]);
-                    this.currentRoute = route;
+                    this.setCurrentRoute(route);
                     if (pushState) {
                         history.pushState({ route }, '', '/' + route);
                     }
@@ -204,7 +224,7 @@
 
                     if (data.message) {
                         this.updateContent(data.message);
-                        this.currentRoute = route;
+                        this.setCurrentRoute(route);
                         if (pushState) {
                             history.pushState({ route }, '', '/' + route);
                         }

--- a/wiki/templates/wiki/includes/sidebar.html
+++ b/wiki/templates/wiki/includes/sidebar.html
@@ -134,6 +134,34 @@
                 });
                 // Set initial state (preserve hash for TOC anchor links)
                 history.replaceState({ route: this.currentRoute }, '', window.location.pathname + window.location.hash);
+                this.delegateRowEvents();
+            },
+
+            // One delegated pair for every tree row, rather than @click and
+            // @mouseenter attributes repeated on each of them -- the tree
+            // renders twice per page and runs to hundreds of rows on a large
+            // space. Group toggles and external links are excluded: neither
+            // carries data-route on a .wiki-link.
+            delegateRowEvents() {
+                const rowFor = (event) => event.target.closest?.('.wiki-link[data-route]');
+
+                document.addEventListener('click', (event) => {
+                    const row = rowFor(event);
+                    if (!row) return;
+                    event.preventDefault();
+                    this.navigateTo(row.dataset.route);
+                });
+
+                // mouseover bubbles where mouseenter doesn't, so it's the one
+                // that can be delegated; tracking the last row keeps it firing
+                // once per row entry rather than on every pointer move.
+                let hovered = null;
+                document.addEventListener('mouseover', (event) => {
+                    const row = rowFor(event);
+                    if (row === hovered) return;
+                    hovered = row;
+                    if (row) this.prefetch(row.dataset.route);
+                });
             },
 
             // Move the active-row marker. The server renders aria-current on the
@@ -175,8 +203,15 @@
                 return !routesStr.split('|').some((route) => this.inTab(route));
             },
 
+            // Routes with a prefetch already in the air. The cache alone can't
+            // deduplicate: delegated mouseover fires more often than the
+            // per-row mouseenter it replaced, so a second hover can arrive
+            // before the first response lands.
+            prefetchInFlight: {},
+
             async prefetch(route) {
-                if (route === this.currentRoute || this.prefetchCache[route]) return;
+                if (route === this.currentRoute || this.prefetchCache[route] || this.prefetchInFlight[route]) return;
+                this.prefetchInFlight[route] = true;
 
                 try {
                     const response = await fetch('/api/method/wiki.frappe_wiki.doctype.wiki_document.wiki_document.get_page_data', {
@@ -193,6 +228,8 @@
                     }
                 } catch (e) {
                     // Silently fail - prefetch is just an optimization
+                } finally {
+                    delete this.prefetchInFlight[route];
                 }
             },
 

--- a/wiki/templates/wiki/layout.html
+++ b/wiki/templates/wiki/layout.html
@@ -19,6 +19,11 @@
     <script type="application/ld+json">{{ breadcrumbs | safe }}</script>
     {% endif %}
 
+    {#- The variable font backs every glyph on the page, but it's only discovered
+        once tailwind.css has parsed. Preloading it overlaps the two downloads
+        instead of chaining them. -#}
+    <link rel="preload" href="/assets/wiki/fonts/Inter.var.woff2?v=3.19" as="font" type="font/woff2" crossorigin>
+
     <link rel="stylesheet" href="/assets/wiki/css/tailwind.css?v={{get_tailwindcss_hash()}}">
 
     <!-- Hide x-cloak elements until Alpine loads -->
@@ -51,6 +56,10 @@
         window.CSRF_TOKEN = '{{ csrf_token }}';
     </script>
 
+    {#- Not deferred, deliberately: both plugins register on `alpine:init`, and
+        so do the inline store definitions further down the body. Deferring the
+        plugins would put their listeners *after* the inline ones, so the stores
+        would call Alpine.$persist before it exists. ~3 KB combined. -#}
     <script src="/assets/wiki/js/vendor/alpinejs/plugins/persist.js"></script>
     <script src="/assets/wiki/js/vendor/alpinejs/plugins/collapse.js"></script>
 
@@ -109,11 +118,15 @@
          the frappe-ui editor), so the public reader tokenises 1-1 with the
          editor and the shared frappe-ui-code.css theme. Must load before
          code-blocks.js, which calls window.hljs.highlightAll(). -->
-    <script src="/assets/wiki/js/wiki-highlight.bundle.js?v={{ get_asset_hash('public/js/wiki-highlight.bundle.js') }}"></script>
-    <script src="/assets/wiki/js/code-blocks.js?v={{ get_asset_hash('public/js/code-blocks.js') }}"></script>
-    <script src="/assets/wiki/js/image-viewer.js?v={{ get_asset_hash('public/js/image-viewer.js') }}"></script>
+    {#- Deferred, not bare: none of these paint anything, and highlight.js alone
+        is ~160 KB of parser blocking first paint. `defer` preserves execution
+        order and still runs everything before DOMContentLoaded, which is what
+        code-blocks.js and mermaid-renderer.js hang off. -#}
+    <script defer src="/assets/wiki/js/wiki-highlight.bundle.js?v={{ get_asset_hash('public/js/wiki-highlight.bundle.js') }}"></script>
+    <script defer src="/assets/wiki/js/code-blocks.js?v={{ get_asset_hash('public/js/code-blocks.js') }}"></script>
+    <script defer src="/assets/wiki/js/image-viewer.js?v={{ get_asset_hash('public/js/image-viewer.js') }}"></script>
     <script defer src="/assets/wiki/js/pdf-viewer.js?v={{ get_asset_hash('public/js/pdf-viewer.js') }}"></script>
-    <script src="/assets/wiki/js/mermaid-loader.js?v={{ get_asset_hash('public/js/mermaid-loader.js') }}"></script>
+    <script defer src="/assets/wiki/js/mermaid-loader.js?v={{ get_asset_hash('public/js/mermaid-loader.js') }}"></script>
     <script defer src="/assets/wiki/js/mermaid-renderer.js?v={{ get_asset_hash('public/js/mermaid-renderer.js') }}"></script>
 </body>
 {% block scripts %} {% endblock %}

--- a/wiki/templates/wiki/layout.html
+++ b/wiki/templates/wiki/layout.html
@@ -114,16 +114,17 @@
              class="min-w-[45rem] max-w-[60vw] max-h-[80vh] object-contain cursor-zoom-out max-[768px]:min-w-[100vw]" />
     </div>
 
-    <!-- Wiki-owned highlight.js (highlight.js/lib/common — same language set as
-         the frappe-ui editor), so the public reader tokenises 1-1 with the
-         editor and the shared frappe-ui-code.css theme. Must load before
-         code-blocks.js, which calls window.hljs.highlightAll(). -->
-    {#- Deferred, not bare: none of these paint anything, and highlight.js alone
-        is ~160 KB of parser blocking first paint. `defer` preserves execution
-        order and still runs everything before DOMContentLoaded, which is what
-        code-blocks.js and mermaid-renderer.js hang off. -#}
-    <script defer src="/assets/wiki/js/wiki-highlight.bundle.js?v={{ get_asset_hash('public/js/wiki-highlight.bundle.js') }}"></script>
-    <script defer src="/assets/wiki/js/code-blocks.js?v={{ get_asset_hash('public/js/code-blocks.js') }}"></script>
+    {#- Deferred, not bare: none of these paint anything, and `defer` still runs
+        everything before DOMContentLoaded, which is what code-blocks.js and
+        mermaid-renderer.js hang off.
+
+        wiki-highlight.bundle.js has no tag of its own — code-blocks.js fetches it
+        from data-highlight-src the first time a page actually has a code block.
+        It's the wiki-owned build of highlight.js/lib/common, the same language
+        set as the frappe-ui editor, so the reader tokenises 1-1 with the editor
+        and the shared frappe-ui-code.css theme. -#}
+    <script defer src="/assets/wiki/js/code-blocks.js?v={{ get_asset_hash('public/js/code-blocks.js') }}"
+            data-highlight-src="/assets/wiki/js/wiki-highlight.bundle.js?v={{ get_asset_hash('public/js/wiki-highlight.bundle.js') }}"></script>
     <script defer src="/assets/wiki/js/image-viewer.js?v={{ get_asset_hash('public/js/image-viewer.js') }}"></script>
     <script defer src="/assets/wiki/js/pdf-viewer.js?v={{ get_asset_hash('public/js/pdf-viewer.js') }}"></script>
     <script defer src="/assets/wiki/js/mermaid-loader.js?v={{ get_asset_hash('public/js/mermaid-loader.js') }}"></script>

--- a/wiki/templates/wiki/macros/sidebar_tree.html
+++ b/wiki/templates/wiki/macros/sidebar_tree.html
@@ -3,16 +3,18 @@
     uses — h-11 at text-md, which is a real touch target rather than a
     28px line. -#}
 {% macro render_wiki_tree(nodes, level=0, current_route='', expanded_nodes=set(), dense=True) %}
-    {% set row_geometry = "h-7 rounded" if dense else "h-11 rounded-md" %}
-    {% set row_text = "text-sm" if dense else "text-md" %}
-    {% set row_text_medium = "text-sm-medium" if dense else "text-md font-medium" %}
+    {#- Row presentation (geometry, colours, hover, title size) lives in
+        main.css under .wiki-row. Repeating it as a utility string here cost
+        ~105 KB of markup on a large space, since the tree renders twice per
+        page and once per node. -#}
+    {% set row = "wiki-row wiki-row-dense" if dense else "wiki-row wiki-row-roomy" %}
     {% if nodes %}
         <ul class="wiki-tree list-none m-0 px-0 py-0.5 space-y-0.5">
             {% for node in nodes %}
                 <li class="wiki-item {{ 'is-group' if node.is_group else 'is-page' }}">
                     {% if node.is_group %}
                         {# Group/folder item #}
-                        <button class="wiki-item-content group w-full flex items-center {{ row_geometry }} px-2 text-[var(--ink-gray-7)] transition-colors duration-200 cursor-pointer hover:bg-[var(--surface-gray-2)] hover:text-[var(--ink-gray-8)]"
+                        <button class="wiki-item-content {{ row }} wiki-row-hover"
                                 @click="toggleNode('{{ node.name }}')"
                                 :aria-expanded="isExpanded('{{ node.name }}')"
                                 aria-controls="{{ node.name }}-children"
@@ -31,16 +33,16 @@
                                     <path d="m9 18 6-6-6-6"/>
                                 </svg>
                             </span>
-                            <span class="wiki-title {{ row_text_medium }} truncate">{{ node.title }}</span>
+                            <span class="wiki-title">{{ node.title }}</span>
                         </button>
                     {% elif node.is_external_link %}
                         {# External link item #}
                         <a href="{{ node.external_url }}"
                            target="_blank"
                            rel="noopener noreferrer"
-                           class="wiki-item-content wiki-link wiki-external-link group w-full flex items-center {{ row_geometry }} px-2 text-[var(--ink-gray-7)] no-underline transition-colors duration-200 hover:bg-[var(--surface-gray-2)] hover:text-[var(--ink-gray-8)]"
+                           class="wiki-item-content wiki-link wiki-external-link {{ row }} wiki-row-hover"
                            title="{{ node.title }}">
-                            <span class="wiki-title {{ row_text }} truncate {{ 'pl-5' if level == 0 else '' }}">{{ node.title }}</span>
+                            <span class="wiki-title {{ 'pl-5' if level == 0 else '' }}">{{ node.title }}</span>
                             {# External link icon right next to text #}
                             <svg class="w-3 h-3 ml-2 text-[var(--ink-gray-4)] flex-shrink-0" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
                                 <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
@@ -55,13 +57,13 @@
                         <a href="/{{ node.route }}"
                            @click.prevent="$store.navigation.navigateTo({{ node.route | tojson | forceescape }})"
                            @mouseenter="$store.navigation.prefetch({{ node.route | tojson | forceescape }})"
-                           class="wiki-item-content wiki-link group w-full flex items-center {{ row_geometry }} px-2 text-[var(--ink-gray-7)] no-underline transition-colors duration-200"
+                           class="wiki-item-content wiki-link {{ row }}"
                            :class="$store.navigation.currentRoute === {{ node.route | tojson | forceescape }} ? 'bg-[var(--surface-gray-2)] text-[var(--ink-gray-8)]' : 'hover:bg-[var(--surface-gray-2)] hover:text-[var(--ink-gray-8)]'"
                            :aria-current="$store.navigation.currentRoute === {{ node.route | tojson | forceescape }} ? 'page' : false"
                            title="{{ node.title }}"
                            data-route="{{ node.route }}"
                            data-node-id="{{ node.name }}">
-                            <span class="wiki-title {{ row_text }} truncate {{ 'pl-5' if level == 0 else '' }}">{{ node.title }}</span>
+                            <span class="wiki-title {{ 'pl-5' if level == 0 else '' }}">{{ node.title }}</span>
                         </a>
                     {% endif %}
 

--- a/wiki/templates/wiki/macros/sidebar_tree.html
+++ b/wiki/templates/wiki/macros/sidebar_tree.html
@@ -14,7 +14,7 @@
                 <li class="wiki-item {{ 'is-group' if node.is_group else 'is-page' }}">
                     {% if node.is_group %}
                         {# Group/folder item #}
-                        <button class="wiki-item-content {{ row }} wiki-row-hover"
+                        <button class="wiki-item-content {{ row }}"
                                 @click="toggleNode('{{ node.name }}')"
                                 :aria-expanded="isExpanded('{{ node.name }}')"
                                 aria-controls="{{ node.name }}-children"
@@ -40,7 +40,7 @@
                         <a href="{{ node.external_url }}"
                            target="_blank"
                            rel="noopener noreferrer"
-                           class="wiki-item-content wiki-link wiki-external-link {{ row }} wiki-row-hover"
+                           class="wiki-item-content wiki-link wiki-external-link {{ row }}"
                            title="{{ node.title }}">
                             <span class="wiki-title {{ 'pl-5' if level == 0 else '' }}">{{ node.title }}</span>
                             {# External link icon right next to text #}
@@ -54,12 +54,16 @@
                         {# Page/leaf item #}
                         {# node.route is editor-set free text; tojson keeps it a
                            safe JS string literal in these Alpine expressions. #}
+                        {# Active state is a server-rendered aria-current that the
+                           navigation store moves on SPA nav (markActiveRow), and
+                           CSS styles off. Binding it per node instead cost two
+                           Alpine expressions on every row -- ~1,400 of them on a
+                           large space, all recomputing the same comparison. #}
                         <a href="/{{ node.route }}"
                            @click.prevent="$store.navigation.navigateTo({{ node.route | tojson | forceescape }})"
                            @mouseenter="$store.navigation.prefetch({{ node.route | tojson | forceescape }})"
                            class="wiki-item-content wiki-link {{ row }}"
-                           :class="$store.navigation.currentRoute === {{ node.route | tojson | forceescape }} ? 'bg-[var(--surface-gray-2)] text-[var(--ink-gray-8)]' : 'hover:bg-[var(--surface-gray-2)] hover:text-[var(--ink-gray-8)]'"
-                           :aria-current="$store.navigation.currentRoute === {{ node.route | tojson | forceescape }} ? 'page' : false"
+                           {% if node.route == current_route %}aria-current="page"{% endif %}
                            title="{{ node.title }}"
                            data-route="{{ node.route }}"
                            data-node-id="{{ node.name }}">

--- a/wiki/templates/wiki/macros/sidebar_tree.html
+++ b/wiki/templates/wiki/macros/sidebar_tree.html
@@ -51,17 +51,13 @@
                             </svg>
                         </a>
                     {% else %}
-                        {# Page/leaf item #}
-                        {# node.route is editor-set free text; tojson keeps it a
-                           safe JS string literal in these Alpine expressions. #}
-                        {# Active state is a server-rendered aria-current that the
-                           navigation store moves on SPA nav (markActiveRow), and
-                           CSS styles off. Binding it per node instead cost two
-                           Alpine expressions on every row -- ~1,400 of them on a
-                           large space, all recomputing the same comparison. #}
+                        {# Page/leaf item. Carries no Alpine of its own: navigation
+                           and prefetch are delegated off data-route (see
+                           delegateRowEvents), and the active state is a
+                           server-rendered aria-current the store moves on SPA nav
+                           (markActiveRow) and CSS styles. Bound per node instead,
+                           the four expressions here came to ~1,700 bytes a row. #}
                         <a href="/{{ node.route }}"
-                           @click.prevent="$store.navigation.navigateTo({{ node.route | tojson | forceescape }})"
-                           @mouseenter="$store.navigation.prefetch({{ node.route | tojson | forceescape }})"
                            class="wiki-item-content wiki-link {{ row }}"
                            {% if node.route == current_route %}aria-current="page"{% endif %}
                            title="{{ node.title }}"

--- a/wiki/wiki/doctype/wiki_settings/wiki_settings.py
+++ b/wiki/wiki/doctype/wiki_settings/wiki_settings.py
@@ -3,6 +3,7 @@
 
 import frappe
 from frappe.model.document import Document
+from frappe.website.utils import delete_page_cache
 
 
 class WikiSettings(Document):
@@ -22,6 +23,15 @@ class WikiSettings(Document):
 		head_html: DF.Code | None
 		javascript: DF.Code | None
 	# end: auto-generated types
+
+	def on_update(self):
+		"""Drop the cached reader pages -- most of these settings are baked into them.
+
+		head_html, javascript, the TOC toggle and the feedback switch all change
+		markup that the page cache is holding verbatim.
+		"""
+		delete_page_cache()
+		frappe.db.after_commit.add(delete_page_cache)
 
 
 @frappe.whitelist()

--- a/wiki/wiki/markdown.py
+++ b/wiki/wiki/markdown.py
@@ -352,6 +352,43 @@ def _encode_image_url_spaces(content: str) -> str:
 	return IMAGE_PATTERN.sub(encode_url, content)
 
 
+def _image_dimensions(src: str) -> tuple[int, int] | None:
+	"""Intrinsic pixel size of a site-local image, or None if it can't be read.
+
+	The reader emits these as width/height attributes so the browser can reserve
+	the box before the bytes arrive — without them every image above the fold
+	shifts the layout below it (CLS). Only `/files/` and `/private/files/` are
+	resolved: a remote URL would mean a network round-trip per image, and the
+	whole render is memoised per document anyway (get_rendered_content), so the
+	disk read happens once per content edit rather than once per request.
+	"""
+	if not src.startswith(("/files/", "/private/files/")):
+		return None
+
+	from urllib.parse import unquote, urlsplit
+
+	relative = unquote(urlsplit(src).path).lstrip("/")
+	if ".." in relative.split("/"):
+		return None
+
+	try:
+		import frappe
+		from PIL import Image
+
+		# /private/files/x -> ("private", "files", "x"); /files/x -> ("public", "files", "x")
+		parts = relative.split("/")
+		segments = parts if parts[0] == "private" else ["public", *parts]
+
+		with Image.open(frappe.get_site_path(*segments)) as image:
+			width, height = image.size
+	except Exception:
+		# Missing file, an SVG, a decoder Pillow lacks, or no site context in
+		# tests — all mean "no dimensions", never a failed page render.
+		return None
+
+	return (width, height) if width and height else None
+
+
 # Private-use Unicode sentinel — stands in for `|` inside inline-code on table
 # rows during parsing, then gets swapped back after rendering. Both Mistune and
 # markdown-it-py count raw pipes per row in their table plugin and reject the
@@ -420,7 +457,13 @@ def _build_markdown() -> MarkdownIt:
 	md.renderer.rules["fence"] = fence_rstrip
 	md.renderer.rules["code_block"] = code_block_rstrip
 
+	# Counts images across the whole document, callouts included: the renderer
+	# instance is reused for the nested callout render pass (see
+	# _replace_callout_placeholders), so "first" stays first.
+	images_rendered = 0
+
 	def image_render(tokens, idx, options, env):
+		nonlocal images_rendered
 		tok = tokens[idx]
 		src = tok.attrGet("src") or ""
 		alt = _remove_script_tags(tok.content)
@@ -437,10 +480,24 @@ def _build_markdown() -> MarkdownIt:
 			)
 		if _is_pdf_url(src):
 			return _generate_pdf_html(src, alt)
+		images_rendered += 1
 		s = f'<img src="{src}" alt="{alt}"'
 		if title:
 			s += f' title="{title}"'
-		return s + " />"
+
+		dimensions = _image_dimensions(src)
+		if dimensions:
+			s += f' width="{dimensions[0]}" height="{dimensions[1]}"'
+
+		# The first image is usually the hero and often the LCP element, so it
+		# gets fetched eagerly at high priority; everything below it waits until
+		# it approaches the viewport.
+		if images_rendered == 1:
+			s += ' fetchpriority="high"'
+		else:
+			s += ' loading="lazy"'
+
+		return s + ' decoding="async" />'
 
 	md.renderer.rules["image"] = image_render
 	return md
@@ -543,3 +600,40 @@ def render_markdown(content: str) -> str:
 	"""
 	html, _ = render_markdown_with_toc(content)
 	return html
+
+
+# Ordered: fenced code and directive blocks go first so their contents never
+# reach the inline rules below.
+_EXCERPT_STRIPPERS = (
+	(re.compile(r"^(?: {0,3})(`{3,}|~{3,}).*?^(?: {0,3})\1[ \t]*$", re.S | re.M), " "),
+	(re.compile(r"^:::.*$", re.M), " "),
+	(re.compile(r"<[^>]+>"), " "),
+	(re.compile(r"!\[[^\]]*\]\([^)]*\)"), " "),
+	(re.compile(r"\[([^\]]*)\]\([^)]*\)"), r"\1"),
+	(re.compile(r"^\s{0,3}(#{1,6}\s+|>\s?|[-*+]\s+|\d+\.\s+)", re.M), ""),
+	(re.compile(r"[`*_~]"), ""),
+)
+
+
+def markdown_excerpt(content: str, limit: int = 155) -> str:
+	"""First `limit` characters of a document's prose, markdown syntax removed.
+
+	Used as the meta description when an author hasn't written one — search
+	engines otherwise synthesise their own snippet, and Lighthouse flags the
+	page as having none.
+	"""
+	if not content:
+		return ""
+
+	text = content
+	for pattern, replacement in _EXCERPT_STRIPPERS:
+		text = pattern.sub(replacement, text)
+
+	text = " ".join(text.split())
+	if len(text) <= limit:
+		return text
+
+	# Cut on a word boundary so the snippet doesn't end mid-word.
+	head = text[: limit + 1]
+	cut = head.rfind(" ")
+	return (head[:cut] if cut > 0 else text[:limit]).rstrip(" ,;:.-") + "…"

--- a/wiki/wiki/test_markdown.py
+++ b/wiki/wiki/test_markdown.py
@@ -3,7 +3,7 @@
 
 import unittest
 
-from wiki.wiki.markdown import render_markdown, render_markdown_with_toc
+from wiki.wiki.markdown import markdown_excerpt, render_markdown, render_markdown_with_toc
 
 
 class TestMarkdownRenderer(unittest.TestCase):
@@ -769,6 +769,90 @@ class TestTocHeadingText(unittest.TestCase):
 	def test_plain_heading_unchanged(self):
 		"""Plain headings are unaffected by the code-aware extraction."""
 		self.assertEqual(self._texts("## Normal Heading\n"), ["Normal Heading"])
+
+
+class TestImageLoadingHints(unittest.TestCase):
+	"""Loading hints that keep images off the critical path (Lighthouse LCP/CLS)."""
+
+	def test_first_image_is_eager_and_high_priority(self):
+		result = render_markdown("![Hero](/files/hero.png)")
+		self.assertIn('fetchpriority="high"', result)
+		self.assertNotIn('loading="lazy"', result)
+
+	def test_later_images_are_lazy(self):
+		result = render_markdown("![One](/files/a.png)\n\n![Two](/files/b.png)\n\n![Three](/files/c.png)")
+		self.assertEqual(result.count('fetchpriority="high"'), 1)
+		self.assertEqual(result.count('loading="lazy"'), 2)
+
+	def test_callout_images_share_the_document_counter(self):
+		"""A callout renders in a second pass; the hero must stay the only eager image."""
+		content = "![Hero](/files/hero.png)\n\n:::note\n![Inside](/files/inside.png)\n:::\n"
+		result = render_markdown(content)
+		self.assertEqual(result.count('fetchpriority="high"'), 1)
+		self.assertIn('src="/files/inside.png" alt="Inside" loading="lazy"', result)
+
+	def test_every_image_decodes_async(self):
+		result = render_markdown("![One](/files/a.png)\n\n![Two](/files/b.png)")
+		self.assertEqual(result.count('decoding="async"'), 2)
+
+	def test_missing_file_omits_dimensions(self):
+		"""An unreadable path must not break the render — it just skips width/height."""
+		result = render_markdown("![Gone](/files/does-not-exist.png)")
+		self.assertIn('<img src="/files/does-not-exist.png"', result)
+		self.assertNotIn("width=", result)
+
+	def test_remote_image_is_not_resolved(self):
+		result = render_markdown("![Remote](https://example.com/a.png)")
+		self.assertNotIn("width=", result)
+		self.assertIn('fetchpriority="high"', result)
+
+	def test_local_image_carries_intrinsic_size(self):
+		"""width/height come from the file on disk, so the browser reserves the box."""
+		import os
+		import tempfile
+		from unittest.mock import patch
+
+		from PIL import Image
+
+		with tempfile.TemporaryDirectory() as site_path:
+			files_dir = os.path.join(site_path, "public", "files")
+			os.makedirs(files_dir)
+			Image.new("RGB", (640, 360)).save(os.path.join(files_dir, "sized.png"))
+
+			with patch("frappe.get_site_path", lambda *parts: os.path.join(site_path, *parts)):
+				result = render_markdown("![Sized](/files/sized.png)")
+
+		self.assertIn('width="640" height="360"', result)
+
+
+class TestMarkdownExcerpt(unittest.TestCase):
+	"""Meta-description fallback derived from the document body."""
+
+	def test_empty_content(self):
+		self.assertEqual(markdown_excerpt(""), "")
+		self.assertEqual(markdown_excerpt(None), "")
+
+	def test_strips_markdown_syntax(self):
+		content = "# Title\n\nSome **bold** and [a link](/somewhere) plus `code`.\n"
+		self.assertEqual(markdown_excerpt(content), "Title Some bold and a link plus code.")
+
+	def test_drops_fenced_code_and_directives(self):
+		content = "Intro text.\n\n```python\nsecret = 1\n```\n\n:::note\nCallout body\n:::\n"
+		excerpt = markdown_excerpt(content)
+		self.assertIn("Intro text.", excerpt)
+		self.assertNotIn("secret", excerpt)
+		self.assertNotIn(":::", excerpt)
+
+	def test_drops_images_but_keeps_link_text(self):
+		content = "![Hero](/files/hero.png) See [the docs](/docs) for more."
+		self.assertEqual(markdown_excerpt(content), "See the docs for more.")
+
+	def test_truncates_on_a_word_boundary(self):
+		excerpt = markdown_excerpt("alpha bravo charlie delta echo", limit=16)
+		self.assertEqual(excerpt, "alpha bravo…")
+
+	def test_short_content_is_not_truncated(self):
+		self.assertEqual(markdown_excerpt("Short enough."), "Short enough.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> **Work in progress** — more improvements to come.

Lighthouse (before → after):

| | before | after |
|---|---|---|
| Performance | 56 | 57 |
| Accessibility | 88 | **95** |
| Best Practices | 100 | 100 |
| SEO | 91 | **100** |

## Problem

Lighthouse on a public reader page reported 4,020 ms of render-blocking scripts, no meta description, and unlabelled icon buttons. On `docs.frappe.io/erpnext/introduction` the hero image is the LCP element with a 5.8 s load delay, and on its own causes a 0.107 CLS.

## Solution

- `defer` on the five body scripts — highlight.js alone is ~160 KB of parser blocking first paint
- preload the Inter variable font so it downloads alongside the stylesheet instead of after it
- rendered images now carry `width`/`height` (read off disk for `/files/` and `/private/files/`), `decoding="async"`, and `loading="lazy"` past the first one; the first is fetched eagerly at high priority as the likely LCP element
- fall back to a body excerpt when a page has no meta description
- `aria-label` on the mobile search and theme-toggle buttons
- fetch highlight.js only once a page actually has a code block
- serve reader pages from frappe's website page cache
- shrink the sidebar tree: row styling into a component class, active state marked once instead of per node

The Alpine plugins stay non-deferred on purpose: they register on `alpine:init` like the inline store definitions do, so deferring them puts their listeners last and the stores call `Alpine.$persist` before it exists. Comment left in the template.

Image dimensions are resolved with Pillow at render time, but `render_markdown_with_toc` is already memoised per document, so the disk read happens once per content edit rather than once per request. Remote URLs are never resolved.

### highlight.js on demand

The bundle is ~160 KB (53 KB brotli) and shipped on every page, but most doc pages have no code at all — `docs.frappe.io/erpnext/introduction` has zero `<code>` elements and still paid for it. `code-blocks.js` now reads the hashed URL off its own `data-highlight-src` and injects the script the first time it sees a `pre > code`, so SPA navigation into a code page loads it too. A failed load resolves rather than rejects, leaving plain readable blocks.

### The page cache

Every reader request rebuilt the whole page — sidebar tree, space switcher, TOC — and frappe's `process_response` then stamped it `no-store`, so the browser couldn't reuse it and the page was disqualified from the back/forward cache. In production that reads as `x-from-cache: False` with a 1,020 ms TTFB on every hit.

`WikiDocumentRenderer` now reads and writes `website_page::<route>`, the same key format frappe's own `cache_html` uses, so `delete_page_cache` and `clear_cache(route)` already drop these entries. A hit also sets `private,max-age=300,stale-while-revalidate=10800`, which opts the page out of the `no-store` default.

Only anonymous renders are stored. The key is the route alone and the page carries the visitor's Edit button, so caching a signed-in render would show one editor's chrome to every reader; an unauthorized Guest throws out of `get_web_context` before anything is written. The CSRF token is rendered as a placeholder and substituted after the lookup, so no visitor is ever handed another's token.

Invalidation: `clear_wiki_tree_cache` drops every cached page, since each one embeds a copy of the sidebar tree, and Wiki Settings does the same on save because `head_html`, `javascript` and the TOC toggle are baked in.

Two things worth flagging for review. `can_cache()` refuses to cache under `developer_mode`, so none of this is observable on a dev bench — the integration tests patch it on and drive the real HTTP client. And `last_updated` is a server-rendered relative string, so a cached page can show "Last updated 5 minutes ago" for up to 30 minutes; the exact timestamp is already in the `title`/`data-timestamp` attributes.

## Numbers

Lighthouse mobile, local reader page:

| | before | after |
|---|---|---|
| FCP | 11.0 s | **8.7 s** |
| Speed Index | 11.0 s | **8.7 s** |
| CLS | 0.001 | **0** |
| render-blocking | 4,020 ms | **930 ms** |

Performance barely moves locally because LCP is now 96% render delay, which on the dev server is the uncompressed HTML document — prod gzips it. The image work can't show up locally either; the test page has no images.

### The sidebar tree

The tree renders twice per page — mobile sheet, then desktop rail — and on `docs.frappe.io/erpnext/introduction` those two copies are essentially the whole 2,548 KB document: 1,276 KB and 724 anchors for the desktop copy alone, at 1,804 bytes per row. Two things account for most of it, and neither is load-bearing.

The repeated utility string moved into `.wiki-row` in `main.css`, with dense/roomy geometry variants. `@layer components` rather than `@utility`, since these are multi-property component classes and utilities should still win where a caller overrides one; `no-underline` and `cursor-pointer` key off `:where(a)` / `:where(button)` instead of extra class names, and title size follows from the geometry class. The dead `group` class went too — nothing in the reader uses `group-hover`.

Then the active-row state. Every leaf carried two Alpine expressions — a `:class` ternary and an `:aria-current` binding — each re-evaluating the same `currentRoute === '<this route>'` comparison: ~2,800 reactive expressions per page across both trees, and 214 KB of markup to express them. The server now renders `aria-current` on the matching row, the navigation store moves it in one pass on SPA nav (`markActiveRow`), and CSS styles both the active row and the hover state off the attribute.

Finally the click and prefetch handlers, which embedded the route a second and third time on every row. The store now binds one `click` and one `mouseover` listener and reads `data-route` off the closest `.wiki-link`, so row markup carries no Alpine at all — and delegation survives the sheet's markup being replaced, which per-node handlers don't. Group toggles and external links are untouched; neither is a `.wiki-link` with `data-route`.

That last one needed a real fix, not just a move: `mouseover` fires far more often than the `mouseenter` it replaces, so `prefetch` now tracks in-flight routes as well as cached ones. Without it a single hover could put two identical requests on the wire before the first response landed. The new e2e covers it and fails with the guard removed.

Leaf row opening tags: **976 → 327 bytes**, a ~67% cut, and `$store.navigation` drops from 84 occurrences to 12 on a test page. Brotli already squashes this markup hard, so the win is DOM size and Alpine effect count, not transfer.

Rendering is unchanged — a screenshot diff of the same page before and after is 0% different across 1,296,000 pixels, and a real-pointer hover check confirms idle rows still highlight while the current one doesn't.

## Benchmarks

Server-side render vs cache read, median of 15 rounds over 6 real pages on a dev bench:

| | context | template | total render | cache hit | speedup |
|---|---|---|---|---|---|
| median | 46 ms | 39 ms | **86 ms** | **0.83 ms** | ~105x |

Full request through the werkzeug test client — routing, session, render, response build — median of 12 rounds over 5 pages:

| | no cache | cached | saved |
|---|---|---|---|
| median | **75.3 ms** | **8.0 ms** | **89%** |

Invalidation cost, since `delete_page_cache()` is a Redis `KEYS` scan and runs on every document save: 0.4 ms at 100 cached pages, 1.1 ms at 500, 3.9 ms at 2,000. Cheap enough to keep the blanket clear rather than tracking which routes a tree change touched.

Highlight bundle: 162,235 B raw / 53,293 B gzip / 39,062 B brotli, now not fetched at all on a page without code. Lighthouse on a prose page drops from 13 requests to 12 and 1,983 KiB to 1,864 KiB, with LCP 11.4 s → 10.8 s.

## Tests

- 13 new unit tests in `test_markdown.py` covering the image loading hints and the excerpt; full module is 76 passing
- 4 new integration tests in `test_wiki_document.py` for the page cache: reuse across requests, placeholder-not-token in the stored copy, signed-in renders never stored, tree change drops everything. Full module is 111 passing
- new `e2e/tests/code-blocks.spec.ts`: the bundle is not fetched on a prose page, is fetched on a code page, and arrives on SPA navigation into one
- new `e2e/tests/sidebar-row-events.spec.ts`: hovering a row prefetches exactly once, and a group toggle expands instead of navigating
- 21 passing across `sidebar`, `sidebar-reveal`, `toc-navigation`, `tab-navigation`, `external-link`, `page-actions-ai-url` — the existing specs already assert `aria-current="page"` on load and after SPA nav
- e2e `image-viewer`, `public-pages`, `mermaid`, `sidebar`, `toc-navigation`, `search-modal` pass. Two `mobile-view.spec.ts` failures are pre-existing — they fail identically on a clean `develop`

## Not in scope

Still on the table: the mobile sheet renders a second full copy of the tree that could be built lazily on open — the single biggest DOM win left, but it wants its own PR. The tree's Jinja indent whitespace is 36.8% of the sidebar markup, though it's pure formatting that brotli already erases, so removing it would cost source readability for bytes that don't reach the wire. `Inter.var.woff2` is 316 KB unsubsetted, with a `unicode-range` covering CJK the file doesn't contain, so it always downloads whole. The space switcher is O(spaces) and rendered twice — only 17 spaces on docs.frappe.io today, so it's latent rather than urgent. Uploads have no WebP/AVIF variants. And the Cloudflare JS challenge burns 5,398 ms of bootup by itself, which no change in this repo can touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
