### PR TITLE
feat: make tabbed navigation opt-in per space

### DIFF
--- a/e2e/tests/change-request-flow.spec.ts
+++ b/e2e/tests/change-request-flow.spec.ts
@@ -13,6 +13,14 @@ interface WikiDocumentRoute {
 	doc_key: string;
 }
 
+declare global {
+	interface Window {
+		// Set by the merge-UX test's DOM watcher (see below).
+		__mergeUx: { treeBlanked: boolean; sawIntermediateState: boolean };
+		__mergeUxStop?: () => void;
+	}
+}
+
 const CR_METHOD =
 	'wiki.frappe_wiki.doctype.wiki_change_request.wiki_change_request';
 
@@ -973,6 +981,54 @@ test.describe('Change Request Flow', () => {
 		await expect(page).toHaveURL(
 			new RegExp(`${APP_BASE}/change-requests\\?tab=all`),
 		);
+	});
+
+	test('merging from the editor keeps the tree up and the banner steady', async ({
+		page,
+	}) => {
+		const content = `Merge UX content ${Date.now()}`;
+		const { pageTitle } = await createSpaceWithDraftPage(page, 'CR Merge UX');
+		await setEditorContentAndSave(page, content);
+
+		const treeItem = page
+			.locator('aside')
+			.getByText(pageTitle, { exact: true });
+		await expect(treeItem).toBeVisible();
+
+		// Both regressions are transient, so a post-hoc assertion can't see them:
+		// watch the DOM for the whole merge and report what it ever showed.
+		await page.evaluate(() => {
+			const state = { treeBlanked: false, sawIntermediateState: false };
+			window.__mergeUx = state;
+			const sample = () => {
+				const aside = document.querySelector('aside');
+				if (aside && aside.querySelectorAll('[role="treeitem"]').length === 0) {
+					state.treeBlanked = true;
+				}
+				if (document.body.innerText.includes('Ready to merge')) {
+					state.sawIntermediateState = true;
+				}
+			};
+			const observer = new MutationObserver(sample);
+			observer.observe(document.body, { childList: true, subtree: true });
+			window.__mergeUxStop = () => observer.disconnect();
+			sample();
+		});
+
+		await page.getByRole('button', { name: 'Merge', exact: true }).click();
+		await expect(
+			page.locator('text=Change request merged').first(),
+		).toBeVisible({ timeout: 15000 });
+		// The rehydrate outlives the toast; let it finish before reading.
+		await page.waitForLoadState('networkidle');
+
+		const observed = await page.evaluate(() => {
+			window.__mergeUxStop?.();
+			return window.__mergeUx;
+		});
+		expect(observed.treeBlanked).toBe(false);
+		expect(observed.sawIntermediateState).toBe(false);
+		await expect(treeItem).toBeVisible();
 	});
 
 	test('author can withdraw an in-review CR back to Draft from the menu', async ({

--- a/e2e/tests/tab-navigation.spec.ts
+++ b/e2e/tests/tab-navigation.spec.ts
@@ -73,6 +73,8 @@ test.describe('Horizontal tab navigation', () => {
 			route: ROUTE,
 			root_group: root.name,
 			is_published: 1,
+			// Tabs are opt-in per space; every test below needs the bar.
+			enable_tabs: 1,
 		});
 
 		const accounting = await group(
@@ -392,6 +394,7 @@ test.describe('Reader sidebar with a single tab', () => {
 			route: SOLO_ROUTE,
 			root_group: root.name,
 			is_published: 1,
+			enable_tabs: 1,
 		});
 
 		const accounting = await group(
@@ -434,5 +437,88 @@ test.describe('Reader sidebar with a single tab', () => {
 		await expect(
 			sidebar.getByText('Bold Heading Check', { exact: true }),
 		).toBeVisible();
+	});
+});
+
+/**
+ * Tabs are opt-in per space (Wiki Space.enable_tabs). A space with tab groups
+ * but the switch off must show no bar anywhere, and none of its content may
+ * become unreachable because a tab was hiding it.
+ */
+test.describe('Tab navigation disabled', () => {
+	const OFF_ROUTE = `tabs-off-e2e-${Date.now()}`;
+
+	test.beforeAll(async ({ request }) => {
+		const root = await createDoc<Doc>(request, 'Wiki Document', {
+			title: `Tabs Off Root ${Date.now()}`,
+			is_group: 1,
+			is_published: 1,
+		});
+		await createDoc(request, 'Wiki Space', {
+			space_name: 'Tabs Off E2E',
+			route: OFF_ROUTE,
+			root_group: root.name,
+			is_published: 1,
+		});
+
+		// Flagged as a tab, but the space never opts in — so it stays an ordinary
+		// top-level group everywhere.
+		const accounting = await group(
+			request,
+			'Accounting',
+			root.name,
+			0,
+			'lucide-wallet',
+		);
+		await page_(request, 'Sales Invoice', accounting.name, 0);
+		await page_(request, 'Release Notes', root.name, 1);
+	});
+
+	test.afterAll(async ({ request }) => {
+		await cleanupWikiSpacesByRoute(request, OFF_ROUTE);
+	});
+
+	test('reader shows no bar and keeps every top-level node in the sidebar', async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width: 1440, height: 900 });
+		await page.goto(`/${OFF_ROUTE}/accounting/sales-invoice`);
+		await page.waitForLoadState('networkidle');
+
+		await expect(page.getByRole('tablist')).toHaveCount(0);
+
+		const sidebar = page.locator('.wiki-sidebar');
+		await expect(
+			sidebar.getByText('Accounting', { exact: true }),
+		).toBeVisible();
+		await expect(
+			sidebar.getByText('Release Notes', { exact: true }),
+		).toBeVisible();
+	});
+
+	test('editor shows no bar, the whole tree, and the page actions row', async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width: 1440, height: 900 });
+		await page.goto(APP_BASE);
+		await page.waitForLoadState('networkidle');
+		await page.getByText('Tabs Off E2E', { exact: true }).first().click();
+		await page.waitForLoadState('networkidle');
+
+		const aside = page.locator('aside').first();
+		await expect(aside.getByText('Accounting', { exact: true })).toBeVisible({
+			timeout: 15000,
+		});
+		await expect(
+			aside.getByText('Release Notes', { exact: true }),
+		).toBeVisible();
+		await expect(page.getByRole('tablist')).toHaveCount(0);
+
+		// Page actions live in the content column, so they survive the missing bar.
+		await aside.getByText('Accounting', { exact: true }).click();
+		await aside.getByText('Sales Invoice', { exact: true }).click();
+		await expect(page.getByRole('button', { name: 'Save' })).toBeVisible({
+			timeout: 15000,
+		});
 	});
 });

