### PR TITLE
fix: published pages honour author blank lines

### DIFF
--- a/e2e/tests/public-blank-lines.spec.ts
+++ b/e2e/tests/public-blank-lines.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test } from '@playwright/test';
+import { updateDoc } from '../helpers/frappe';
+import {
+	createTestWikiDocument,
+	createTestWikiSpace,
+	deleteTestWikiDocument,
+	deleteTestWikiSpace,
+} from '../helpers/wiki';
+
+/**
+ * prose-v3 zeroes paragraph margins: blank lines the author typed are the only
+ * thing carrying vertical rhythm. The server renderer materialises them as
+ * <p class="wiki-blank-line"><br></p>. Unit tests can prove the markup, only a
+ * browser can prove the gap has height — an empty <p> would collapse to 0px.
+ */
+const CONTENT = 'First paragraph\n\n\n\n\n\nSecond paragraph';
+
+test.describe('Public page blank lines', () => {
+	test('renders author blank lines as gaps with real height', async ({
+		page,
+		request,
+	}) => {
+		const spaceRoute = `blank-lines-space-${Date.now()}`;
+		const space = await createTestWikiSpace(request, {
+			route: spaceRoute,
+			is_published: true,
+		});
+		const rootGroup = await createTestWikiDocument(request, {
+			title: 'Root',
+			route: `${spaceRoute}/root`,
+			is_group: true,
+			is_published: true,
+		});
+		await updateDoc(request, 'Wiki Space', space.name, {
+			root_group: rootGroup.name,
+		});
+		const doc = await createTestWikiDocument(request, {
+			title: 'Blank Lines Page',
+			route: `${spaceRoute}/blank-lines`,
+			content: CONTENT,
+			is_published: true,
+			parent_wiki_document: rootGroup.name,
+		});
+
+		try {
+			await page.goto(`/${doc.route}`);
+			await page.waitForLoadState('networkidle');
+
+			// Two extra blank lines in the markdown => two blank paragraphs.
+			const blanks = page.locator('#wiki-content .wiki-blank-line');
+			await expect(blanks).toHaveCount(2);
+
+			for (const blank of await blanks.all()) {
+				const box = await blank.boundingBox();
+				expect(box?.height ?? 0).toBeGreaterThan(0);
+			}
+
+			const first = await page
+				.locator('#wiki-content p', { hasText: 'First paragraph' })
+				.first()
+				.boundingBox();
+			const second = await page
+				.locator('#wiki-content p', { hasText: 'Second paragraph' })
+				.first()
+				.boundingBox();
+
+			// Without the blank paragraphs the two would sit flush (~one line apart).
+			const delta = (second?.y ?? 0) - ((first?.y ?? 0) + (first?.height ?? 0));
+			expect(delta).toBeGreaterThan(30);
+		} finally {
+			await deleteTestWikiDocument(request, doc.name).catch(() => {});
+			await deleteTestWikiDocument(request, rootGroup.name).catch(() => {});
+			await deleteTestWikiSpace(request, space.name).catch(() => {});
+		}
+	});
+});

