### PR TITLE
fix: assign Wiki User role without triggering nested User.save()

### DIFF
--- a/wiki/utils.py
+++ b/wiki/utils.py
@@ -23,10 +23,12 @@ def check_app_permission():
 
 def add_wiki_user_role(doc, event=None):
 	if not any(r.role == "Wiki User" for r in doc.get("roles", [])):
-		frappe.get_doc({
-			"doctype": "Has Role",
-			"parent": doc.name,
-			"parenttype": "User",
-			"parentfield": "roles",
-			"role": "Wiki User"
-		}).insert(ignore_permissions=True)
+		frappe.get_doc(
+			{
+				"doctype": "Has Role",
+				"parent": doc.name,
+				"parenttype": "User",
+				"parentfield": "roles",
+				"role": "Wiki User",
+			}
+		).insert(ignore_permissions=True)

--- a/wiki/utils.py
+++ b/wiki/utils.py
@@ -22,4 +22,11 @@ def check_app_permission():
 
 
 def add_wiki_user_role(doc, event=None):
-	doc.add_roles("Wiki User")
+	if not any(r.role == "Wiki User" for r in doc.get("roles", [])):
+		frappe.get_doc({
+			"doctype": "Has Role",
+			"parent": doc.name,
+			"parenttype": "User",
+			"parentfield": "roles",
+			"role": "Wiki User"
+		}).insert(ignore_permissions=True)


### PR DESCRIPTION
## Description

This PR updates `add_wiki_user_role` to assign the "Wiki User" role without invoking a full `User.save()` re-validation cycle.

## Problem

Currently, `add_wiki_user_role` uses `doc.add_roles("Wiki User")` inside the `User` document's `after_insert` hook. Calling `doc.add_roles()` triggers a nested `User.save()` statement during insertion.

In multi-worker environments, this secondary save re-triggers `User.on_update` and enqueues background tasks (such as `create_contact`) twice simultaneously. Because both workers execute in parallel, they both see no existing contact for the user, resulting in **two duplicate Contact records being created** on user signup.

## Solution

1. In `wiki/utils.py`, inspect `doc.get("roles", [])` in memory to check if `"Wiki User"` is already present (zero DB queries).
2. Insert the `Has Role` child document directly using `frappe.get_doc({...}).insert(ignore_permissions=True)`.

This attaches the role to the user cleanly upon creation without invoking an extra `User.save()` cycle or triggering duplicate enqueued background jobs.

<img width="2156" height="1660" alt="image" src="https://github.com/user-attachments/assets/11ba0766-c9d1-4ad6-993d-32b1e74adcfa" />
<img width="2244" height="1664" alt="image" src="https://github.com/user-attachments/assets/bc08ac39-c206-409a-8694-535d42717e24" />