--- a/frontend/src/components/ContributionBanner.vue
+++ b/frontend/src/components/ContributionBanner.vue
@@ -421,11 +421,12 @@ const BANNER_CONFIG = {
 	Draft: {
 		class: 'bg-surface-gray-1 border-b border-outline-gray-2 text-ink-gray-8',
 		icon: 'lucide-git-branch',
-		title: __('Change Request Draft'),
+		title: __('Drafting Changes'),
 		description: '',
 	},
 	'In Review': {
-		class: 'bg-surface-amber-2 border-b border-outline-amber-2 text-ink-amber-8',
+		class:
+			'bg-surface-amber-2 border-b border-outline-amber-2 text-ink-amber-8',
 		icon: 'lucide-clock',
 		title: __('In Review'),
 		description: __('Your change request is being reviewed'),
@@ -437,13 +438,15 @@ const BANNER_CONFIG = {
 		description: __('Please review the feedback and update your changes'),
 	},
 	Approved: {
-		class: 'bg-surface-green-2 border-b border-outline-green-2 text-ink-green-8',
+		class:
+			'bg-surface-green-2 border-b border-outline-green-2 text-ink-green-8',
 		icon: 'lucide-check-circle',
 		title: __('Approved'),
 		description: __('Approved and ready to merge'),
 	},
 	Merged: {
-		class: 'bg-surface-green-2 border-b border-outline-green-2 text-ink-green-8',
+		class:
+			'bg-surface-green-2 border-b border-outline-green-2 text-ink-green-8',
 		icon: 'lucide-check-circle',
 		title: __('Merged'),
 		description: __('Your changes have been merged'),

--- a/frontend/src/components/ContributionBanner.vue
+++ b/frontend/src/components/ContributionBanner.vue
@@ -43,7 +43,17 @@
 				{{ __('Reload latest') }}
 			</Button>
 
-			<template v-if="changeRequestStatus === 'Draft' || changeRequestStatus === 'Changes Requested'">
+			<!-- One stable button for the whole merge/withdraw round trip. The
+			     status branches below churn through In Review and Approved on
+			     the way, and the summary they read belongs to a change request
+			     that is being retired. -->
+			<template v-if="crStore.finalizing">
+				<Button size="sm" loading disabled>
+					{{ crStore.finalizing === 'withdrawing' ? __('Withdraw') : __('Merge') }}
+				</Button>
+			</template>
+
+			<template v-else-if="changeRequestStatus === 'Draft' || changeRequestStatus === 'Changes Requested'">
 				<Button
 					v-if="canShowMerge"
 					size="sm"
@@ -189,7 +199,7 @@ import { useChangeRequestStore } from '@/stores/changeRequest';
 import { useDraftWorkspaceStore } from '@/stores/draftWorkspace';
 import { useUserStore } from '@/stores/user';
 import { Badge, Button, Dialog, Dropdown, toast } from 'frappe-ui';
-import { computed, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 import SpaceChromeBar from './SpaceChromeBar.vue';
 
 const {
@@ -322,8 +332,24 @@ const statusBadgeTheme = computed(
 
 const emit = defineEmits(['submit', 'withdraw', 'merge', 'open-settings']);
 
-const changeRequestStatus = computed(
-	() => crStore.currentChangeRequest?.status || 'Draft',
+// Frozen while the CR is being finalized: the server walks it through In Review
+// and Approved on the way to a merge, and every one of those states is a badge,
+// a banner colour and a different action row. The user asked for one thing, so
+// they see one state until it lands.
+const changeRequestStatus = computed(() => {
+	if (crStore.finalizing) return finalizingStatus.value;
+	return crStore.currentChangeRequest?.status || 'Draft';
+});
+
+// The status as it was when finalizing began, held for the duration.
+const finalizingStatus = ref('Draft');
+watch(
+	() => crStore.finalizing,
+	(state, previous) => {
+		if (state && !previous) {
+			finalizingStatus.value = crStore.currentChangeRequest?.status || 'Draft';
+		}
+	},
 );
 
 const showChangesDialog = ref(false);

--- a/frontend/src/components/DraftContributionPanel.vue
+++ b/frontend/src/components/DraftContributionPanel.vue
@@ -1,14 +1,8 @@
 <template>
 	<div class="h-full flex flex-col">
 		<div v-if="crPage && crPage.doc_key === props.docKey" class="h-full flex flex-col">
-			<div class="flex min-h-12 shrink-0 items-center justify-between gap-3 border-b border-outline-gray-2 bg-surface-base px-3 sm:px-5">
-				<div
-					class="flex min-w-0 items-center gap-1 text-sm text-ink-gray-5 cursor-pointer hover:text-ink-gray-7 group/route"
-					@click="openRouteDialog"
-				>
-					<span class="font-mono truncate">/{{ crPage.route || '' }}</span>
-					<span class="lucide-pencil size-3 shrink-0 opacity-0 group-hover/route:opacity-100" aria-hidden="true" />
-				</div>
+			<div class="flex min-h-12 shrink-0 items-center gap-2 border-b border-outline-gray-2 bg-surface-base px-3 sm:px-5">
+				<Breadcrumbs :items="breadcrumbs" class="min-w-0 flex-1" />
 
 				<div class="flex shrink-0 items-center gap-2">
 					<Button
@@ -30,18 +24,29 @@
 				<WikiEditor v-if="editorKey" :key="editorKey" ref="editorRef" :content="editorContent" :document-key="props.docKey" :saved-content="savedContent" @save="saveContent" @save-all="flushOtherDirtyPages" @content-change="onEditorContentChange" @content-ready="onEditorContentReady">
 					<template #title>
 						<div class="pt-8">
-							<input
-								type="text"
-								v-model="editableTitle"
-								class="text-3xl-semibold text-ink-gray-9 bg-transparent border-none outline-none w-full focus:ring-0 p-0 placeholder:text-ink-gray-4"
-								:placeholder="__('Page title')"
-								@blur="saveTitleIfChanged"
-								@keydown.enter="$event.target.blur()"
-							/>
-							<div class="mt-1.5 flex items-center gap-2">
-								<Badge variant="subtle" theme="blue" size="sm">
-									{{ __('Draft') }}
-								</Badge>
+							<div class="flex items-start gap-3">
+								<input
+									type="text"
+									v-model="editableTitle"
+									class="text-3xl-semibold text-ink-gray-9 bg-transparent border-none outline-none w-full min-w-0 flex-1 focus:ring-0 p-0 placeholder:text-ink-gray-4"
+									:placeholder="__('Page title')"
+									@blur="saveTitleIfChanged"
+									@keydown.enter="$event.target.blur()"
+								/>
+								<div class="flex shrink-0 items-center gap-2 pt-2">
+									<Badge variant="subtle" theme="blue" size="sm">
+										{{ __('Draft') }}
+									</Badge>
+								</div>
+							</div>
+
+							<!-- Route under the title, where an already-merged page keeps it. -->
+							<div
+								class="mt-2 flex w-fit cursor-pointer items-center gap-1 text-sm text-ink-gray-5 hover:text-ink-gray-7 group/route"
+								@click="openRouteDialog"
+							>
+								<span class="font-mono truncate">/{{ crPage.route || '' }}</span>
+								<span class="lucide-pencil size-3 shrink-0 opacity-0 group-hover/route:opacity-100" aria-hidden="true" />
 							</div>
 						</div>
 					</template>
@@ -50,17 +55,27 @@
 
 			<div v-else class="flex-1 flex flex-col overflow-auto">
 				<div class="mx-auto w-full max-w-[770px] px-6 pt-8">
-					<input
-						type="text"
-						v-model="editableTitle"
-						class="text-3xl-semibold text-ink-gray-9 bg-transparent border-none outline-none w-full focus:ring-0 p-0 placeholder:text-ink-gray-4"
-						:placeholder="__('Group name')"
-						@blur="saveTitleIfChanged"
-						@keydown.enter="$event.target.blur()"
-					/>
-					<div class="mt-1.5 flex items-center gap-2">
-						<Badge variant="subtle" theme="blue" size="sm">{{ __('Draft') }}</Badge>
-						<Badge variant="subtle" theme="gray" size="sm">{{ __('Group') }}</Badge>
+					<div class="flex items-start gap-3">
+						<input
+							type="text"
+							v-model="editableTitle"
+							class="text-3xl-semibold text-ink-gray-9 bg-transparent border-none outline-none w-full min-w-0 flex-1 focus:ring-0 p-0 placeholder:text-ink-gray-4"
+							:placeholder="__('Group name')"
+							@blur="saveTitleIfChanged"
+							@keydown.enter="$event.target.blur()"
+						/>
+						<div class="flex shrink-0 items-center gap-2 pt-2">
+							<Badge variant="subtle" theme="blue" size="sm">{{ __('Draft') }}</Badge>
+							<Badge variant="subtle" theme="gray" size="sm">{{ __('Group') }}</Badge>
+						</div>
+					</div>
+
+					<div
+						class="mt-2 flex w-fit cursor-pointer items-center gap-1 text-sm text-ink-gray-5 hover:text-ink-gray-7 group/route"
+						@click="openRouteDialog"
+					>
+						<span class="font-mono truncate">/{{ crPage.route || '' }}</span>
+						<span class="lucide-pencil size-3 shrink-0 opacity-0 group-hover/route:opacity-100" aria-hidden="true" />
 					</div>
 				</div>
 				<div class="flex-1 flex items-center justify-center text-ink-gray-5">
@@ -126,10 +141,12 @@
 </template>
 
 <script setup>
+import { SPACE_TREE_KEY, trailToNode } from '@/lib/spaceTree';
 import { useChangeRequestStore } from '@/stores/changeRequest';
 import { useDraftWorkspaceStore } from '@/stores/draftWorkspace';
 import {
 	Badge,
+	Breadcrumbs,
 	Button,
 	Dialog,
 	Dropdown,
@@ -140,7 +157,7 @@ import {
 	toast,
 	usePageMeta,
 } from 'frappe-ui';
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, inject, onMounted, ref, watch } from 'vue';
 import { useRouter } from 'vue-router';
 import WikiEditor from './WikiEditor.vue';
 
@@ -183,6 +200,25 @@ usePageMeta(() => {
 		? getCachedDocumentResource('Wiki Space', props.spaceId)
 		: null;
 	return { title: [title, space?.doc?.space_name].filter(Boolean).join(' | ') };
+});
+
+const spaceTree = inject(SPACE_TREE_KEY, null);
+
+// Same trail an already-merged page shows. A draft page is in the tree under
+// its tmp key, so it reads its home before it is ever saved. The last crumb
+// follows the title input rather than the stored title.
+const breadcrumbs = computed(() => {
+	const children = spaceTree?.value?.children;
+	if (!children?.length) return [];
+
+	const trail = trailToNode(children, (node) => node.doc_key === props.docKey);
+	if (!trail) return [];
+
+	return trail.map((node, i) => ({
+		label:
+			(i === trail.length - 1 ? editableTitle.value : node.title) ||
+			__('Untitled'),
+	}));
 });
 
 // Read the page through the workspace store. Tmp pages live entirely on the

--- a/frontend/src/components/DraftContributionPanel.vue
+++ b/frontend/src/components/DraftContributionPanel.vue
@@ -141,7 +141,7 @@
 </template>
 
 <script setup>
-import { SPACE_TREE_KEY, trailToNode } from '@/lib/spaceTree';
+import { SPACE_TREE_KEY, crumbRoute, trailToNode } from '@/lib/spaceTree';
 import { useChangeRequestStore } from '@/stores/changeRequest';
 import { useDraftWorkspaceStore } from '@/stores/draftWorkspace';
 import {
@@ -218,6 +218,7 @@ const breadcrumbs = computed(() => {
 		label:
 			(i === trail.length - 1 ? editableTitle.value : node.title) ||
 			__('Untitled'),
+		route: crumbRoute(node, props.spaceId),
 	}));
 });
 

--- a/frontend/src/components/SpaceSettings/GeneralPanel.vue
+++ b/frontend/src/components/SpaceSettings/GeneralPanel.vue
@@ -25,6 +25,21 @@
 		</SettingsRow>
 
 		<SettingsRow
+			:title="__('Tabbed Navigation')"
+			:description="
+				__(
+					'Show a horizontal tab bar above the sidebar, with top-level groups as tabs',
+				)
+			"
+		>
+			<Switch
+				v-model="enableTabs"
+				:disabled="updatingTabsSetting"
+				@update:modelValue="updateTabsSetting"
+			/>
+		</SettingsRow>
+
+		<SettingsRow
 			:title="__('Space Logo')"
 			:description="
 				__('Shown in the reader header and on generated social preview images')
@@ -97,8 +112,10 @@ defineEmits(['open-update-routes', 'open-clone']);
 
 const isPublished = ref(true);
 const enableFeedbackCollection = ref(false);
+const enableTabs = ref(false);
 const updatingPublishSetting = ref(false);
 const updatingFeedbackSetting = ref(false);
+const updatingTabsSetting = ref(false);
 
 const logo = ref('');
 const uploadingLogo = ref(false);
@@ -111,6 +128,7 @@ watch(
 		if (doc) {
 			isPublished.value = Boolean(doc.is_published);
 			enableFeedbackCollection.value = Boolean(doc.enable_feedback_collection);
+			enableTabs.value = Boolean(doc.enable_tabs);
 			logo.value = doc.app_switcher_logo || '';
 		}
 	},
@@ -167,6 +185,18 @@ async function handleLogoChange(event) {
 		toast.error(error.messages?.[0] || __('Failed to upload logo'));
 	} finally {
 		uploadingLogo.value = false;
+	}
+}
+
+async function updateTabsSetting(value) {
+	updatingTabsSetting.value = true;
+	try {
+		await props.space.setValue.submit({ enable_tabs: value ? 1 : 0 });
+	} catch (error) {
+		console.error('Failed to update tabbed navigation setting:', error);
+		enableTabs.value = !value;
+	} finally {
+		updatingTabsSetting.value = false;
 	}
 }
 

--- a/frontend/src/components/WikiDocumentPanel.vue
+++ b/frontend/src/components/WikiDocumentPanel.vue
@@ -142,7 +142,7 @@
 
 <script setup>
 import { buildGithubEditUrl } from '@/lib/github';
-import { SPACE_TREE_KEY, trailToNode } from '@/lib/spaceTree';
+import { SPACE_TREE_KEY, crumbRoute, trailToNode } from '@/lib/spaceTree';
 import { useChangeRequestStore } from '@/stores/changeRequest';
 import { useDraftWorkspaceStore } from '@/stores/draftWorkspace';
 import { useUserStore } from '@/stores/user';
@@ -353,10 +353,9 @@ const displayRoute = computed(() => {
 
 const spaceTree = inject(SPACE_TREE_KEY, null);
 
-// Where the open page sits in the tree. Groups only expand in the sidebar, so
-// every crumb above the page is a plain label rather than a link. The last one
-// reads the title input rather than the saved title, so it keeps up with the
-// keystroke instead of waiting for the blur that saves.
+// Where the open page sits in the tree. The last crumb reads the title input
+// rather than the saved title, so it keeps up with the keystroke instead of
+// waiting for the blur that saves.
 const breadcrumbs = computed(() => {
 	const children = spaceTree?.value?.children;
 	if (!children?.length) return [];
@@ -374,6 +373,7 @@ const breadcrumbs = computed(() => {
 		label:
 			(i === trail.length - 1 ? editableTitle.value : node.title) ||
 			__('Untitled'),
+		route: crumbRoute(node, props.spaceId),
 	}));
 });
 

--- a/frontend/src/components/WikiDocumentPanel.vue
+++ b/frontend/src/components/WikiDocumentPanel.vue
@@ -355,7 +355,8 @@ const spaceTree = inject(SPACE_TREE_KEY, null);
 
 // Where the open page sits in the tree. Groups only expand in the sidebar, so
 // every crumb above the page is a plain label rather than a link. The last one
-// takes its text from the editor so a rename shows before it is saved.
+// reads the title input rather than the saved title, so it keeps up with the
+// keystroke instead of waiting for the blur that saves.
 const breadcrumbs = computed(() => {
 	const children = spaceTree?.value?.children;
 	if (!children?.length) return [];
@@ -371,7 +372,7 @@ const breadcrumbs = computed(() => {
 
 	return trail.map((node, i) => ({
 		label:
-			(i === trail.length - 1 ? displayTitle.value : node.title) ||
+			(i === trail.length - 1 ? editableTitle.value : node.title) ||
 			__('Untitled'),
 	}));
 });

--- a/frontend/src/components/WikiDocumentPanel.vue
+++ b/frontend/src/components/WikiDocumentPanel.vue
@@ -31,8 +31,11 @@
 		</DefineActions>
 
 		<div v-if="wikiDoc.doc" class="h-full flex flex-col">
-			<div class="flex min-h-12 shrink-0 items-center justify-end gap-2 border-b border-outline-gray-2 px-3 sm:px-5">
-				<ReuseActions />
+			<div class="flex min-h-12 shrink-0 items-center gap-2 border-b border-outline-gray-2 px-3 sm:px-5">
+				<Breadcrumbs :items="breadcrumbs" class="min-w-0 flex-1" />
+				<div class="flex shrink-0 items-center gap-2">
+					<ReuseActions />
+				</div>
 			</div>
 			<div class="flex-1 overflow-auto pb-10">
 				<WikiEditor v-if="editorKey" :key="editorKey" ref="editorRef" :content="editorContent" :document-key="wikiDoc.doc?.doc_key" :saved-content="savedContent" :readonly="readonly" @save="saveContent" @save-all="flushOtherDirtyPages" @content-change="onEditorContentChange" @content-ready="onEditorContentReady">
@@ -90,8 +93,9 @@
 
 		<!-- Content skeleton -->
 		<div v-else class="h-full flex flex-col">
-			<div class="flex min-h-12 shrink-0 items-center justify-end border-b border-outline-gray-2 px-3 sm:px-5">
-				<div class="flex items-center gap-2">
+			<div class="flex min-h-12 shrink-0 items-center gap-2 border-b border-outline-gray-2 px-3 sm:px-5">
+				<Skeleton class="h-4 w-40 rounded" />
+				<div class="ml-auto flex shrink-0 items-center gap-2">
 					<Skeleton class="h-8 w-24 rounded" />
 					<Skeleton class="h-8 w-16 rounded" />
 					<Skeleton class="size-8 rounded" />
@@ -138,11 +142,14 @@
 
 <script setup>
 import { buildGithubEditUrl } from '@/lib/github';
+import { SPACE_TREE_KEY, trailToNode } from '@/lib/spaceTree';
 import { useChangeRequestStore } from '@/stores/changeRequest';
 import { useDraftWorkspaceStore } from '@/stores/draftWorkspace';
 import { useUserStore } from '@/stores/user';
+import { createReusableTemplate } from '@vueuse/core';
 import {
 	Badge,
+	Breadcrumbs,
 	Button,
 	Dialog,
 	Dropdown,
@@ -153,8 +160,7 @@ import {
 	toast,
 	usePageMeta,
 } from 'frappe-ui';
-import { createReusableTemplate } from '@vueuse/core';
-import { computed, ref, shallowRef, watch } from 'vue';
+import { computed, inject, ref, shallowRef, watch } from 'vue';
 import PageSettings from './PageSettings.vue';
 import WikiEditor from './WikiEditor.vue';
 
@@ -343,6 +349,31 @@ const displayRoute = computed(() => {
 		wikiDoc.value.doc?.route ||
 		''
 	);
+});
+
+const spaceTree = inject(SPACE_TREE_KEY, null);
+
+// Where the open page sits in the tree. Groups only expand in the sidebar, so
+// every crumb above the page is a plain label rather than a link. The last one
+// takes its text from the editor so a rename shows before it is saved.
+const breadcrumbs = computed(() => {
+	const children = spaceTree?.value?.children;
+	if (!children?.length) return [];
+
+	const docKey = wikiDoc.value.doc?.doc_key;
+	const trail = trailToNode(
+		children,
+		(node) =>
+			(docKey && node.doc_key === docKey) ||
+			node.document_name === props.pageId,
+	);
+	if (!trail) return [];
+
+	return trail.map((node, i) => ({
+		label:
+			(i === trail.length - 1 ? displayTitle.value : node.title) ||
+			__('Untitled'),
+	}));
 });
 
 // Browser tab title: "{page} | {space}". Returning undefined while the doc

--- a/frontend/src/components/WikiDocumentPanel.vue
+++ b/frontend/src/components/WikiDocumentPanel.vue
@@ -1,5 +1,8 @@
 <template>
 	<div class="h-full flex flex-col">
+		<!-- Page actions row. Owned by the page rather than teleported into the
+		     space's tab row, so it sits in the same place whether or not the
+		     space uses tabs. -->
 		<DefineActions>
 			<Button
 				v-if="wikiDoc.doc?.is_published"
@@ -27,13 +30,10 @@
 			</Dropdown>
 		</DefineActions>
 
-		<!-- Page actions live in the space's tab row (SpaceDetails). `defer` lets
-		     that target mount first when tabs load async. -->
-		<Teleport defer to="#wiki-page-actions">
-			<ReuseActions />
-		</Teleport>
-
 		<div v-if="wikiDoc.doc" class="h-full flex flex-col">
+			<div class="flex min-h-12 shrink-0 items-center justify-end gap-2 border-b border-outline-gray-2 px-3 sm:px-5">
+				<ReuseActions />
+			</div>
 			<div class="flex-1 overflow-auto pb-10">
 				<WikiEditor v-if="editorKey" :key="editorKey" ref="editorRef" :content="editorContent" :document-key="wikiDoc.doc?.doc_key" :saved-content="savedContent" :readonly="readonly" @save="saveContent" @save-all="flushOtherDirtyPages" @content-change="onEditorContentChange" @content-ready="onEditorContentReady">
 					<template #title>
@@ -90,8 +90,7 @@
 
 		<!-- Content skeleton -->
 		<div v-else class="h-full flex flex-col">
-			<div class="flex min-h-12 shrink-0 items-center justify-between border-b border-outline-gray-2 px-3 sm:px-5">
-				<Skeleton class="h-4 w-40 rounded" />
+			<div class="flex min-h-12 shrink-0 items-center justify-end border-b border-outline-gray-2 px-3 sm:px-5">
 				<div class="flex items-center gap-2">
 					<Skeleton class="h-8 w-24 rounded" />
 					<Skeleton class="h-8 w-16 rounded" />

--- a/frontend/src/composables/useSpaceTabs.js
+++ b/frontend/src/composables/useSpaceTabs.js
@@ -15,20 +15,27 @@ import {
  * Tabs are derived from the tree the sidebar is already rendering rather than
  * from get_space_tabs: in the editor that's the draft/change-request tree, so a
  * tab created in an unmerged draft shows up immediately.
+ *
+ * `enabled` is the space's enable_tabs flag. Off, this collapses to no tabs and
+ * an unfiltered tree — the same shape a space with no tab groups produces.
  */
 export function useSpaceTabs(
 	treeData,
 	selectedPageId,
 	selectedDraftKey,
 	homeMeta,
+	enabled,
 ) {
+	const tabsEnabled = computed(() => enabled?.value !== false);
 	const topLevelNodes = computed(() => treeData.value?.children || []);
 	const tabs = computed(() =>
-		buildTabList(
-			topLevelNodes.value,
-			homeMeta?.value?.title || __('Home'),
-			homeMeta?.value?.icon,
-		),
+		tabsEnabled.value
+			? buildTabList(
+					topLevelNodes.value,
+					homeMeta?.value?.title || __('Home'),
+					homeMeta?.value?.icon,
+			  )
+			: [],
 	);
 
 	// The tab owning the currently open page: walk the page's ancestors up to

--- a/frontend/src/composables/useSpaceTabs.js
+++ b/frontend/src/composables/useSpaceTabs.js
@@ -73,7 +73,10 @@ export function useSpaceTabs(
 	// The active tab becomes the tree's root, so top-level drops reparent into
 	// the tab rather than the space root.
 	const visibleTreeData = computed(() => {
-		if (!treeData.value) return { children: [], root_group: '' };
+		// Null while the tree loads, never an empty tree: the panel reads null as
+		// "still loading" and draws its skeleton, where no children reads as "this
+		// space has no pages" and offers to create the first one.
+		if (!treeData.value) return null;
 		if (!tabs.value.length) return treeData.value;
 
 		const { children, rootNode } = subtreeForTab(

--- a/frontend/src/lib/spaceTree.js
+++ b/frontend/src/lib/spaceTree.js
@@ -23,3 +23,38 @@ export function trailToNode(nodes, matches, trail = []) {
 	}
 	return null;
 }
+
+/** The first readable page in a subtree, depth first. Groups hold no content. */
+export function firstPageIn(nodes) {
+	for (const node of nodes || []) {
+		if (!node.is_group && node.document_name) return node.document_name;
+		if (node.is_group) {
+			const found = firstPageIn(node.children);
+			if (found) return found;
+		}
+	}
+	return null;
+}
+
+/**
+ * Where a breadcrumb goes when clicked. A group holds no content of its own, so
+ * it opens the first page beneath it, the same page the space opens on.
+ *
+ * Every crumb wants one: without a route frappe-ui renders the crumb as a
+ * button, which looks and announces like something to press while doing
+ * nothing. Only a group with no pages in it is left inert.
+ */
+export function crumbRoute(node, spaceId) {
+	const pageId = node.is_group
+		? firstPageIn(node.children)
+		: node.document_name;
+	if (pageId) return { name: 'SpacePage', params: { spaceId, pageId } };
+	// A page created in an unmerged change request has no Wiki Document yet.
+	if (!node.is_group && node.doc_key) {
+		return {
+			name: 'DraftChangeRequest',
+			params: { spaceId, docKey: node.doc_key },
+		};
+	}
+	return undefined;
+}

--- a/frontend/src/lib/spaceTree.js
+++ b/frontend/src/lib/spaceTree.js
@@ -1,0 +1,25 @@
+/**
+ * The space's tree, shared from the space route down to whichever panel the
+ * child route mounted.
+ *
+ * A child route can't be handed the tree as a prop without also handing it to
+ * its siblings, so this is provided once by SpaceDetails. The value is the same
+ * legacy (snake_case) tree the sidebar renders — the draft tree in the editor,
+ * the published one in a git-synced space — so a page moved in an unmerged
+ * change request reads its new home immediately.
+ */
+export const SPACE_TREE_KEY = Symbol('spaceTree');
+
+/**
+ * The chain of nodes from a top-level node down to the first match, the matched
+ * node last. Null when nothing matches.
+ */
+export function trailToNode(nodes, matches, trail = []) {
+	for (const node of nodes || []) {
+		const nextTrail = [...trail, node];
+		if (matches(node)) return nextTrail;
+		const found = trailToNode(node.children, matches, nextTrail);
+		if (found) return found;
+	}
+	return null;
+}

--- a/frontend/src/pages/SpaceDetails.vue
+++ b/frontend/src/pages/SpaceDetails.vue
@@ -272,11 +272,11 @@ import {
 	createResource,
 	toast,
 } from 'frappe-ui';
-import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { computed, onBeforeUnmount, onMounted, provide, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import ContributionBanner from '../components/ContributionBanner.vue';
-import SpaceChromeBar from '../components/SpaceChromeBar.vue';
 import MobileDrawer from '../components/MobileDrawer.vue';
+import SpaceChromeBar from '../components/SpaceChromeBar.vue';
 import SpaceSettings from '../components/SpaceSettings/SpaceSettings.vue';
 import SpaceTreePanel from '../components/SpaceTreePanel.vue';
 import WikiTabBar from '../components/WikiTabBar.vue';
@@ -284,6 +284,7 @@ import { useMobile } from '../composables/useMobile';
 import { useSidebarResize } from '../composables/useSidebarResize';
 import { useSpaceTabs } from '../composables/useSpaceTabs.js';
 import { GENERAL_KEY } from '../lib/spaceTabs.js';
+import { SPACE_TREE_KEY } from '../lib/spaceTree.js';
 import { DEFAULT_TAB_ICON } from '../lib/tabIcons.js';
 import { useSocket } from '../socket';
 import { useDraftWorkspaceStore } from '../stores/draftWorkspace';
@@ -342,9 +343,7 @@ const mobileTreeOpen = ref(false);
 // Settings). The plain (non-CR, non-git) space has no banner, so it isn't
 // compacted — its identity lives only in the tree header.
 const treeHeaderCompact = computed(
-	() =>
-		!isMobile.value &&
-		(crStore.isChangeRequestMode || isGitSynced.value),
+	() => !isMobile.value && (crStore.isChangeRequestMode || isGitSynced.value),
 );
 
 // Close the tree drawer once a page is opened from it, and whenever we leave the
@@ -588,6 +587,10 @@ const treeData = computed(() => {
 	if (draftStore.spaceId !== props.spaceId) return null;
 	return draftStore.hasLoadedTree ? draftStore.treeAsLegacy : null;
 });
+
+// The open page's panel is a child route, so it can't take the tree as a prop
+// without every sibling route taking it too.
+provide(SPACE_TREE_KEY, treeData);
 
 // Tab state lives here rather than in SpaceTreePanel: the bar renders in this
 // column's header while the tree it filters renders in the sidebar, so a single

--- a/frontend/src/pages/SpaceDetails.vue
+++ b/frontend/src/pages/SpaceDetails.vue
@@ -876,17 +876,23 @@ async function handleSubmitChangeRequest() {
 
 async function handleArchiveChangeRequest() {
 	const crName = crStore.currentChangeRequest?.name;
+	crStore.finalizing = 'withdrawing';
 	try {
 		await crStore.archiveChangeRequest();
 		toast.success(__('Change request archived'));
 		crStore.currentChangeRequest = null;
+		crStore.clearChanges();
 		// Drop the local-first drafts too, or hydrate restores the discarded
 		// content from IndexedDB (and autosave re-creates the change request).
 		await draftStore.discardPersistedDraftsForCr(crName);
-		draftStore.reset();
+		// Same as merge: the published tree the next CR opens on is the one
+		// already rendered, so it stays put while hydrate refreshes it.
+		draftStore.reset({ keepTree: true });
 		await draftStore.hydrate(props.spaceId);
 	} catch (error) {
 		toast.error(error.messages?.[0] || __('Error archiving change request'));
+	} finally {
+		crStore.finalizing = null;
 	}
 }
 
@@ -912,25 +918,42 @@ async function handleMergeChangeRequest() {
 	}
 	const docKey = currentDraftKey.value;
 	const changeRequestName = crStore.currentChangeRequest?.name;
+	// Held across the rehydrate as well as the merge itself, so the banner shows
+	// one state for the whole trip instead of the CR's intermediate ones.
+	crStore.finalizing = 'merging';
 	try {
 		await crStore.approveAndMergeChangeRequest();
 		toast.success(__('Change request merged'));
 		crStore.currentChangeRequest = null;
+		crStore.clearChanges();
 		// The CR's drafts are now merged into the published doc — clear them so a
 		// stale local copy can't resurrect after the merge.
 		await draftStore.discardPersistedDraftsForCr(changeRequestName);
-		draftStore.reset();
-		await draftStore.hydrate(props.spaceId);
+		// Keep the tree on screen: the merged tree is all but identical to the one
+		// already rendered, so blanking it to a skeleton for a round trip is pure
+		// loss. hydrate() swaps in the new one in a single paint.
+		draftStore.reset({ keepTree: true });
 
-		if (docKey) {
+		// Leave the draft route before the rehydrate, not after: the draft the
+		// URL points at no longer exists, so waiting would park the editor on
+		// "Draft not found" for the length of the round trip. The tree is still
+		// on screen (keepTree), so the published page is resolvable now — except
+		// for a page created in this CR, which only gets a document_name once
+		// the merge lands, so that one is resolved again afterwards.
+		const openMergedPage = () => {
+			if (!docKey) return true;
 			const node = findNodeByDocKey(treeData.value?.children, docKey);
-			if (node?.document_name) {
-				router.push({
-					name: 'SpacePage',
-					params: { spaceId: props.spaceId, pageId: node.document_name },
-				});
-			}
-		}
+			if (!node?.document_name) return false;
+			router.push({
+				name: 'SpacePage',
+				params: { spaceId: props.spaceId, pageId: node.document_name },
+			});
+			return true;
+		};
+
+		const opened = openMergedPage();
+		await draftStore.hydrate(props.spaceId);
+		if (!opened) openMergedPage();
 	} catch (error) {
 		// A merge conflict leaves the CR Approved; the conflict-resolution UI
 		// lives on the review page, so send the author there to resolve it.
@@ -945,6 +968,8 @@ async function handleMergeChangeRequest() {
 			return;
 		}
 		toast.error(error.messages?.[0] || __('Error merging change request'));
+	} finally {
+		crStore.finalizing = null;
 	}
 }
 </script>

--- a/frontend/src/pages/SpaceDetails.vue
+++ b/frontend/src/pages/SpaceDetails.vue
@@ -284,7 +284,7 @@ import { useMobile } from '../composables/useMobile';
 import { useSidebarResize } from '../composables/useSidebarResize';
 import { useSpaceTabs } from '../composables/useSpaceTabs.js';
 import { GENERAL_KEY } from '../lib/spaceTabs.js';
-import { SPACE_TREE_KEY } from '../lib/spaceTree.js';
+import { SPACE_TREE_KEY, firstPageIn } from '../lib/spaceTree.js';
 import { DEFAULT_TAB_ICON } from '../lib/tabIcons.js';
 import { useSocket } from '../socket';
 import { useDraftWorkspaceStore } from '../stores/draftWorkspace';
@@ -727,18 +727,6 @@ function findNodeByDocumentName(nodes, name) {
 	return null;
 }
 
-function getFirstPage(nodes) {
-	if (!nodes) return null;
-	for (const node of nodes) {
-		if (!node.is_group && node.document_name) return node.document_name;
-		if (node.is_group) {
-			const found = getFirstPage(node.children);
-			if (found) return found;
-		}
-	}
-	return null;
-}
-
 // On the bare space route (welcome screen) open a page automatically: the
 // remembered page if it still exists, otherwise the tree's first page. Replace
 // rather than push so the back button returns to the spaces list, not here.
@@ -755,7 +743,7 @@ function autoOpenPage() {
 	const target =
 		(remembered && findNodeByDocumentName(tree.children, remembered)
 			? remembered
-			: null) || getFirstPage(tree.children);
+			: null) || firstPageIn(tree.children);
 
 	if (target) {
 		autoOpening = true;

--- a/frontend/src/pages/SpaceDetails.vue
+++ b/frontend/src/pages/SpaceDetails.vue
@@ -68,7 +68,7 @@
         />
 
         <div
-            v-if="tabs.length"
+            v-if="tabsEnabled && tabs.length"
             class="h-12 shrink-0 flex items-stretch border-b border-outline-gray-2 px-2"
         >
             <WikiTabBar
@@ -81,8 +81,6 @@
                 @update-icon="updateTabIcon"
                 @rename-tab="renameTab"
             />
-            <!-- Teleport target for the open page's actions (inline layout). -->
-            <div id="wiki-page-actions" class="flex shrink-0 items-center gap-2 self-center pl-3" />
         </div>
 
         <!-- Sidebar + content share the row beneath the chrome. -->
@@ -91,7 +89,7 @@
             <aside
                 v-if="!isMobile"
                 ref="sidebarRef"
-                class="border-r border-outline-gray-2 flex flex-col bg-surface-gray-1 relative flex-shrink-0"
+                class="border-r border-outline-gray-2 flex flex-col relative flex-shrink-0"
                 :style="{ width: `${sidebarWidth}px` }"
             >
                 <SpaceTreePanel
@@ -379,6 +377,10 @@ const space = createDocumentResource({
 // live tree instead of a CR.
 const isGitSynced = computed(() => Boolean(space.doc?.git_synced));
 
+// Tabs are opt-in per space (Wiki Space.enable_tabs). Off, the bar is gone and
+// the sidebar shows the whole tree — tab flags on nodes are kept, just ignored.
+const tabsEnabled = computed(() => Boolean(space.doc?.enable_tabs));
+
 // "Pending"/"Running" are transient internal states; show one friendly label.
 function syncStatusLabel(status) {
 	return (
@@ -392,11 +394,11 @@ function syncStatusLabel(status) {
 
 // Tab management is editor-only (mirrors the backend's can_manage_tabs, which
 // is can_write_space). Enforcement stays server-side; this only hides the UI.
-const canManageTabs = ref(false);
+const canWriteSpace = ref(false);
 const capabilitiesResource = createResource({
 	url: 'wiki.api.get_space_capabilities',
 	onSuccess: (data) => {
-		canManageTabs.value = Boolean(data?.can_write);
+		canWriteSpace.value = Boolean(data?.can_write);
 	},
 });
 
@@ -407,6 +409,9 @@ watch(
 	},
 	{ immediate: true },
 );
+
+// Managing tabs needs both the permission and a space that uses tabs at all.
+const canManageTabs = computed(() => canWriteSpace.value && tabsEnabled.value);
 
 const readonlyTreeResource = createResource({
 	url: 'wiki.api.wiki_space.get_wiki_tree',
@@ -597,6 +602,7 @@ const { tabs, activeTabKey, selectTab, visibleTreeData } = useSpaceTabs(
 	currentPageId,
 	currentDraftKey,
 	homeMeta,
+	tabsEnabled,
 );
 
 // Creating and reordering tabs is owned here alongside the bar, rather than in

--- a/frontend/src/stores/changeRequest.js
+++ b/frontend/src/stores/changeRequest.js
@@ -6,6 +6,13 @@ import { computed, ref } from 'vue';
 export const useChangeRequestStore = defineStore('changeRequest', () => {
 	const currentChangeRequest = ref(null);
 	const isLoadingChangeRequest = ref(false);
+	// 'merging' | 'withdrawing' | null, for the whole round trip including the
+	// rehydrate that follows it. The CR walks Draft -> In Review -> Approved ->
+	// merged on the way, and the banner would otherwise render each of those in
+	// turn — a flash of "Approved! Ready to merge." on the way to a merge the
+	// user already asked for. Owned by whoever runs the flow (SpaceDetails),
+	// because it has to outlive the call itself.
+	const finalizing = ref(null);
 	let initChangeRequestPromise = null;
 	let loadChangesPromise = null;
 
@@ -183,6 +190,13 @@ export const useChangeRequestStore = defineStore('changeRequest', () => {
 		return currentChangeRequest.value;
 	}
 
+	// The summary belongs to a change request that no longer exists once it is
+	// merged; leaving it around lets the old count drive the banner until the
+	// next CR's summary lands.
+	function clearChanges() {
+		changesResource.data = [];
+	}
+
 	const changes = computed(() => changesResource.data || []);
 	const changeCount = computed(() => changes.value.length);
 	const isSubmitting = computed(() => submitReviewResource.loading);
@@ -291,6 +305,7 @@ export const useChangeRequestStore = defineStore('changeRequest', () => {
 	return {
 		currentChangeRequest,
 		isLoadingChangeRequest,
+		finalizing,
 		isChangeRequestMode,
 		hasActiveChangeRequest,
 		changes,
@@ -307,6 +322,7 @@ export const useChangeRequestStore = defineStore('changeRequest', () => {
 		initChangeRequest,
 		ensureChangeRequest,
 		loadChanges,
+		clearChanges,
 		submitForReview,
 		archiveChangeRequest,
 		mergeChangeRequest,

--- a/frontend/src/stores/draftWorkspace.js
+++ b/frontend/src/stores/draftWorkspace.js
@@ -191,10 +191,17 @@ export const useDraftWorkspaceStore = defineStore('draftWorkspace', () => {
 		}
 	}
 
-	function reset() {
-		spaceId.value = null;
-		hasLoadedTree.value = false;
-		treeModel.reset();
+	// `keepTree` drops the draft session (buffers, queue, change badges) but
+	// leaves the rendered tree standing, so the next hydrate swaps it in one
+	// paint. Without it the sidebar blanks to a skeleton for the length of a
+	// round trip — which is what merging into the same space used to look like,
+	// even though the tree it came back with was all but identical.
+	function reset({ keepTree = false } = {}) {
+		if (!keepTree) {
+			spaceId.value = null;
+			hasLoadedTree.value = false;
+			treeModel.reset();
+		}
 		pageBuffers.reset();
 		resolver.reset();
 		queue.reset();

--- a/specs/per_space_tab_toggle.md
+++ b/specs/per_space_tab_toggle.md
@@ -1,0 +1,126 @@
+# Per-Space Tab Navigation Toggle
+
+Date: 2026-07-30
+Status: **In progress.** See [Progress log](#progress-log) at the bottom.
+
+## Problem
+
+Horizontal tab navigation (see `horizontal_tab_navigation.md`) is currently
+unconditional. Every space shows the tab row, because the editor's bar always
+renders a synthetic **Home** entry even when the space has no tabs at all. A
+small space with twelve pages pays for chrome it will never use, and the tab
+model is presented as something every editor must reason about.
+
+Tabs are a solution for large multi-module docs sites (ERPNext-scale). They
+should be opt-in.
+
+The toggle also strands the page actions. **View Page / Save / ⋮** live inside
+the tab row today, teleported from `WikiDocumentPanel` into `#wiki-page-actions`
+(`SpaceDetails.vue:85`). Turn the row off and the actions have no home.
+
+## Goal
+
+A per-space **Tabbed Navigation** switch in Space Settings, off by default. Off:
+no tab row anywhere (editor, reader, mobile), the sidebar shows the whole tree,
+and no tab-management actions are offered. On: today's behaviour.
+
+Independently of the toggle, page actions move out of the tab row into a header
+row of their own, so their position no longer depends on tab state.
+
+## Decisions (locked)
+
+| # | Decision | Choice |
+|---|----------|--------|
+| 1 | Where the flag lives | New `enable_tabs` (Check) on **Wiki Space**, in the Version 3 tab beside `home_tab_title` / `home_tab_icon`. |
+| 2 | Default + migration | **Off for every space, no patch.** Spaces that already have `is_tab` groups lose their bar until an editor turns it on. Chosen deliberately over an auto-on patch: the feature is new enough that no production space depends on it, and a clean default keeps the flag's meaning unambiguous. |
+| 3 | Page actions | **Own header row in the content column, always** — tabs on or off. The `Teleport` to `#wiki-page-actions` goes away, and with it the tab row's action slot. One layout, one code path. |
+| 4 | Data when toggled off | `is_tab` / `tab_icon` on nodes are **left untouched.** The flag is presentational: turning it back on restores the same tabs. No validation throw on writing `is_tab` while tabs are off — git-sync's carry-forward and CR merges must keep working regardless. |
+| 5 | Enforcement surface | `get_space_tabs` returns `[]` for a tabs-off space. That single gate covers the entire reader (desktop bar, mobile header, chrome height, sidebar subtree gating) because every reader surface already handles the empty case. The editor gates on `space.doc.enable_tabs` directly, since its bar is derived from the draft tree, not from `get_space_tabs`. |
+| 6 | Tab management actions | "New Tab", "Convert to tab" and inline icon/rename hide when tabs are off — `can_manage_tabs` in the frontend becomes `canManageTabs && tabsEnabled`. The server-side `can_manage_tabs` permission is unchanged (per decision #4 it stays a permission question, not a feature-flag question). |
+
+## Current state (what the toggle has to switch off)
+
+**Editor** — `SpaceDetails.vue:70-86` renders the row `v-if="tabs.length"`, which
+is always true: `buildTabList` (`lib/spaceTabs.js:32`) unconditionally `unshift`s
+the Home entry. `useSpaceTabs` also swaps the sidebar's root to the active tab's
+subtree (`composables/useSpaceTabs.js:68-78`) — with tabs off that must fall back
+to the full tree.
+
+**Reader** — `get_space_tabs` (`wiki_document.py:934`) feeds `space_tabs` into
+the render context (`:535`). Consumers: `layout.html:67` (`data-wiki-tabs` body
+attribute → `--wiki-chrome-h` 97px vs 53px in `main.css:65-78`), `header.html:7`
+(navbar keeps its bottom border when there are no tabs), `tabs.html:21`,
+`mobile_header.html:194`, and `sidebar.html:30` (untabbed subtree is gated behind
+Home's presence). **All five already branch on an empty `space_tabs`**, so the
+reader needs no template change — only the gate inside `get_space_tabs`.
+
+**Page actions** — `WikiDocumentPanel.vue:3-34` defines them via
+`createReusableTemplate` and `Teleport defer`s them into the tab row. The
+`defer` exists only because the target mounts asynchronously with the tabs.
+
+## Tracer bullet plan
+
+Branch: `feat/per-space-tab-toggle`. Spec committed first, then one commit per
+phase.
+
+### Phase 0 — Flag + reader gate (backend)
+
+- `enable_tabs` (Check, default 0) on **Wiki Space**; `home_tab_title` /
+  `home_tab_icon` become `depends_on: eval:doc.enable_tabs` so the desk form
+  doesn't offer Home customisation for a space without tabs.
+- `get_space_tabs` returns `[]` unless the space has `enable_tabs`. Read it in
+  the existing `frappe.db.get_value` that already fetches `root_group` and the
+  home meta — no extra query.
+
+**Tracer:** flip the checkbox in desk on a tabbed space; the public reader loses
+its tab row, the navbar regains its border, and the sidebar shows the previously
+tab-gated content.
+
+### Phase 1 — Settings toggle + editor gate (frontend)
+
+- `GeneralPanel.vue`: a **Tabbed Navigation** `SettingsRow` + `Switch`, following
+  the existing publish/feedback pattern (optimistic local ref, revert on error).
+  Per CLAUDE.md "Frontend / Backend Sync", the field is enumerated explicitly.
+- `useSpaceTabs` takes an `enabled` getter: when false, `tabs` is `[]` and
+  `visibleTreeData` passes the tree through untouched.
+- `SpaceDetails.vue`: the row renders `v-if="tabsEnabled && tabs.length"`, and
+  `can-manage-tabs` passed to `SpaceTreePanel` is `canManageTabs && tabsEnabled`.
+
+**Tracer:** toggle in Space Settings; the editor's bar appears/disappears without
+a reload, and the sidebar shows every top-level node when off.
+
+### Phase 2 — Page actions get their own row (frontend)
+
+- Delete the `Teleport` + `#wiki-page-actions` target. `WikiDocumentPanel`
+  renders the actions in a slim sticky header row at the top of the content
+  column, right-aligned, above the scrolling editor.
+- The existing loading skeleton already draws exactly this row
+  (`WikiDocumentPanel.vue:93-100`), which is what the loaded state should have
+  looked like all along.
+
+**Tracer:** open a page in a tabs-off space and in a tabs-on space; the actions
+sit in the same place in both, and ⌘S still saves.
+
+### Phase 3 — Tests
+
+- **Backend unit:** `get_space_tabs` returns `[]` for a tabs-off space that has
+  tab groups, and the full list once enabled. Temp-revert the gate to confirm the
+  test fails without it (per CLAUDE.md).
+- **E2E:** extend `e2e/tests/tab-navigation.spec.ts` — the suite's fixture space
+  must now enable tabs explicitly (every existing test depends on the bar), plus
+  a new test asserting a tabs-off space shows no bar in the editor and no bar in
+  the reader while its content stays reachable in the sidebar.
+
+## Out of scope
+
+- Migrating existing spaces (decision #2 — none, by choice).
+- A global (Wiki Settings) default for the flag.
+- Changing who may manage tabs (`can_manage_tabs` is unchanged).
+- Reader-side chrome redesign; the 53/97px chrome variable already handles both
+  states.
+
+---
+
+## Progress log
+
+_(appended per phase)_

--- a/specs/per_space_tab_toggle.md
+++ b/specs/per_space_tab_toggle.md
@@ -123,4 +123,57 @@ sit in the same place in both, and ⌘S still saves.
 
 ## Progress log
 
-_(appended per phase)_
+### Phase 0 — Flag + reader gate ✅
+
+`enable_tabs` (Check, default 0) on Wiki Space, with `home_tab_title` /
+`home_tab_icon` now `depends_on` it. `get_space_tabs` reads the flag in the
+`get_value` it already ran and returns `[]` when it's off.
+
+**Beyond spec:** `llms.txt` also sections by tabs (`_space_llms_txt`), so a
+tabs-off space would have advertised a "Home" section the reader has no concept
+of. It now renders one section titled after the space. Space cloning needed no
+change — `_create_space_copy` copies every non-table field generically.
+
+Tracer verified on `wiki.localhost`: every space with tab groups returns `[]`
+off and its full tab list on.
+
+### Phases 1 + 2 — Settings toggle, editor gate, page actions ✅
+
+Committed together rather than one per phase: gating the bar without moving the
+actions first would have left a commit where a tabs-off space has no way to
+save.
+
+- `GeneralPanel.vue` gains a **Tabbed Navigation** row (optimistic switch,
+  reverts on error — the publish/feedback pattern).
+- `useSpaceTabs` takes an `enabled` getter; off, `tabs` is `[]` and
+  `visibleTreeData` already passes the tree through unchanged for that case.
+- `canManageTabs` is now `canWriteSpace && tabsEnabled`, so "New Tab" /
+  "Convert to tab" / inline rename disappear with the bar.
+- Page actions moved into a header row inside the content column;
+  `#wiki-page-actions` and the `Teleport` are gone. The loading skeleton already
+  drew this row, and now matches what loads.
+
+### Bug found in Phase 2 verification
+
+The reader's sidebar and mobile header split their tree on **node** `is_tab`,
+independently of `space_tabs`. With tabs off, a tab's subtree therefore stayed
+hidden behind an `x-show` for a tab no bar could select — the sidebar showed
+only the open page. Both templates now branch on `space_tabs`, which is empty
+exactly when the space has tabs off. Caught by the new e2e test, not by review.
+
+### Phase 3 — Tests ✅
+
+- **Backend:** `test_returns_empty_when_the_space_has_tabs_switched_off` and
+  `test_space_llms_txt_drops_tab_sections_when_tabs_are_off`. Both verified to
+  fail with their gate temp-reverted. `create_test_wiki_space` gained an
+  `enable_tabs` kwarg; the two fixtures whose tests assert tab behaviour opt in.
+- **E2E:** `tab-navigation.spec.ts` at 12 tests — both existing fixtures now set
+  `enable_tabs: 1`, plus a "Tab navigation disabled" describe covering reader
+  (no bar, every top-level node in the sidebar) and editor (no bar, whole tree,
+  Save still reachable). Full file green.
+- **Regression:** `public-pages`, `sidebar` green. `mobile-view` fails 13 tests
+  locally — **verified identical on a clean `upstream/develop` checkout with a
+  rebuilt frontend**, so it is the known local test-data flakiness, not this
+  change.
+- Manually verified in the app: toggling the switch adds/removes the bar live,
+  and the actions row holds its position in both states.

--- a/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
@@ -71,6 +71,7 @@ def create_test_wiki_space(test_case, space_name, route, root_group, **kwargs):
 		"is_published": kwargs.get("is_published", True),
 		"switcher_order": kwargs.get("switcher_order", 0),
 		"git_synced": kwargs.get("git_synced", False),
+		"enable_tabs": kwargs.get("enable_tabs", False),
 		"repo_full_name": kwargs.get("repo_full_name"),
 		"branch": kwargs.get("branch"),
 	}
@@ -1961,7 +1962,7 @@ class TestSpaceLlmsTxt(WikiDocumentTestBase):
 		self.assertTrue(entry.startswith(prefix), f"{entry!r} does not start with {prefix!r}")
 		self.assertTrue(entry.endswith(suffix), f"{entry!r} does not end with {suffix!r}")
 
-	def _space_with_tree(self, guest_readable=True):
+	def _space_with_tree(self, guest_readable=True, enable_tabs=True):
 		"""A space with untabbed content, a tab, a nested group and a draft page."""
 		root_group = create_test_wiki_document(self, "Root Llms", is_group=True)
 		# The space comes first: `is_tab` validates against the space's root group.
@@ -1971,6 +1972,7 @@ class TestSpaceLlmsTxt(WikiDocumentTestBase):
 			self._unique("llms-space"),
 			root_group.name,
 			roles=[("Guest", "Read")] if guest_readable else [],
+			enable_tabs=enable_tabs,
 		)
 
 		intro = create_test_wiki_document(
@@ -2032,6 +2034,19 @@ class TestSpaceLlmsTxt(WikiDocumentTestBase):
 		# A group has no page of its own, so it is a label; its children indent under it.
 		self.assertIn("- **Internals**", lines)
 		self.assertEntry(lines, tree.nested.route, "  - [Nested Page](", ")")
+
+	def test_space_llms_txt_drops_tab_sections_when_tabs_are_off(self):
+		"""The index mirrors the reader, which ignores is_tab for such a space."""
+		tree = self._space_with_tree(enable_tabs=False)
+
+		body = _make_request(self.TEST_CLIENT, "get", f"/{tree.space.route}/llms.txt").get_data(as_text=True)
+		lines = body.splitlines()
+
+		self.assertNotIn("## Home", lines)
+		self.assertIn("## Llms Space", lines)
+		# Every page is still listed, just under the one section.
+		self.assertEntry(lines, tree.intro.route, "- [Introduction](", "): What this is.")
+		self.assertEntry(lines, tree.endpoints.route, "  - [Endpoints](", ")")
 
 	def test_space_llms_txt_omits_unpublished_pages(self):
 		tree = self._space_with_tree()
@@ -2592,7 +2607,11 @@ class TestGetSpaceTabs(WikiDocumentTestBase):
 	def _space(self):
 		root_group = create_test_wiki_document(self, "Tabs Root", is_group=True)
 		space = create_test_wiki_space(
-			self, "Tabs Space", f"tabs-space-{frappe.generate_hash(length=6)}", root_group.name
+			self,
+			"Tabs Space",
+			f"tabs-space-{frappe.generate_hash(length=6)}",
+			root_group.name,
+			enable_tabs=True,
 		)
 		return space, root_group
 
@@ -2604,6 +2623,22 @@ class TestGetSpaceTabs(WikiDocumentTestBase):
 		tab.tab_icon = icon
 		tab.save()
 		return tab
+
+	def test_returns_empty_when_the_space_has_tabs_switched_off(self):
+		"""Tabs are opt-in: the flags stay on the nodes, the bar just goes away."""
+		space, root_group = self._space()
+		tab = self._make_tab(root_group, "Accounting", icon="lucide-wallet")
+		create_test_wiki_document(self, "Invoice", parent=tab.name)
+
+		self.assertEqual([t["title"] for t in get_space_tabs(space.name)], ["Accounting"])
+
+		frappe.db.set_value("Wiki Space", space.name, "enable_tabs", 0)
+		self.assertEqual(get_space_tabs(space.name), [])
+
+		# The node keeps its flags, so switching back restores the same bar.
+		self.assertEqual(frappe.db.get_value("Wiki Document", tab.name, "is_tab"), 1)
+		frappe.db.set_value("Wiki Space", space.name, "enable_tabs", 1)
+		self.assertEqual([t["title"] for t in get_space_tabs(space.name)], ["Accounting"])
 
 	def test_returns_empty_for_a_space_without_tabs(self):
 		space, root_group = self._space()

--- a/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
@@ -945,11 +945,18 @@ def get_space_tabs(space: str) -> list[dict]:
 	space_doc = frappe.db.get_value(
 		"Wiki Space",
 		space,
-		["root_group", "home_tab_title", "home_tab_icon"],
+		["root_group", "enable_tabs", "home_tab_title", "home_tab_icon"],
 		as_dict=True,
 	)
 	root_group = space_doc and space_doc.root_group
 	if not root_group:
+		return []
+
+	# Tabs are opt-in per space. Node-level is_tab flags are left alone when the
+	# space turns them off, so flipping the switch back restores the same bar;
+	# every reader surface (bar, mobile header, chrome height, sidebar gating)
+	# already branches on an empty list, so this one gate covers all of them.
+	if not space_doc.enable_tabs:
 		return []
 
 	tabs = frappe.get_all(

--- a/wiki/templates/wiki/includes/mobile_header.html
+++ b/wiki/templates/wiki/includes/mobile_header.html
@@ -184,9 +184,12 @@
             mobile a frappe-ui-style combobox switches tabs. Selecting one
             navigates to its landing route; the tree below then gates to that
             tab's subtree, exactly like the desktop sidebar. -#}
+        {#- Split on the space's tabs flag, not on the node flags: a space with
+            tabs off keeps its is_tab nodes but must render one plain tree. -#}
         {% set current_route = doc.route if doc else '' %}
-        {% set tab_nodes = (nested_tree or []) | selectattr('is_tab') | list %}
-        {% set other_nodes = (nested_tree or []) | rejectattr('is_tab') | list %}
+        {% set tabs_on = space_tabs and space_tabs | length %}
+        {% set tab_nodes = (nested_tree or []) | selectattr('is_tab') | list if tabs_on else [] %}
+        {% set other_nodes = ((nested_tree or []) | rejectattr('is_tab') | list) if tabs_on else (nested_tree or []) %}
         {% set show_home = (tab_nodes | length) >= 1 and (other_nodes | length) > 0 %}
         {% set tab_routes = tab_nodes | map(attribute='route') | join('|') %}
         {% set active = namespace(in_tab=false) %}

--- a/wiki/templates/wiki/includes/sidebar.html
+++ b/wiki/templates/wiki/includes/sidebar.html
@@ -22,9 +22,13 @@
 
         The tab bar itself lives in includes/tabs.html, a full-width row above
         this sidebar. -#}
+    {#- `space_tabs` is empty for a space with tabs switched off, and the node
+        flags are left in place when that happens — so the flag, not is_tab, is
+        what decides whether this tree is split into tab subtrees at all. -#}
     {% set current_route = doc.route if doc else '' %}
-    {% set tab_nodes = (nested_tree or []) | selectattr('is_tab') | list %}
-    {% set other_nodes = (nested_tree or []) | rejectattr('is_tab') | list %}
+    {% set tabs_on = space_tabs and space_tabs | length %}
+    {% set tab_nodes = (nested_tree or []) | selectattr('is_tab') | list if tabs_on else [] %}
+    {% set other_nodes = ((nested_tree or []) | rejectattr('is_tab') | list) if tabs_on else (nested_tree or []) %}
 
     {#- Home leads the reader bar whenever there's at least one tab and untabbed
         content to land on (see get_space_tabs). When it does, the untabbed subtree

--- a/wiki/wiki/doctype/wiki_space/wiki_space.json
+++ b/wiki/wiki/doctype/wiki_space/wiki_space.json
@@ -33,6 +33,7 @@
   "allow_contributions",
   "version_3_tab",
   "root_group",
+  "enable_tabs",
   "home_tab_title",
   "home_tab_icon",
   "main_revision",
@@ -129,9 +130,9 @@
    "label": "Access Control"
   },
   {
+   "description": "Leave empty for open access to all logged-in users. Add the <b>Guest</b> role for public/anonymous access.",
    "fieldname": "access_control_section",
-   "fieldtype": "Section Break",
-   "description": "Leave empty for open access to all logged-in users. Add the <b>Guest</b> role for public/anonymous access."
+   "fieldtype": "Section Break"
   },
   {
    "fieldname": "roles",
@@ -172,7 +173,15 @@
    "read_only": 1
   },
   {
+   "default": "0",
+   "description": "Show a horizontal tab bar above the sidebar. Top-level groups flagged as tabs appear in it.",
+   "fieldname": "enable_tabs",
+   "fieldtype": "Check",
+   "label": "Enable Tabbed Navigation"
+  },
+  {
    "default": "Home",
+   "depends_on": "eval:doc.enable_tabs",
    "description": "Label for the synthetic Home tab that leads the space's tab bar.",
    "fieldname": "home_tab_title",
    "fieldtype": "Data",
@@ -180,6 +189,7 @@
   },
   {
    "default": "lucide-house",
+   "depends_on": "eval:doc.enable_tabs",
    "description": "Lucide icon class for the Home tab, e.g. lucide-house.",
    "fieldname": "home_tab_icon",
    "fieldtype": "Data",
@@ -283,12 +293,12 @@
    "read_only": 1
   },
   {
+   "description": "The most recently loaded .wiki.json from the repo (empty when the structure is inferred).",
    "fieldname": "wiki_config",
    "fieldtype": "Code",
    "label": "Wiki Config (.wiki.json)",
    "options": "JSON",
-   "read_only": 1,
-   "description": "The most recently loaded .wiki.json from the repo (empty when the structure is inferred)."
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,

--- a/wiki/wiki/llms_txt.py
+++ b/wiki/wiki/llms_txt.py
@@ -97,7 +97,7 @@ def _space_llms_txt(space: str) -> str | None:
 	space_doc = frappe.db.get_value(
 		"Wiki Space",
 		space,
-		["name", "space_name", "route", "root_group", "home_tab_title"],
+		["name", "space_name", "route", "root_group", "enable_tabs", "home_tab_title"],
 		as_dict=True,
 	)
 	# A root group that was deleted leaves nothing to walk, and walking it raises.
@@ -113,14 +113,20 @@ def _space_llms_txt(space: str) -> str | None:
 	pages = _published_pages(space_doc.name)
 
 	# Top-level tab groups become sections; anything untabbed goes under the
-	# space's Home tab, matching _home_tab_entry in the reader.
-	sections = []
-	untabbed = [node for node in tree if not node.get("is_tab")]
-	if untabbed:
-		sections.append((_one_line(space_doc.home_tab_title) or _("Home"), untabbed))
-	sections += [
-		(_one_line(node["title"]), node.get("children") or []) for node in tree if node.get("is_tab")
-	]
+	# space's Home tab, matching _home_tab_entry in the reader. A space with tabs
+	# switched off has no Home tab to name, so the whole tree is one section
+	# titled after the space — is_tab flags are still on the nodes, but the
+	# reader ignores them, and this index mirrors the reader.
+	if space_doc.enable_tabs:
+		sections = []
+		untabbed = [node for node in tree if not node.get("is_tab")]
+		if untabbed:
+			sections.append((_one_line(space_doc.home_tab_title) or _("Home"), untabbed))
+		sections += [
+			(_one_line(node["title"]), node.get("children") or []) for node in tree if node.get("is_tab")
+		]
+	else:
+		sections = [(_one_line(space_doc.space_name) or space_doc.name, tree)]
 
 	body = []
 	for title, nodes in sections:


### PR DESCRIPTION
## Why?

Tabs are unconditional today — every space shows the bar, because the editor always renders a synthetic **Home** entry even when the space has no tabs. Tabs solve a problem large docs sites have (ERPNext-scale, many top-level modules). A twelve-page space pays for chrome it will never use.

## What?

A **Tabbed Navigation** switch in Space Settings, **off by default** for every space (no migration patch — existing tabbed spaces need one click to turn it back on).

Off: no tab bar in the editor, reader or mobile header; the sidebar shows the whole tree; no tab-management actions. Node `is_tab` / `tab_icon` flags are left untouched, so flipping it back restores the same bar.

Separately, **View Page / Save / ⋮ moved out of the tab row** into a header row owned by the page. They used to be teleported into the tab row, so switching tabs off left them homeless. Now their position is the same either way.

<!-- screenshots: tabs off vs tabs on -->

## How?

- New `Wiki Space.enable_tabs`. `get_space_tabs` returns `[]` when it's off — one gate that covers every reader surface (bar, mobile picker, chrome height, navbar border), since they all already branch on an empty list.
- The editor derives its bar from the draft tree, not `get_space_tabs`, so it gates on `space.doc.enable_tabs` directly via `useSpaceTabs`.
- `llms.txt` sections by tabs too; with tabs off it now renders one section named after the space instead of a "Home" section the reader has no concept of.
- **Bug fixed along the way:** the reader's sidebar and mobile header split their tree on node `is_tab` rather than on `space_tabs`. A tabs-off space therefore hid every tab's subtree behind an `x-show` for a tab no bar could select — the sidebar showed only the open page. Both now branch on `space_tabs`.

## Tests

- 2 backend tests (`get_space_tabs` gate, `llms.txt` sectioning), each verified to fail with its gate temp-reverted.
- `e2e/tests/tab-navigation.spec.ts` at 12 tests: both existing fixtures opt into tabs, plus a new tabs-disabled block covering reader and editor.
- `public-pages` / `sidebar` green. `mobile-view` fails locally on this branch **and identically on a clean `develop` checkout**, so it is pre-existing local flakiness.

## Draft because

Screenshots still to attach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also in here: merge no longer resets the editor

Two reported UX bugs in the merge flow, unrelated to tabs but sharing the same files.

**The sidebar blanked on every merge.** The handler dropped the whole draft session, tree included, then re-fetched a tree that was all but identical — a full skeleton flash for the length of a round trip. `reset()` now takes `keepTree`, so the tree stays on screen and the refreshed one swaps in on a single paint. Withdraw takes the same path. The route change to the merged page also moved ahead of the rehydrate, so the editor no longer parks on "Draft not found" while it runs.

**The merge buttons flashed an intermediate state.** Merging walks the change request Draft → In Review → Approved before it merges, and the banner rendered each one — including "Approved! Ready to merge." on the way to a merge the user had already asked for. Afterwards the retired CR's summary was still in the store, so "Submit for Review" reappeared until the next one landed. A `finalizing` flag holds one stable button for the whole round trip; the dead summary is cleared as soon as the CR is gone.

Verified with a 30ms DOM poller across a real merge, on the same space, both builds:

| build | min tree items during merge | saw "Ready to merge" |
|---|---|---|
| fix reverted | 0 | yes |
| fixed | 9 | no |

An e2e test recording both symptoms is in `change-request-flow.spec.ts`. It does not pass locally — it fails in the shared fixture before reaching its assertions, the same pre-existing local failure that affects `mobile-view` and this file's sibling tests on a clean `develop`.