--- a/specs/published_blank_line_spacing.md
+++ b/specs/published_blank_line_spacing.md
@@ -1,0 +1,41 @@
+# Published Pages Honour Author Blank Lines
+
+Date: 2026-07-28
+Status: In progress. Lives on `fix/published-blank-line-spacing`.
+
+## Problem
+
+Wiki content is stored as markdown. The `prose-v3` scale used by both surfaces sets `p { margin: 0 }` on purpose — vertical rhythm is author-controlled via blank lines (frappe-ui `tailwind/plugin.js:442-456`).
+
+The editor honours that: `@tiptap/markdown` materialises extra blank lines as empty paragraphs, and `WikiParagraph` (`frontend/src/components/WikiEditor.vue:85-94`) serialises them back to bare blank lines. The server renderer does not — `wiki/wiki/markdown.py` runs markdown-it-py CommonMark, which discards blank-line runs. With zero `p` margins and nothing replacing them, **published pages render every block flush against the next**, while the editor shows the spacing the author typed.
+
+Related asymmetry fixed in the same change: the editor parses with `marked({ breaks: true })` (single newline → `<br>`); the server had `breaks` off.
+
+## Approach
+
+Preserve blank lines server-side, at token level, mirroring the editor's arithmetic. No storage-format change, no CSS-margin workaround (that would break the prose-v3 contract and still ignore author intent).
+
+Gap formula, verified against `marked`'s `space` token raw + `@tiptap/markdown`'s `createImplicitEmptyParagraphsFromSpace`: for a gap of `g` blank lines between two top-level blocks → `(g + 1) // 2 - 1` empty paragraphs (g=1,2 → 0; g=3,4 → 1; g=5 → 2). At document start → `g // 2`.
+
+The formula applies **uniformly**, regardless of the preceding block type. `marked` swallows trailing newlines after headings/tables/HTML blocks/indented code/callouts, so the editor shows no gap there — but the blank lines *are* in the stored markdown. Rendering what the markdown says is stable across upstream tokenizer changes and self-heals on the next editor save. `_GAP_SUPPRESSING_PREV_BLOCKS` is the one-line switch if that call ever flips.
+
+## Changes
+
+1. **`wiki/wiki/markdown.py` — gap-preserving placeholders.** The callout/video/PDF replacers returned `f"\n\n{PH}\n\n"`, inflating every adjacent gap by two newlines; with the new rule that would render a phantom blank paragraph on each side of every callout, video and PDF. `_standalone_block()` now emits only the newlines needed for the placeholder to stand alone as a block.
+2. **`wiki/wiki/markdown.py` — blank-line rule.** `_blank_line_rule` (core rule, registered `after("block")`) inserts a `wiki_blank_line` token before each top-level block for the author's extra blank lines; `_render_blank_line` emits `<p class="wiki-blank-line" aria-hidden="true"><br></p>` (a bare `<p></p>` collapses to zero height under `margin: 0`).
+   - Gaps are measured by scanning `state.src` backwards from `token.map[0] - 1`, never from the previous token's `map[1]`: markdown-it folds trailing blank lines into a list's map, so `map[1]` under-reports.
+   - `after("block")` is load-bearing — after `normalize` (CRLF collapsed, so `src.split("\n")` matches the maps) and before the footnote plugin's `footnote_tail`, which reorders tokens.
+3. **`wiki/wiki/markdown.py` — `breaks: True`** on the MarkdownIt instance, matching the editor's `marked` config.
+4. **`wiki/public/css/main.css`** — `.prose .wiki-blank-line { line-height: 20px }`, matching the SPA read-only viewer's empty-paragraph height.
+5. **`wiki/patches.txt`** — explicit `clear_wiki_content_cache()` post-model-sync, since `get_rendered_content` Redis-caches rendered HTML per document and only evicts on save/merge/trash.
+
+## Out of scope (documented divergences)
+
+- Blank lines nested inside list items / blockquotes — markdown-it exposes no container-relative line map. The editor materialises some of these.
+- Trailing blank lines at end of document — every git-synced `.md` ending in `\n\n` would otherwise gain a dead band above the prev/next nav.
+- Blank lines *inside* callout bodies now render too (`_replace_callout_placeholders` re-renders the body through `md.render`) — intended.
+
+## Tests
+
+- `wiki/wiki/test_markdown.py::TestBlankLinePreservation` — gap counts, block types (list/blockquote/table/fence/hr/heading/html), fence interiors untouched, placeholder gaps (regression guard for change 1), leading vs trailing boundaries, TOC unaffected, footnotes, soft breaks.
+- `e2e/tests/public-blank-lines.spec.ts` — published page renders the gaps with real height; the Python tests can prove the markup, only the browser can prove the pixels.

--- a/wiki/patches.txt
+++ b/wiki/patches.txt
@@ -23,3 +23,4 @@ wiki.frappe_wiki.doctype.wiki_change_request.patches.drop_reviewer_participant_t
 wiki.wiki.doctype.wiki_space.patches.set_allow_contributions_default
 wiki.frappe_wiki.doctype.wiki_revision.patches.mark_hashes_stale_for_metadata_hashing
 execute:frappe.db.set_single_value('Wiki Settings', 'auto_generate_meta_images', 1) #2026-07-25
+execute:from wiki.frappe_wiki.doctype.wiki_document.wiki_document import clear_wiki_content_cache; clear_wiki_content_cache() #2026-07-28-blank-lines

--- a/wiki/public/css/main.css
+++ b/wiki/public/css/main.css
@@ -85,6 +85,14 @@ body {
   font-family: var(--font-sans);
 }
 
