### PR TITLE
fix: untrack broken wiki/public/node_modules symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ wiki/docs/current
 wiki/public/dist
 dist/
 css-rtl/
+node_modules
 node_modules/*
 .cypress-coverage
 cypress/screenshots

--- a/wiki/public/node_modules
+++ b/wiki/public/node_modules
@@ -1,1 +1,0 @@
-/Users/mdhussain/Frappe/benches/december-bench/apps/wiki/node_modules


### PR DESCRIPTION
## Problem

`wiki/public/node_modules` is a bundler-generated symlink that got committed. It points to an absolute path on one machine, so it is broken everywhere else. `flit` fails to build the wheel and the app cannot be installed. Reported by the marketplace audit in #736 (both `ImportCheck` and `SymlinkCheck`).

## Solution

Untrack the symlink and ignore it. The existing `node_modules/*` rule only matches files inside such a directory, not the symlink itself, so a plain `node_modules` rule was added.

Verified: no symlinks remain in the tracked tree, and `uv build --wheel` on a clean export of the tree succeeds.

Closes #736

🤖 Generated with [Claude Code](https://claude.com/claude-code)