### PR TITLE
fix: reader column widths on wide screens

### DIFF
--- a/wiki/templates/wiki/document.html
+++ b/wiki/templates/wiki/document.html
@@ -13,7 +13,7 @@
 <div x-data="wikiPage" x-init="$store.navigation.init()" class="flex-1 min-w-0 flex">
     <!-- Main Content Area -->
     <main class="flex-1 min-w-0 px-4 py-6 lg:px-6 lg:py-8 xl:px-12 flex justify-center">
-        <article class="w-full min-w-0 transition-opacity duration-300 xl:max-w-[100ch]"
+        <article class="min-w-0 w-full transition-opacity duration-300 xl:max-w-[85ch]"
              :class="{ 'opacity-50': $store.navigation.loading, 'xl:!max-w-[100ch]': $store.sidebar?.isCollapsed }">
         <!-- Page Header -->
         <header class="py-6 mb-6 border-b border-[var(--outline-gray-1)]">
@@ -79,7 +79,7 @@
 
         <!-- Page Content -->
         <!-- prose prose-v3 mirrors the SPA editor's EditorContent defaults -->
-        <div class="prose prose-v3 max-w-none text-[15px] [&>*:first-child]:mt-0" id="wiki-content">
+        <div class="prose prose-v3 !max-w-none text-[15px] [&>*:first-child]:mt-0" id="wiki-content">
             {{ rendered_content | safe }}
         </div>
 

--- a/wiki/templates/wiki/includes/sidebar.html
+++ b/wiki/templates/wiki/includes/sidebar.html
@@ -290,13 +290,8 @@
 
                 if (!headings || headings.length === 0) {
                     tocContainer.innerHTML = '';
-                    tocContainer.classList.remove('w-[200px]');
-                    tocContainer.classList.add('w-0', '!p-0');
                     return;
                 }
-
-                tocContainer.classList.remove('w-0', '!p-0');
-                tocContainer.classList.add('w-[200px]');
 
                 const escapeHtml = (str) => {
                     const div = document.createElement('div');

--- a/wiki/templates/wiki/includes/toc.html
+++ b/wiki/templates/wiki/includes/toc.html
@@ -8,7 +8,7 @@
     the rail. Indenting unconditionally misaligns the label; not indenting at
     all throws away the hierarchy on mixed pages. -#}
 {% set has_h2 = toc_headings and (toc_headings | selectattr('level', 'equalto', 2) | list | length) > 0 %}
-<aside id="wiki-toc" class="hidden lg:block flex-shrink-0 py-6 pr-6 {% if toc_headings and toc_headings|length > 0 %}w-[200px]{% else %}w-0 !p-0{% endif %}">
+<aside id="wiki-toc" class="hidden lg:block flex-shrink-0 py-6 pr-6 {% if toc_headings and toc_headings|length > 0 %}w-[300px]{% else %}w-0 !p-0{% endif %}">
 {% if toc_headings and toc_headings|length > 0 %}
     {# Sticks 24px under the chrome (navbar + tab row); see --wiki-chrome-h in main.css.
        Mirrored by the nav-store's SPA re-render in includes/sidebar.html — edit both. #}

--- a/wiki/templates/wiki/layout.html
+++ b/wiki/templates/wiki/layout.html
@@ -65,7 +65,7 @@
     offsets against. It's a CSS variable rather than an inline value because the
     chrome is desktop-only — below `lg` the offset has to collapse to zero. -#}
 {% set has_tabs = space_tabs and space_tabs|length %}
-<body class="min-h-screen antialiased bg-[var(--surface-base)] text-[var(--ink-gray-9)] text-base"
+<body class="min-h-screen antialiased bg-[var(--surface-base)] text-[var(--ink-gray-9)] text-base max-w-[2000px] mx-auto"
       {% if hide_chrome %}data-wiki-bare{% elif has_tabs %}data-wiki-tabs{% endif %}>
     {% if not hide_chrome %}
     {% include "templates/wiki/includes/search_modal.html" %}


### PR DESCRIPTION
## Problem

The public reader stretched to the full viewport width. On wide displays the prose line length and the gap between the article and the table of contents kept growing, and long TOC headings wrapped inside a 200px rail.

## Solution

- Cap the page at `2000px` and centre it.
- Hold the article at `85ch` while the sidebar is open (still `100ch` when it is collapsed).
- Widen the TOC rail to `300px`.