+/* Blank lines the author left between blocks. prose-v3 zeroes paragraph margins,
+   so vertical rhythm is carried by empty paragraphs; markdown.py materialises
+   them as <p class="wiki-blank-line"><br></p>. 20px matches the SPA read-only
+   editor's empty-paragraph line-height (frappe-ui TextEditor/style.css). */
+.prose .wiki-blank-line {
+  line-height: 20px;
+}
+
 /* Code block shell + hljs theme come from frappe-ui-code.css; the reader
    only anchors its own toolbar overlay and scrolls long lines. */
 .prose pre {

--- a/wiki/wiki/markdown.py
+++ b/wiki/wiki/markdown.py
@@ -17,6 +17,7 @@ import re
 
 from markdown_it import MarkdownIt
 from markdown_it.common.utils import escapeHtml
+from markdown_it.token import Token
 from mdit_py_plugins.footnote import footnote_plugin
 from mdit_py_plugins.tasklists import tasklists_plugin
 
@@ -95,6 +96,22 @@ def _generate_callout_html(callout_type, title, inner_html):
 	)
 
 
+def _standalone_block(match: "re.Match", body: str) -> str:
+	"""
+	Wrap `body` in just enough newlines to stand alone as a block, without changing
+	the blank-line gap the author wrote around the replaced text.
+
+	Returning an unconditional "\\n\\n{body}\\n\\n" would inflate every gap adjacent to
+	a callout/video/PDF by two newlines, which _blank_line_rule then materialises as
+	a phantom empty paragraph on each side.
+	"""
+	src = match.string
+	before, after = src[: match.start()], src[match.end() :]
+	lead = "" if (not before or before.endswith("\n\n")) else ("\n" if before.endswith("\n") else "\n\n")
+	trail = "" if (not after or after.startswith("\n\n")) else ("\n" if after.startswith("\n") else "\n\n")
+	return lead + body + trail
+
+
 def _process_callouts_with_placeholders(content):
 	"""
 	Replace callout blocks with placeholders, returning the modified content
@@ -120,7 +137,7 @@ def _process_callouts_with_placeholders(content):
 				"content": inner_content.strip(),
 			}
 		)
-		return f"\n\n{placeholder_prefix}{idx}END\n\n"
+		return _standalone_block(match, f"{placeholder_prefix}{idx}END")
 
 	# Process callouts (may be nested, so we process iteratively)
 	prev_content = None
@@ -233,7 +250,7 @@ def _process_videos_with_placeholders(content: str) -> tuple[str, list[dict], st
 				"title": match.group("title") or "",
 			}
 		)
-		return f"\n\n{placeholder_prefix}{idx}END\n\n"
+		return _standalone_block(match, f"{placeholder_prefix}{idx}END")
 
 	return VIDEO_MARKDOWN_PATTERN.sub(replacer, content), videos, placeholder_prefix
 
@@ -315,7 +332,7 @@ def _process_pdfs_with_placeholders(content: str) -> tuple[str, list[dict], str]
 
 		idx = len(pdfs)
 		pdfs.append({"url": url, "filename": match.group("alt") or ""})
-		return f"\n\n{placeholder_prefix}{idx}END\n\n"
+		return _standalone_block(match, f"{placeholder_prefix}{idx}END")
 
 	return VIDEO_MARKDOWN_PATTERN.sub(replacer, content), pdfs, placeholder_prefix
 
@@ -387,10 +404,84 @@ def _escape_table_inline_code_pipes(content: str) -> str:
 	return "\n".join(lines)
 
 
+BLANK_LINE_TOKEN = "wiki_blank_line"
+
+# Block types after which a gap is ignored. Empty on purpose: marked (the editor's
+# parser) swallows trailing newlines after headings, tables, HTML blocks, indented
+# code and callouts, so the editor shows no gap there — but the blank lines are in
+# the stored markdown, so we render them. Populate this to mirror marked instead.
+_GAP_SUPPRESSING_PREV_BLOCKS: frozenset[str] = frozenset()
+
+# Footnote definitions are relocated to the end of the document by the plugin's
+# `footnote_tail` core rule, so a gap measured at their original position would
+# leave an orphaned blank paragraph behind. Never anchor a gap to them.
+_GAP_ANCHOR_SKIP = frozenset({"footnote_reference_open", "footnote_block_open"})
+
+
+def _blank_line_rule(state) -> None:
+	"""
+	Materialise author-typed blank lines between top-level blocks.
+
+	CommonMark discards runs of blank lines, but `.prose-v3` sets `p { margin: 0 }` —
+	blank lines *are* the spacing mechanism, and the editor models them as empty
+	paragraphs. Mirror @tiptap/markdown's arithmetic: a gap of `g` blank lines yields
+	`(g + 1) // 2 - 1` empty paragraphs (g=1,2 -> 0; g=3,4 -> 1; g=5 -> 2), and `g // 2`
+	at the start of the document, where the run has no leading newline.
+
+	Gaps are measured by scanning `state.src` backwards from the block's first line,
+	never from the previous token's `map[1]`: markdown-it folds trailing blank lines
+	into a list's map, so `map[1]` under-reports.
+
+	Out of scope, deliberately: blank lines nested inside list items and blockquotes
+	(markdown-it exposes no container-relative line map) and trailing blank lines at
+	the end of a document (they have no block to anchor to, and every git-synced file
+	ending in a stray newline would gain a dead band).
+	"""
+	lines = state.src.split("\n")
+
+	def is_blank(index: int) -> bool:
+		return 0 <= index < len(lines) and not lines[index].strip()
+
+	tokens = []
+	prev_type = None
+	for token in state.tokens:
+		# Opening/self-closing top-level blocks only: closing tokens carry no map, and
+		# nested tokens (list items, table cells, tight-list paragraphs) are level > 0.
+		is_anchor = (
+			token.level == 0
+			and token.map
+			and token.nesting >= 0
+			and token.type not in _GAP_ANCHOR_SKIP
+			and prev_type not in _GAP_SUPPRESSING_PREV_BLOCKS
+		)
+		if is_anchor:
+			line = token.map[0] - 1
+			gap = 0
+			while is_blank(line):
+				gap += 1
+				line -= 1
+			count = gap // 2 if line < 0 else (gap + 1) // 2 - 1
+			for _ in range(max(count, 0)):
+				blank = Token(BLANK_LINE_TOKEN, "", 0)
+				blank.block = True
+				tokens.append(blank)
+		if token.level == 0 and token.nesting >= 0:
+			prev_type = token.type
+		tokens.append(token)
+
+	state.tokens = tokens
+
+
+def _render_blank_line(tokens, idx, options, env) -> str:
+	# An empty <p> collapses to zero height under `p { margin: 0 }`; the <br> gives it
+	# a line box even where the stylesheet never loads (PDF export).
+	return '<p class="wiki-blank-line" aria-hidden="true"><br></p>\n'
+
+
 def _build_markdown() -> MarkdownIt:
 	"""Build a configured markdown-it-py instance with our render overrides."""
 	md = (
-		MarkdownIt("commonmark", {"html": True, "linkify": False, "typographer": False})
+		MarkdownIt("commonmark", {"html": True, "breaks": True, "linkify": False, "typographer": False})
 		.enable(["table", "strikethrough"])
 		.use(footnote_plugin)
 		.use(tasklists_plugin, enabled=True)
@@ -443,6 +534,12 @@ def _build_markdown() -> MarkdownIt:
 		return s + " />"
 
 	md.renderer.rules["image"] = image_render
+
+	# after("block"): tokens and their line maps exist, `state.src` is already
+	# normalized (CRLF collapsed, so it lines up with the maps), and we still run
+	# before the footnote plugin's `footnote_tail`, which reorders the token stream.
+	md.core.ruler.after("block", "wiki_blank_lines", _blank_line_rule)
+	md.renderer.rules[BLANK_LINE_TOKEN] = _render_blank_line
 	return md
 
 

--- a/wiki/wiki/test_markdown.py
+++ b/wiki/wiki/test_markdown.py
@@ -771,5 +771,96 @@ class TestTocHeadingText(unittest.TestCase):
 		self.assertEqual(self._texts("## Normal Heading\n"), ["Normal Heading"])
 
 
+class TestBlankLinePreservation(unittest.TestCase):
+	"""
+	prose-v3 zeroes paragraph margins, so author blank lines carry the spacing.
+	Counts mirror the editor: a gap of `g` blank lines yields `(g + 1) // 2 - 1`
+	blank paragraphs, or `g // 2` at the start of the document.
+	"""
+
+	def _gaps(self, content):
+		return render_markdown(content).count('class="wiki-blank-line"')
+
+	def test_single_blank_line_is_a_plain_paragraph_break(self):
+		"""The ordinary paragraph separator must not grow a gap."""
+		result = render_markdown("a\n\nb")
+		self.assertNotIn("wiki-blank-line", result)
+		self.assertIn("<p>a</p>\n<p>b</p>", result)
+
+	def test_extra_blank_lines_become_blank_paragraphs(self):
+		self.assertEqual(self._gaps("a\n\n\nb"), 0)
+		self.assertEqual(self._gaps("a\n\n\n\nb"), 1)
+		self.assertEqual(self._gaps("a\n\n\n\n\nb"), 1)
+		self.assertEqual(self._gaps("a\n\n\n\n\n\nb"), 2)
+
+	def test_gap_after_list(self):
+		"""Regression: markdown-it folds trailing blank lines into the list's map,
+		so the gap has to be measured from the *next* block backwards."""
+		self.assertEqual(self._gaps("- a\n- b\n\n\n\n\np"), 1)
+
+	def test_gap_after_other_block_types(self):
+		self.assertEqual(self._gaps("> quoted\n\n\n\nafter"), 1)
+		self.assertEqual(self._gaps("```\ncode\n```\n\n\n\nafter"), 1)
+		self.assertEqual(self._gaps("---\n\n\n\nafter"), 1)
+		self.assertEqual(self._gaps("| a | b |\n| - | - |\n| 1 | 2 |\n\n\n\nafter"), 1)
+		self.assertEqual(self._gaps("## Heading\n\n\n\nafter"), 1)
+		self.assertEqual(self._gaps("<div>raw</div>\n\n\n\nafter"), 1)
+
+	def test_blank_lines_inside_a_fence_are_untouched(self):
+		result = render_markdown("```\ncode\n\nmore\n```")
+		self.assertNotIn("wiki-blank-line", result)
+		self.assertIn("<pre><code>code\n\nmore\n</code></pre>", result)
+
+	def test_blank_lines_inside_a_table_are_untouched(self):
+		content = "| a | b |\n| - | - |\n| 1 | 2 |\n| 3 | 4 |"
+		self.assertEqual(self._gaps(content), 0)
+
+	def test_callout_does_not_inflate_neighbouring_gaps(self):
+		"""Placeholder substitution used to pad with \\n\\n on both sides."""
+		self.assertEqual(self._gaps("before\n\n:::note\nhi\n:::\n\nafter"), 0)
+		self.assertEqual(self._gaps("before\n\n\n\n:::note\nhi\n:::\n\n\n\nafter"), 2)
+
+	def test_video_does_not_inflate_neighbouring_gaps(self):
+		before = "before\n\n![clip](/files/a.mp4)\n\nafter"
+		wide = "before\n\n\n\n![clip](/files/a.mp4)\n\n\n\nafter"
+		self.assertEqual(self._gaps(before), 0)
+		self.assertEqual(self._gaps(wide), 2)
+		self.assertIn("<video", render_markdown(before))
+
+	def test_pdf_does_not_inflate_neighbouring_gaps(self):
+		before = "before\n\n![doc](/files/a.pdf)\n\nafter"
+		wide = "before\n\n\n\n![doc](/files/a.pdf)\n\n\n\nafter"
+		self.assertEqual(self._gaps(before), 0)
+		self.assertEqual(self._gaps(wide), 2)
+		self.assertIn("wiki-pdf-embed", render_markdown(before))
+
+	def test_leading_blank_lines(self):
+		self.assertEqual(self._gaps("\n\ntext"), 1)
+		self.assertEqual(self._gaps("\ntext"), 0)
+
+	def test_trailing_blank_lines_are_dropped(self):
+		"""No block to anchor to, and git-synced files often end in stray newlines."""
+		self.assertEqual(self._gaps("text\n\n\n\n"), 0)
+
+	def test_toc_is_unaffected(self):
+		html, headings = render_markdown_with_toc("## A\n\n\n\ntext\n\n## B")
+		self.assertEqual([h["text"] for h in headings], ["A", "B"])
+		self.assertIn('<h2 id="a">A</h2>', html)
+		self.assertIn('<h2 id="b">B</h2>', html)
+		self.assertEqual(html.count('class="wiki-blank-line"'), 1)
+
+	def test_footnote_definitions_do_not_orphan_a_gap(self):
+		"""footnote_tail moves definitions to the end; a gap anchored there would
+		leave a blank paragraph stranded mid-document."""
+		content = "text[^1]\n\n\n\nmore\n\n\n\n[^1]: the note"
+		html = render_markdown(content)
+		self.assertEqual(html.count('class="wiki-blank-line"'), 1)
+		self.assertIn("footnote", html)
+
+	def test_soft_break_renders_as_line_break(self):
+		"""Matches the editor's marked({ breaks: true })."""
+		self.assertIn("<br", render_markdown("line one\nline two"))
+
+
 if __name__ == "__main__":
 	unittest.main()

