### PR TITLE
fix: letterboxed, overflowing YouTube embeds on the public reader, paste to embed

### DIFF
--- a/e2e/tests/iframe-embed.spec.ts
+++ b/e2e/tests/iframe-embed.spec.ts
@@ -146,6 +146,74 @@ test.describe('Iframe embed extension', () => {
 		expect(md2).toBe(md1);
 	});
 
+	/**
+	 * Fire a real `paste` ClipboardEvent at the ProseMirror node so the editor's
+	 * own handlePaste runs — the path a user's Cmd+V takes. A URL copied from
+	 * the browser's address bar carries text/plain and nothing else, which is
+	 * also the shape that makes handlePaste treat the payload as markdown.
+	 */
+	async function pasteText(
+		page: import('@playwright/test').Page,
+		text: string,
+	) {
+		await page.evaluate((text) => {
+			const dom = document.querySelector('.ProseMirror') as HTMLElement | null;
+			if (!dom) throw new Error('editor not found');
+			dom.focus();
+			const dt = new DataTransfer();
+			dt.setData('text/plain', text);
+			dom.dispatchEvent(
+				new ClipboardEvent('paste', {
+					clipboardData: dt,
+					bubbles: true,
+					cancelable: true,
+				}),
+			);
+		}, text);
+	}
+
+	test('turns a pasted YouTube link into an embed', async ({ page }) => {
+		await createDraftAndOpenEditor(page, `iframe-paste-${Date.now()}`);
+
+		await pasteText(page, 'https://www.youtube.com/watch?v=QDia3e12czc');
+
+		await expect
+			.poll(
+				() =>
+					page.evaluate(() => {
+						const block = window.wikiEditor
+							.getJSON()
+							.content?.find((n) => n.type === 'iframeBlock');
+						return (block?.attrs?.src as string) ?? null;
+					}),
+				{ timeout: 5000 },
+			)
+			.toBe('https://www.youtube-nocookie.com/embed/QDia3e12czc');
+	});
+
+	// A URL sitting inside a sentence is a link, not a video. Only a paste whose
+	// entire payload is the URL should embed.
+	test('leaves a pasted sentence containing a link as text', async ({
+		page,
+	}) => {
+		await createDraftAndOpenEditor(page, `iframe-paste-inline-${Date.now()}`);
+
+		await pasteText(
+			page,
+			'watch https://www.youtube.com/watch?v=QDia3e12czc later',
+		);
+
+		await page.waitForTimeout(500);
+		const hasBlock = await page.evaluate(() =>
+			Boolean(
+				window.wikiEditor
+					.getJSON()
+					.content?.some((n) => n.type === 'iframeBlock'),
+			),
+		);
+		expect(hasBlock).toBe(false);
+	});
+
 	test('accepts the full iframe tag in the /embed URL input', async ({
 		page,
 	}) => {

--- a/e2e/tests/iframe-embed.spec.ts
+++ b/e2e/tests/iframe-embed.spec.ts
@@ -19,6 +19,13 @@ const IFRAME_FIXTURE =
 const IFRAME_SRC =
 	'https://www.youtube.com/embed/QDia3e12czc?si=8or3Lz5IEeelsdcF';
 
+// What the same fixture becomes once it goes through normalizeEmbedUrl: the
+// privacy-enhanced host, share query intact. Only paths that normalize (the
+// URL input, a paste) produce this — markdown already stored on a page is
+// parsed as-is and keeps whichever host it was written with.
+const IFRAME_SRC_NORMALIZED =
+	'https://www.youtube-nocookie.com/embed/QDia3e12czc?si=8or3Lz5IEeelsdcF';
+
 declare global {
 	interface Window {
 		wikiEditor: {
@@ -165,14 +172,14 @@ test.describe('Iframe embed extension', () => {
 			.click();
 
 		const preview = page.locator(
-			'.iframe-block-wrapper iframe[src*="youtube.com/embed"]',
+			'.iframe-block-wrapper iframe[src*="youtube-nocookie.com/embed"]',
 		);
 		await expect(preview).toBeVisible({ timeout: 5000 });
-		await expect(preview).toHaveAttribute('src', IFRAME_SRC);
+		await expect(preview).toHaveAttribute('src', IFRAME_SRC_NORMALIZED);
 
 		// Saved markdown reflects the attrs pulled from the pasted iframe HTML.
 		const md = await page.evaluate(() => window.wikiEditor.getMarkdown());
-		expect(md).toContain(`src="${IFRAME_SRC}"`);
+		expect(md).toContain(`src="${IFRAME_SRC_NORMALIZED}"`);
 		expect(md).toContain('title="YouTube video player"');
 	});
 });

--- a/e2e/tests/public-embed-layout.spec.ts
+++ b/e2e/tests/public-embed-layout.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from '@playwright/test';
+import { updateDoc } from '../helpers/frappe';
+import {
+	createTestWikiDocument,
+	createTestWikiSpace,
+	deleteTestWikiDocument,
+	deleteTestWikiSpace,
+} from '../helpers/wiki';
+
+/**
+ * Authors paste whatever dimensions the provider's share dialog hands them, and
+ * those get stored verbatim. This fixture is the shape that caused frappe/wiki's
+ * letterboxed embeds: 800x473 is ratio 1.69, not 16:9, so YouTube pads the video
+ * with black bars — and 800px is wider than the article column, so it overflows
+ * flush-left. The reader has to ignore both numbers.
+ *
+ * Only a browser can prove this: the markup is unchanged, it's the used box that
+ * has to come out right.
+ */
+const CONTENT =
+	'<iframe width="800" height="473.33333333" ' +
+	'src="https://www.youtube.com/embed/QDia3e12czc" ' +
+	'title="YouTube video player" frameborder="0" allowfullscreen></iframe>';
+
+test.describe('Public reader embed layout', () => {
+	test('renders a mis-sized embed as a centered 16:9 box', async ({
+		page,
+		request,
+	}) => {
+		const spaceRoute = `embed-layout-space-${Date.now()}`;
+		const space = await createTestWikiSpace(request, {
+			route: spaceRoute,
+			is_published: true,
+		});
+		const rootGroup = await createTestWikiDocument(request, {
+			title: 'Root',
+			route: `${spaceRoute}/root`,
+			is_group: true,
+			is_published: true,
+		});
+		await updateDoc(request, 'Wiki Space', space.name, {
+			root_group: rootGroup.name,
+		});
+		const doc = await createTestWikiDocument(request, {
+			title: 'Embed Page',
+			route: `${spaceRoute}/embed`,
+			content: CONTENT,
+			is_published: true,
+			parent_wiki_document: rootGroup.name,
+		});
+
+		try {
+			// Wide enough that the 720px cap leaves visible slack on both sides,
+			// so the centering assertion below is actually measuring something.
+			await page.setViewportSize({ width: 1600, height: 900 });
+			await page.goto(`/${doc.route}`);
+			await page.waitForLoadState('networkidle');
+
+			const frame = page.locator('#wiki-content iframe');
+			await expect(frame).toBeVisible();
+
+			const box = await frame.boundingBox();
+			const column = await page.locator('#wiki-content').boundingBox();
+			expect(box).not.toBeNull();
+			expect(column).not.toBeNull();
+			if (!box || !column) return;
+
+			// The authored 800px must not win over the column.
+			expect(box.width).toBeLessThanOrEqual(720);
+
+			// The bars are gone only if the box is exactly 16:9.
+			expect(Math.abs(box.width / box.height - 16 / 9)).toBeLessThan(0.02);
+
+			const leftGap = box.x - column.x;
+			const rightGap = column.x + column.width - (box.x + box.width);
+			expect(leftGap).toBeGreaterThan(0);
+			expect(Math.abs(leftGap - rightGap)).toBeLessThan(2);
+		} finally {
+			await deleteTestWikiDocument(request, doc.name).catch(() => {});
+			await deleteTestWikiDocument(request, rootGroup.name).catch(() => {});
+			await deleteTestWikiSpace(request, space.name).catch(() => {});
+		}
+	});
+});

--- a/frontend/src/components/WikiEditor.vue
+++ b/frontend/src/components/WikiEditor.vue
@@ -64,6 +64,7 @@ import WikiToolbar from './tiptap-extensions/WikiToolbar.vue';
 // Import custom extensions
 import { CalloutBlock } from './tiptap-extensions/callout-block.js';
 import { IframeBlock } from './tiptap-extensions/iframe-block.js';
+import { isEmbedUrlPaste } from './tiptap-extensions/iframe-embed.js';
 import { WikiImage } from './tiptap-extensions/image-extension.js';
 import { WikiLink } from './tiptap-extensions/link-extension.js';
 import { canonicalizeMarkdown } from './tiptap-extensions/markdown-normalize.js';
@@ -297,6 +298,15 @@ function handlePaste(_view, event) {
 	// default handler keep the rich formatting.
 	const text = event.clipboardData?.getData('text/plain');
 	const html = event.clipboardData?.getData('text/html');
+
+	// A paste that is nothing but an embeddable URL belongs to the iframe
+	// block's paste rule. Handling it as markdown here would consume the event
+	// (returning true stops ProseMirror applying its slice, and with it every
+	// paste rule) and leave a bare link where the video should be.
+	if (text && isEmbedUrlPaste(text)) {
+		return false;
+	}
+
 	if (text && !html && editor.value?.markdown) {
 		event.preventDefault();
 		editor.value

--- a/frontend/src/components/tiptap-extensions/IframeBlockView.vue
+++ b/frontend/src/components/tiptap-extensions/IframeBlockView.vue
@@ -112,7 +112,10 @@ function handleKeyDown(event) {
 	display: flex;
 	flex-direction: column;
 	align-items: stretch;
-	margin: 0.5rem 0;
+	/* Same 720px cap the public reader applies in main.css, so an embed is the
+	   same box in the editor, the readonly reader and a change-request preview. */
+	max-width: 720px;
+	margin: 0.5rem auto;
 	border-radius: 8px;
 	transition: outline-color 0.2s ease;
 }
@@ -128,6 +131,17 @@ function handleKeyDown(event) {
 	overflow: hidden;
 	border-radius: 8px;
 	background-color: #000;
+}
+
+/* Documents, boards and code sandboxes aren't 16:9 video — a widescreen box
+   just wastes half the height on their own scrollbars. */
+.iframe-block-wrapper[data-provider='figma'] .iframe-container,
+.iframe-block-wrapper[data-provider='miro'] .iframe-container,
+.iframe-block-wrapper[data-provider='google'] .iframe-container,
+.iframe-block-wrapper[data-provider='codepen'] .iframe-container,
+.iframe-block-wrapper[data-provider='codesandbox'] .iframe-container,
+.iframe-block-wrapper[data-provider='github-gist'] .iframe-container {
+	aspect-ratio: 4 / 3;
 }
 
 .iframe-container iframe {

--- a/frontend/src/components/tiptap-extensions/iframe-embed.js
+++ b/frontend/src/components/tiptap-extensions/iframe-embed.js
@@ -58,6 +58,30 @@ export function isAllowedIframeSrc(url) {
 }
 
 /**
+ * Seconds from a YouTube `t` param, which is either a plain count ("90") or a
+ * duration ("1m30s", "1h2m3s"). Returns null when there's nothing usable.
+ */
+function youtubeStartSeconds(value) {
+	if (!value) return null;
+	if (/^\d+$/.test(value)) return Number(value);
+	const parts = value.match(/^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/);
+	if (!parts) return null;
+	const seconds =
+		Number(parts[1] || 0) * 3600 +
+		Number(parts[2] || 0) * 60 +
+		Number(parts[3] || 0);
+	return seconds || null;
+}
+
+// youtube-nocookie.com is YouTube's privacy-enhanced host: no tracking cookies
+// are set until the viewer actually presses play.
+function youtubeEmbedUrl(id, startParam) {
+	const start = youtubeStartSeconds(startParam);
+	const query = start ? `?start=${start}` : '';
+	return `https://www.youtube-nocookie.com/embed/${id}${query}`;
+}
+
+/**
  * Convert user-friendly URLs (watch pages, share links) into the provider's
  * embed URL. Pasting a plain youtube.com/watch?v=X should Just Work.
  */
@@ -74,18 +98,22 @@ export function normalizeEmbedUrl(url) {
 
 	if (host === 'youtube.com' || host === 'youtube-nocookie.com') {
 		if (u.pathname === '/watch' && u.searchParams.get('v')) {
-			return `https://www.youtube.com/embed/${u.searchParams.get('v')}`;
+			return youtubeEmbedUrl(u.searchParams.get('v'), u.searchParams.get('t'));
 		}
 		if (u.pathname.startsWith('/shorts/')) {
-			return `https://www.youtube.com/embed/${u.pathname.slice(
-				'/shorts/'.length,
-			)}`;
+			return youtubeEmbedUrl(u.pathname.slice('/shorts/'.length));
+		}
+		// Already an embed URL — keep its path and query (YouTube's share dialog
+		// hangs a `?si=…` on it) and only move it to the privacy-enhanced host.
+		if (u.pathname.startsWith('/embed/')) {
+			u.hostname = 'www.youtube-nocookie.com';
+			return u.toString();
 		}
 		return input;
 	}
 	if (host === 'youtu.be') {
 		const id = u.pathname.slice(1);
-		return id ? `https://www.youtube.com/embed/${id}` : input;
+		return id ? youtubeEmbedUrl(id, u.searchParams.get('t')) : input;
 	}
 	if (host === 'vimeo.com') {
 		const id = u.pathname.match(/^\/(\d+)/)?.[1];
@@ -177,8 +205,10 @@ export function iframeAttrsFromHtml(html) {
 	if (!match) return null;
 	const parsed = parseIframeAttrs(match[1]);
 	if (!isAllowedIframeSrc(parsed.src)) return null;
+	// Pasted embed HTML goes through the same normalization as a pasted URL,
+	// otherwise the two paths disagree on which host a YouTube embed lands on.
 	return {
-		src: parsed.src,
+		src: normalizeEmbedUrl(parsed.src),
 		width: parsed.width || null,
 		height: parsed.height || null,
 		title: parsed.title || null,

--- a/frontend/src/components/tiptap-extensions/iframe-embed.js
+++ b/frontend/src/components/tiptap-extensions/iframe-embed.js
@@ -186,6 +186,19 @@ export const EMBED_URL_PASTE_RE = new RegExp(
 	'g',
 );
 
+// Non-global twin for one-off tests — a global regex would carry lastIndex
+// between calls and answer `false` on every other identical paste.
+const EMBED_URL_PASTE_RE_SINGLE = new RegExp(EMBED_URL_PASTE_RE.source);
+
+/**
+ * True when a pasted payload is nothing but an embeddable URL, i.e. exactly
+ * what the iframe block's paste rule claims. Editor-level paste handlers use
+ * this to stand aside instead of consuming the event first.
+ */
+export function isEmbedUrlPaste(text) {
+	return EMBED_URL_PASTE_RE_SINGLE.test(String(text ?? ''));
+}
+
 // Non-global form drives the stateless .exec() in iframeAttrsFromHtml (a global
 // regex would carry lastIndex across calls); EMBED_HTML_PASTE_RE_G is its global
 // twin for the paste rule, which goes through matchAll.

--- a/frontend/src/components/tiptap-extensions/iframe-embed.test.js
+++ b/frontend/src/components/tiptap-extensions/iframe-embed.test.js
@@ -6,6 +6,7 @@ import {
 	EMBED_URL_PASTE_RE,
 	iframeAttrsFromHtml,
 	isAllowedIframeSrc,
+	isEmbedUrlPaste,
 	normalizeEmbedUrl,
 } from './iframe-embed.js';
 
@@ -25,6 +26,23 @@ test('URL paste regex matches a paste that is only an allowlisted embed URL', ()
 	const matches = [...text.matchAll(EMBED_URL_PASTE_RE)];
 	assert.equal(matches.length, 1);
 	assert.equal(matches[0][1], text);
+});
+
+// WikiEditor's handlePaste asks this before deciding whether to consume the
+// event as markdown. A stale lastIndex here would make every other paste of the
+// same URL fall through to markdown and land as a bare link.
+test('isEmbedUrlPaste is stateless and only claims paste-alone embed URLs', () => {
+	for (let i = 0; i < 3; i++) {
+		assert.equal(isEmbedUrlPaste('https://www.youtube.com/watch?v=abc'), true);
+		assert.equal(isEmbedUrlPaste('https://youtu.be/abc'), true);
+	}
+	assert.equal(
+		isEmbedUrlPaste('watch https://www.youtube.com/watch?v=abc later'),
+		false,
+	);
+	assert.equal(isEmbedUrlPaste('https://evil.example.com/x'), false);
+	assert.equal(isEmbedUrlPaste(''), false);
+	assert.equal(isEmbedUrlPaste(undefined), false);
 });
 
 test('URL paste regex ignores an embed URL sitting inside a sentence', () => {

--- a/frontend/src/components/tiptap-extensions/iframe-embed.test.js
+++ b/frontend/src/components/tiptap-extensions/iframe-embed.test.js
@@ -38,7 +38,7 @@ test('HTML paste regex extracts attrs from a self-contained <iframe>', () => {
 	const matches = [...html.matchAll(EMBED_HTML_PASTE_RE_G)];
 	assert.equal(matches.length, 1);
 	const attrs = iframeAttrsFromHtml(matches[0][0]);
-	assert.equal(attrs.src, 'https://www.youtube.com/embed/abc');
+	assert.equal(attrs.src, 'https://www.youtube-nocookie.com/embed/abc');
 	assert.equal(attrs.width, '560');
 });
 
@@ -66,6 +66,50 @@ test('disallowed hosts are rejected on parse', () => {
 test('normalizeEmbedUrl upgrades a youtube watch URL to its embed URL', () => {
 	assert.equal(
 		normalizeEmbedUrl('https://www.youtube.com/watch?v=abc'),
-		'https://www.youtube.com/embed/abc',
+		'https://www.youtube-nocookie.com/embed/abc',
+	);
+});
+
+test('normalizeEmbedUrl sends every youtube form to the nocookie host', () => {
+	for (const url of [
+		'https://youtu.be/abc',
+		'https://www.youtube.com/shorts/abc',
+	]) {
+		assert.equal(
+			normalizeEmbedUrl(url),
+			'https://www.youtube-nocookie.com/embed/abc',
+			url,
+		);
+	}
+});
+
+// YouTube's share dialog hangs a `?si=…` on the embed URL; moving the host must
+// not drop it, or the pasted embed stops matching what the user copied.
+test('normalizeEmbedUrl rehosts an existing embed URL and keeps its query', () => {
+	assert.equal(
+		normalizeEmbedUrl('https://www.youtube.com/embed/abc?si=XyZ'),
+		'https://www.youtube-nocookie.com/embed/abc?si=XyZ',
+	);
+});
+
+test('normalizeEmbedUrl carries a watch timestamp into ?start=', () => {
+	assert.equal(
+		normalizeEmbedUrl('https://www.youtube.com/watch?v=abc&t=90'),
+		'https://www.youtube-nocookie.com/embed/abc?start=90',
+	);
+	assert.equal(
+		normalizeEmbedUrl('https://youtu.be/abc?t=1m30s'),
+		'https://www.youtube-nocookie.com/embed/abc?start=90',
+	);
+});
+
+test('normalizeEmbedUrl leaves non-youtube providers alone', () => {
+	assert.equal(
+		normalizeEmbedUrl('https://vimeo.com/12345'),
+		'https://player.vimeo.com/video/12345',
+	);
+	assert.equal(
+		normalizeEmbedUrl('https://codepen.io/team/pen/abc'),
+		'https://codepen.io/team/pen/abc',
 	);
 });

--- a/wiki/public/css/main.css
+++ b/wiki/public/css/main.css
@@ -479,6 +479,37 @@ body.image-viewer-open {
   font-weight: 600;
 }
 
+/* ---------- Iframe embeds (public) ----------
+   Stored markdown keeps whatever width/height the author pasted out of the
+   provider's share dialog, and Tailwind's preflight leaves `iframe` out of the
+   `max-width: 100%` rule it gives `img`/`video`, so those attributes win: the
+   embed overflows the article column and, when the box isn't the video's own
+   ratio, YouTube letterboxes it with black bars. Impose our own box instead. */
+#wiki-content iframe {
+  display: block;
+  width: 100%;
+  max-width: 720px;
+  margin: 1.5rem auto;
+  border: 0;
+  border-radius: 0.5rem;
+}
+
+/* Video providers get an exact 16:9 box — this is what kills the bars.
+   Everything else (figma, docs, gists, codepen…) keeps its authored height. */
+#wiki-content iframe[src*="youtube.com"],
+#wiki-content iframe[src*="youtube-nocookie.com"],
+#wiki-content iframe[src*="youtu.be"],
+#wiki-content iframe[src*="vimeo.com"],
+#wiki-content iframe[src*="loom.com"],
+#wiki-content iframe[src*="cloudflarestream.com"],
+#wiki-content iframe[src*="videodelivery.net"],
+#wiki-content iframe[src*="mediadelivery.net"],
+#wiki-content iframe[src*="aparat.com"] {
+  height: auto;
+  aspect-ratio: 16 / 9;
+  background: #000;
+}
+
 /* ---------- PDF embed card (public) ---------- */
 .wiki-pdf-embed {
   margin: 1.5rem 0;


### PR DESCRIPTION
## Problem

A YouTube embed renders with black bars top and bottom, sits flush-left, and overflows the text column.

Two causes:

1. Stored markdown keeps whatever dimensions the author pasted from the share dialog — here `width="800" height="473.33"`, a ratio of 1.690 rather than 16:9. YouTube pads its 16:9 video into the too-tall box, which is the black bars.
2. Tailwind preflight leaves `iframe` out of the `max-width: 100%` rule it gives `img`/`video`, and there was no iframe CSS anywhere in the public reader. So `800px` won and overflowed the `85ch` article column.

The SPA editor and reader were already fine — they force 16:9 and ignore the stored attributes.

## Solution

Impose our own box in `#wiki-content`: 100% width capped at 720px, centered, rounded, with an exact 16:9 aspect-ratio for video providers. Non-video embeds (Figma, Docs, gists) keep their authored height. `IframeBlockView.vue` takes the same 720px cap so the editor, the reader and a change-request preview agree.

Existing pages are untouched — the CSS overrides the stored attributes either way.

## Also in here

- **YouTube embeds now use `youtube-nocookie.com`.** No tracking cookies until the viewer presses play. Rehosting an existing embed URL preserves its `?si=` share query, and a `t=90` / `t=1m30s` on a watch link becomes `?start=90` instead of being dropped.
- **Pasting a YouTube link now embeds it.** The iframe block has carried a `nodePasteRule` for provider URLs since the feature shipped, and it never ran: `WikiEditor`'s `handlePaste` claims any plain-text-only clipboard as markdown and returns `true`, which tells ProseMirror not to apply its slice — and paste rules run on that slice. A URL copied from the address bar is exactly that payload, so it always landed as a bare link. It now stands aside for paste-alone embed URLs. A URL inside a sentence still stays text; a paste over a selection still becomes a link.

## Tests

- `e2e/tests/public-embed-layout.spec.ts` — measures the rendered box (720px cap, exact 16:9, centered). Confirmed failing at 800px with the CSS removed.
- `e2e/tests/iframe-embed.spec.ts` — two paste-to-embed cases; the embed case was confirmed failing before the fix.
- `iframe-embed.test.js` — nocookie rewrites, timestamp carry, and `isEmbedUrlPaste` statelessness (the `lastIndex` trap behind #667).

## Note on hiding YouTube's chrome

Not possible with player parameters any more: `modestbranding` has had no effect since 2023-08-15, `showinfo` was removed in 2018, and `rel=0` only restricts related videos to the same channel. The only real option is a facade (own thumbnail + play button, iframe injected on click), which is deliberately not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnyveABWeKpqoQ1CcG1qud