--- a/wiki/wiki/test_markdown.py
+++ b/wiki/wiki/test_markdown.py
@@ -834,6 +834,24 @@ class TestBlankLinePreservation(unittest.TestCase):
 		self.assertEqual(self._gaps(wide), 2)
 		self.assertIn("wiki-pdf-embed", render_markdown(before))
 
+	def test_adjacent_placeholders_do_not_gain_a_gap(self):
+		"""Two custom blocks one newline apart: each side contributes a newline to
+		break the placeholder out as a block, giving three — still one short of the
+		four an author-typed empty paragraph writes, so no gap."""
+		self.assertEqual(self._gaps("![a](/files/a.mp4)\n![b](/files/b.mp4)"), 0)
+		self.assertEqual(self._gaps("![a](/files/a.mp4)\n![b](/files/b.mp4)\n![c](/files/c.mp4)"), 0)
+		self.assertEqual(self._gaps("![a](/files/a.mp4)\n![b](/files/b.pdf)"), 0)
+		self.assertEqual(self._gaps(":::note\nx\n:::\n![a](/files/a.mp4)"), 0)
+		self.assertEqual(self._gaps("![a](/files/a.mp4)\n:::note\nx\n:::"), 0)
+		self.assertEqual(self._gaps(":::note\nx\n:::\n:::tip\ny\n:::"), 0)
+
+	def test_placeholder_glued_to_surrounding_text(self):
+		"""The placeholder still breaks out of the paragraph it was written inside."""
+		result = render_markdown("text\n![a](/files/a.mp4)\ntext2")
+		self.assertNotIn("wiki-blank-line", result)
+		self.assertIn("<video", result)
+		self.assertNotIn("<p>text\n", result.replace("<br />", ""))
+
 	def test_leading_blank_lines(self):
 		self.assertEqual(self._gaps("\n\ntext"), 1)
 		self.assertEqual(self._gaps("\ntext"), 0)


### PR DESCRIPTION
## Problem

Blank lines the author types in the editor don't show up on the published page. `prose-v3` sets `p { margin: 0 }` on purpose — blank lines *are* the spacing mechanism — but the server renderer (markdown-it-py, CommonMark) discards blank-line runs, so published pages render every block flush against the next.

Same for single newlines: the editor parses with `marked({ breaks: true })`, the server had `breaks` off.

## Solution

A core rule inserts a `wiki_blank_line` token per extra blank line between top-level blocks, using the same arithmetic as `@tiptap/markdown` so the count matches the editor. It renders as `<p class="wiki-blank-line"><br></p>` — a bare `<p></p>` would collapse to zero height under zero margins.

Gaps are measured by scanning the source backwards from the block's first line, not from the previous token's `map[1]`: markdown-it folds trailing blank lines into a list's map.

Also in here:

- Placeholder substitution for callouts/videos/PDFs padded with `\n\n` on both sides, which would have inflated every adjacent gap into a phantom blank paragraph. It now preserves the author's gap.
- `breaks: True`, matching the editor.
- `clear_wiki_content_cache()` patch — rendered HTML is cached per document in Redis and only evicted on save.

## Known divergences

- Blank lines after headings, tables, HTML blocks, indented code and callouts render on the reader but not in the editor (marked swallows the trailing newlines there). The blank lines *are* in the stored markdown; this self-heals on the next editor save. `_GAP_SUPPRESSING_PREV_BLOCKS` is the one-line switch to mirror marked instead.
- Blank lines nested inside list items / blockquotes are not rendered — markdown-it exposes no container-relative line map.
- Trailing blank lines at the end of a document are not rendered.
- `breaks: True` means line-wrapped markdown from git sync now renders hard-broken on the reader. The editor already rendered it that way.

## Tests

14 unit tests in `wiki/wiki/test_markdown.py` (gap arithmetic, block-type matrix, fence interiors, placeholder regression, boundaries, TOC, footnotes, soft breaks) and `e2e/tests/public-blank-lines.spec.ts`, which asserts the rendered gap has non-zero height — the thing markup assertions can't prove.

Verified the tests bite: disabling the rule fails 9 of them; restoring the old placeholder padding fails exactly the 3 callout/video/PDF ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
