### PR TITLE
feat(editor): live "On this page" TOC beside the editor

### DIFF
--- a/e2e/tests/editor-toc.spec.ts
+++ b/e2e/tests/editor-toc.spec.ts
@@ -1,0 +1,231 @@
+import { type Page, expect, test } from '@playwright/test';
+import { SPACE_URL_RE, appUrl } from '../helpers/routes';
+import {
+	cleanupWikiSpacesByRoute,
+	clickSidebarAddOption,
+} from '../helpers/wiki';
+
+/**
+ * The editor's "On this page" rail mirrors the public reader's TOC, but is
+ * driven by the live ProseMirror doc rather than the saved markdown. These
+ * specs cover the two things that makes possible: entries that track the
+ * document as it is typed, and click-to-scroll inside the editor.
+ *
+ * The rail collapses to a strip below 900px of editor width, so the narrow
+ * case is exercised by resizing the viewport rather than by a phone project —
+ * the breakpoint is on the editor element, not the device.
+ */
+
+// The breakpoint is on the editor element, which loses ~520px to the app nav
+// and the page tree — hence the gap between these two viewports.
+const WIDE = { width: 1440, height: 900 };
+const NARROW = { width: 1000, height: 900 };
+const PHONE = { width: 375, height: 667 };
+
+const SEED_HTML = [
+	'<h2>Installation</h2>',
+	...Array.from({ length: 25 }, (_, i) => `<p>install step ${i}</p>`),
+	'<h3>Requirements</h3>',
+	...Array.from({ length: 25 }, (_, i) => `<p>requirement ${i}</p>`),
+	'<h2>Usage</h2>',
+	...Array.from({ length: 25 }, (_, i) => `<p>usage note ${i}</p>`),
+].join('');
+
+async function seedEditor(page: Page, html: string) {
+	const applied = await page.evaluate((content) => {
+		const editor = (
+			window as unknown as {
+				wikiEditor?: {
+					commands: { setContent: (value: string) => boolean };
+				};
+			}
+		).wikiEditor;
+		if (!editor) return false;
+		editor.commands.setContent(content);
+		return true;
+	}, html);
+	expect(applied).toBe(true);
+}
+
+async function createSpaceWithPage(page: Page, stamp: number) {
+	const spaceRoute = `editor-toc-${stamp}`;
+
+	await page.setViewportSize(WIDE);
+	await page.goto(appUrl('spaces'));
+	await page.waitForLoadState('networkidle');
+
+	await page.getByRole('button', { name: 'New Space' }).click();
+	await page.waitForSelector('[role="dialog"]', { state: 'visible' });
+	await page.getByLabel('Space Name').fill(spaceRoute);
+	await page.getByLabel('Route').fill(spaceRoute);
+	await page
+		.getByRole('dialog')
+		.getByRole('button', { name: 'Create' })
+		.click();
+	await expect(page).toHaveURL(SPACE_URL_RE);
+	await page.waitForLoadState('networkidle');
+
+	const createFirstPage = page.locator('button:has-text("Create First Page")');
+	if (await createFirstPage.isVisible({ timeout: 2000 }).catch(() => false)) {
+		await createFirstPage.click();
+	} else {
+		await clickSidebarAddOption(page, 'New Page');
+	}
+	const pageTitle = `TOC Page ${stamp}`;
+	await page.getByLabel('Title').fill(pageTitle);
+	await page.getByRole('dialog').getByRole('button', { name: 'Save' }).click();
+	await page.waitForLoadState('networkidle');
+
+	await openPageFromTree(page, pageTitle);
+	return spaceRoute;
+}
+
+/**
+ * Open a page from the tree and wait for the editor.
+ *
+ * Creating a page can land on the draft route before the change-request
+ * overlay is readable ("Draft not found"), which locally is a queue-lag
+ * artefact rather than a product bug — one reload settles it.
+ */
+async function openPageFromTree(page: Page, pageTitle: string) {
+	const treeItem = page.locator('aside').getByText(pageTitle, { exact: false });
+	const editor = page.locator('.ProseMirror');
+
+	for (let attempt = 0; attempt < 3; attempt++) {
+		if (await editor.isVisible({ timeout: 5000 }).catch(() => false)) return;
+		await page.reload();
+		await page.waitForLoadState('networkidle');
+		await treeItem.first().click();
+	}
+
+	await expect(editor).toBeVisible({ timeout: 10000 });
+}
+
+test.describe('Editor table of contents', () => {
+	const createdRoutes: string[] = [];
+
+	test.afterEach(async ({ request }) => {
+		while (createdRoutes.length) {
+			const route = createdRoutes.pop() as string;
+			await cleanupWikiSpacesByRoute(request, route).catch(() => {});
+		}
+	});
+
+	test('lists h2/h3 headings and follows the document as it is typed', async ({
+		page,
+	}) => {
+		createdRoutes.push(await createSpaceWithPage(page, Date.now()));
+		await seedEditor(page, SEED_HTML);
+
+		const rail = page.locator('[data-testid="editor-toc-rail"]');
+		await expect(rail).toBeVisible();
+		await expect(rail.getByText('On this page')).toBeVisible();
+
+		const links = rail.locator('[data-testid="editor-toc-link"]');
+		await expect(links).toHaveText(['Installation', 'Requirements', 'Usage']);
+
+		// The point of an in-editor TOC: a heading typed now shows up now, with
+		// no save and no round trip to the markdown renderer.
+		await page.evaluate(() => {
+			(
+				window as unknown as {
+					wikiEditor?: { commands: { focus: (pos: 'end') => boolean } };
+				}
+			).wikiEditor?.commands.focus('end');
+		});
+		await page.keyboard.press('Enter');
+		await page.keyboard.type('## Troubleshooting');
+
+		await expect(links).toHaveText([
+			'Installation',
+			'Requirements',
+			'Usage',
+			'Troubleshooting',
+		]);
+	});
+
+	test('clicking an entry scrolls that heading into view', async ({ page }) => {
+		createdRoutes.push(await createSpaceWithPage(page, Date.now()));
+		await seedEditor(page, SEED_HTML);
+
+		const rail = page.locator('[data-testid="editor-toc-rail"]');
+		const usage = rail.locator('[data-testid="editor-toc-link"]', {
+			hasText: 'Usage',
+		});
+
+		const heading = page.locator('.ProseMirror h2', { hasText: 'Usage' });
+		// Far enough down the document that it starts off screen.
+		await expect(heading).not.toBeInViewport();
+
+		await usage.click();
+		await expect(heading).toBeInViewport({ timeout: 5000 });
+
+		// It must clear the sticky toolbar rather than hide behind it.
+		const headingBox = await heading.boundingBox();
+		const toolbarBox = await page.locator('.wiki-toolbar').boundingBox();
+		if (!headingBox || !toolbarBox) {
+			throw new Error('Missing layout boxes for scroll assertion');
+		}
+		expect(headingBox.y).toBeGreaterThanOrEqual(
+			toolbarBox.y + toolbarBox.height - 1,
+		);
+
+		// The entry you jumped to becomes the active one.
+		await expect(usage).toHaveClass(/text-ink-gray-9/);
+	});
+
+	test('falls back to a collapsible strip when the editor is too narrow', async ({
+		page,
+	}) => {
+		createdRoutes.push(await createSpaceWithPage(page, Date.now()));
+		await seedEditor(page, SEED_HTML);
+
+		await expect(page.locator('[data-testid="editor-toc-rail"]')).toBeVisible();
+
+		await page.setViewportSize(NARROW);
+		await expect(page.locator('[data-testid="editor-toc-rail"]')).toHaveCount(
+			0,
+		);
+
+		const strip = page.locator('[data-testid="editor-toc-strip"]');
+		await expect(strip).toBeVisible();
+
+		const links = strip.locator('[data-testid="editor-toc-link"]');
+		await expect(links).toHaveCount(0);
+
+		await strip.locator('[data-testid="editor-toc-toggle"]').click();
+		await expect(links).toHaveText(['Installation', 'Requirements', 'Usage']);
+
+		// Choosing a heading scrolls to it and closes the strip again.
+		await links.filter({ hasText: 'Usage' }).click();
+		await expect(links).toHaveCount(0);
+		await expect(
+			page.locator('.ProseMirror h2', { hasText: 'Usage' }),
+		).toBeInViewport({ timeout: 5000 });
+	});
+
+	test('the strip works on a phone without widening the page', async ({
+		page,
+	}) => {
+		createdRoutes.push(await createSpaceWithPage(page, Date.now()));
+		await seedEditor(page, SEED_HTML);
+
+		await page.setViewportSize(PHONE);
+
+		const strip = page.locator('[data-testid="editor-toc-strip"]');
+		await expect(strip).toBeVisible();
+		await strip.locator('[data-testid="editor-toc-toggle"]').click();
+
+		const links = strip.locator('[data-testid="editor-toc-link"]');
+		await expect(links).toHaveText(['Installation', 'Requirements', 'Usage']);
+
+		// Long heading text must truncate inside the strip rather than push the
+		// page into a horizontal scroll.
+		const overflow = await page.evaluate(
+			() =>
+				document.documentElement.scrollWidth -
+				document.documentElement.clientWidth,
+		);
+		expect(overflow).toBeLessThanOrEqual(1);
+	});
+});

--- a/frontend/src/components/EditorTableOfContents.vue
+++ b/frontend/src/components/EditorTableOfContents.vue
@@ -1,0 +1,245 @@
+<template>
+	<!-- The rail keeps its width even with nothing to list, so the content column
+	     doesn't slide sideways the moment the author types their first `##`. -->
+	<aside
+		v-if="variant === 'rail'"
+		ref="rootRef"
+		class="w-[220px] shrink-0 py-6 pr-6"
+		data-testid="editor-toc-rail"
+	>
+		<nav
+			v-if="outline.length"
+			class="hide-scrollbar sticky flex flex-col overflow-y-auto text-sm leading-relaxed"
+			:style="{ top: `${railTop}px`, maxHeight: `calc(100vh - ${railTop}px - 4rem)` }"
+		>
+			<!-- Transparent border keeps the label on the same left edge as the links. -->
+			<span class="whitespace-nowrap border-l border-transparent pl-4 pb-1 font-medium text-ink-gray-8">
+				{{ __('On this page') }}
+			</span>
+			<button
+				v-for="(entry, index) in outline"
+				:key="entry.pos"
+				type="button"
+				data-testid="editor-toc-link"
+				class="truncate border-l py-1 text-left"
+				:class="[
+					entry.level >= 3 && hasH2 ? 'pl-7' : 'pl-4',
+					index === activeIndex
+						? 'border-outline-gray-4 text-ink-gray-9'
+						: 'border-outline-gray-2 text-ink-gray-6 hover:text-ink-gray-9',
+				]"
+				@click="goTo(entry)"
+			>
+				{{ entry.text }}
+			</button>
+		</nav>
+	</aside>
+
+	<!-- Narrow layouts get the reader's collapsed strip instead: one row that
+	     names the section you're in, expanding to the full list on tap. -->
+	<div
+		v-else
+		ref="rootRef"
+		class="sticky z-30 bg-surface-base"
+		:style="{ top: `${toolbarHeight}px` }"
+		data-testid="editor-toc-strip"
+	>
+		<template v-if="outline.length">
+			<button
+				type="button"
+				class="flex w-full items-center justify-between gap-2 border-b border-outline-gray-2 px-4 py-2 text-sm text-ink-gray-7 hover:bg-surface-gray-2"
+				data-testid="editor-toc-toggle"
+				:aria-expanded="open"
+				@click="open = !open"
+			>
+				<span class="flex items-center gap-2">
+					<span class="lucide-list size-4 shrink-0" aria-hidden="true" />
+					{{ __('On this page') }}
+				</span>
+				<span class="flex min-w-0 items-center gap-2">
+					<span class="truncate text-ink-gray-5">{{ activeText }}</span>
+					<span
+						class="lucide-chevron-down size-4 shrink-0 transition-transform"
+						:class="open ? 'rotate-180' : ''"
+						aria-hidden="true"
+					/>
+				</span>
+			</button>
+			<nav
+				v-if="open"
+				class="max-h-64 overflow-y-auto border-b border-outline-gray-2 bg-surface-gray-1 py-1"
+			>
+				<button
+					v-for="(entry, index) in outline"
+					:key="entry.pos"
+					type="button"
+					data-testid="editor-toc-link"
+					class="flex w-full items-center gap-2 py-2 pr-4 text-left text-sm"
+					:class="index === activeIndex
+						? 'bg-surface-gray-2 font-medium text-ink-gray-9'
+						: 'text-ink-gray-6'"
+					:style="{ paddingLeft: `${1 + (entry.level - 2) * 0.75}rem` }"
+					@click="goTo(entry, { collapse: true })"
+				>
+					<span
+						class="size-1.5 shrink-0 rounded-full"
+						:class="index === activeIndex ? 'bg-ink-gray-7' : 'bg-ink-gray-4'"
+						aria-hidden="true"
+					/>
+					<span class="truncate">{{ entry.text }}</span>
+				</button>
+			</nav>
+		</template>
+	</div>
+</template>
+
+<script setup>
+import { useDocumentOutline } from '@/composables/useDocumentOutline';
+import { useEventListener } from '@vueuse/core';
+import {
+	computed,
+	nextTick,
+	onBeforeUnmount,
+	onMounted,
+	ref,
+	watch,
+} from 'vue';
+
+const props = defineProps({
+	editor: {
+		type: Object,
+		default: null,
+	},
+	// 'rail' — the reader's right-hand column, for widths that can spare it.
+	// 'strip' — a collapsible row under the toolbar, for everything narrower.
+	variant: {
+		type: String,
+		default: 'rail',
+	},
+});
+
+const rootRef = ref(null);
+const activeIndex = ref(0);
+const toolbarHeight = ref(0);
+const open = ref(false);
+
+const { outline } = useDocumentOutline(() => props.editor);
+
+// The reader indents h3s only on pages that also have an h2 — on an all-h3 page
+// a blanket indent leaves the "On this page" label hanging off the rail.
+const hasH2 = computed(() => outline.value.some((entry) => entry.level === 2));
+const activeText = computed(() => outline.value[activeIndex.value]?.text || '');
+
+const railTop = computed(() => toolbarHeight.value + 24);
+
+// The editor's nearest scrollable ancestor owns both the scroll position we
+// spy on and the sticky context the rail lives in.
+let scrollContainer = null;
+
+function findScrollContainer(element) {
+	let node = element?.parentElement;
+	while (node) {
+		const overflowY = getComputedStyle(node).overflowY;
+		if (overflowY === 'auto' || overflowY === 'scroll') return node;
+		node = node.parentElement;
+	}
+	return null;
+}
+
+function measureToolbar() {
+	toolbarHeight.value =
+		scrollContainer?.querySelector('.wiki-toolbar')?.offsetHeight || 0;
+}
+
+function headingElement(pos) {
+	try {
+		const node = props.editor?.view?.nodeDOM(pos);
+		return node?.nodeType === Node.ELEMENT_NODE ? node : null;
+	} catch {
+		// A stale position from an outline computed a transaction ago.
+		return null;
+	}
+}
+
+function updateActive() {
+	if (!scrollContainer || !outline.value.length) return;
+	// Anything above the toolbar's lower edge has already scrolled out of sight.
+	const threshold =
+		scrollContainer.getBoundingClientRect().top + toolbarHeight.value + 16;
+
+	let next = 0;
+	for (const [index, entry] of outline.value.entries()) {
+		const element = headingElement(entry.pos);
+		if (!element) continue;
+		if (element.getBoundingClientRect().top > threshold) break;
+		next = index;
+	}
+	activeIndex.value = next;
+}
+
+let frame = null;
+function scheduleUpdateActive() {
+	if (frame) return;
+	frame = requestAnimationFrame(() => {
+		frame = null;
+		updateActive();
+	});
+}
+
+function goTo(entry, { collapse = false } = {}) {
+	const element = headingElement(entry.pos);
+	if (!element || !scrollContainer) return;
+	// scrollIntoView would tuck the heading under the sticky toolbar, so scroll
+	// the container by hand and leave room for it.
+	const top =
+		element.getBoundingClientRect().top -
+		scrollContainer.getBoundingClientRect().top +
+		scrollContainer.scrollTop -
+		toolbarHeight.value -
+		16;
+	scrollContainer.scrollTo({ top, behavior: 'smooth' });
+	if (collapse) open.value = false;
+}
+
+onMounted(() => {
+	scrollContainer = findScrollContainer(rootRef.value);
+	// Registered by hand rather than with useEventListener: the component's
+	// effect scope is no longer active inside a lifecycle hook, so the
+	// composable's auto-dispose wouldn't fire.
+	scrollContainer?.addEventListener('scroll', scheduleUpdateActive, {
+		passive: true,
+	});
+	nextTick(() => {
+		measureToolbar();
+		updateActive();
+	});
+});
+
+onBeforeUnmount(() => {
+	scrollContainer?.removeEventListener('scroll', scheduleUpdateActive);
+	if (frame) cancelAnimationFrame(frame);
+});
+
+useEventListener(window, 'resize', () => {
+	measureToolbar();
+	scheduleUpdateActive();
+});
+
+// Editing above the current heading shifts every position below it; re-run the
+// spy so the highlight tracks the caret's section rather than a stale one.
+watch(outline, () => {
+	if (activeIndex.value >= outline.value.length) {
+		activeIndex.value = Math.max(0, outline.value.length - 1);
+	}
+	scheduleUpdateActive();
+});
+</script>
+
+<style scoped>
+.hide-scrollbar {
+	scrollbar-width: none;
+}
+.hide-scrollbar::-webkit-scrollbar {
+	display: none;
+}
+</style>

--- a/frontend/src/components/WikiEditor.vue
+++ b/frontend/src/components/WikiEditor.vue
@@ -1,10 +1,18 @@
 <template>
-    <div class="wiki-editor-container">
+    <div class="wiki-editor-container" ref="containerRef">
         <div>
+            <!-- Stays outside the content row: it's a full-width sticky bar, and
+                 making it a flex child would strand it above one column. -->
             <WikiToolbar v-if="!readonly" :editor="editor" @uploadImage="handleImageUpload" />
-            <div class="w-full max-w-[770px] px-6">
-                <slot name="title" />
-                <EditorContent :editor="editor" :class="contentClass" />
+            <EditorTableOfContents v-if="showTocStrip" :editor="editor" variant="strip" />
+            <div class="flex">
+                <div class="min-w-0 flex-1 flex justify-center">
+                    <div class="w-full max-w-[770px] px-6">
+                        <slot name="title" />
+                        <EditorContent :editor="editor" :class="contentClass" />
+                    </div>
+                </div>
+                <EditorTableOfContents v-if="showTocRail" :editor="editor" variant="rail" />
             </div>
             <!-- After EditorContent so the ProseMirror DOM is attached when the
                  bubble menu mounts; it derives its flip boundary from the editor's
@@ -37,9 +45,10 @@ import {
 	TableRow,
 } from '@tiptap/extension-table';
 import { Placeholder } from '@tiptap/extensions';
-import { onKeyStroke } from '@vueuse/core';
+import { onKeyStroke, useElementSize } from '@vueuse/core';
 import { toast, useFileUpload } from 'frappe-ui';
 import {
+	computed,
 	createApp,
 	h,
 	onBeforeUnmount,
@@ -57,6 +66,7 @@ import {
 	Markdown,
 	useEditor,
 } from 'frappe-ui/editor';
+import EditorTableOfContents from './EditorTableOfContents.vue';
 import LinkPopup from './tiptap-extensions/LinkPopup.vue';
 import SlashCommandsList from './tiptap-extensions/SlashCommandsList.vue';
 import WikiBubbleMenu from './tiptap-extensions/WikiBubbleMenu.vue';
@@ -132,6 +142,7 @@ let autosaveTimer = null;
 const fileUploader = useFileUpload();
 
 // Refs for file input and link popup
+const containerRef = ref(null);
 const slashImageInput = ref(null);
 let linkPopupInstance = null;
 let linkPopupApp = null;
@@ -670,6 +681,20 @@ const contentClass = [
 	'wiki-editor-content',
 	props.readonly ? '' : 'is-editable',
 ];
+
+// The editor's width is the viewport minus the app nav and the resizable tree,
+// so a viewport media query would measure the wrong box — watch the element
+// instead. On a 1440px laptop with both open the editor gets ~920px, which is
+// the width this threshold is picked to serve: below it the content column
+// would have to give up too much to seat a rail, so the strip takes over.
+const TOC_RAIL_MIN_WIDTH = 900;
+const { width: containerWidth } = useElementSize(containerRef);
+const showTocRail = computed(() => containerWidth.value >= TOC_RAIL_MIN_WIDTH);
+// Width reads 0 until the first ResizeObserver callback; rendering neither
+// variant until then avoids flashing the narrow strip on a wide screen.
+const showTocStrip = computed(
+	() => containerWidth.value > 0 && !showTocRail.value,
+);
 
 function normalizeMarkdown(content) {
 	return canonicalizeMarkdown(editor.value?.markdown, content);

--- a/frontend/src/composables/useDocumentOutline.js
+++ b/frontend/src/composables/useDocumentOutline.js
@@ -1,0 +1,103 @@
+import { onBeforeUnmount, ref, toValue, watch } from 'vue';
+
+// h2/h3 only, matching `_apply_heading_slugs_and_toc` in wiki/wiki/markdown.py.
+// Keeping the two in step is what makes the editor rail a preview of the
+// published page rather than a second, differently-shaped outline.
+const TOC_LEVELS = [2, 3];
+
+/**
+ * Collect the heading entries of a ProseMirror doc, in document order.
+ *
+ * Entries carry the node's position rather than a slug: the editor scrolls by
+ * resolving `pos` back to its DOM node, so the reader's slugify rules don't
+ * need a JS twin.
+ */
+export function extractOutline(doc) {
+	const headings = [];
+	if (!doc?.descendants) return headings;
+
+	doc.descendants((node, pos) => {
+		// Descend through block containers (callouts, blockquotes, table cells can
+		// all hold headings) but never into a paragraph's inline content.
+		if (node.type?.name !== 'heading') return node.isBlock;
+		const level = node.attrs?.level;
+		const text = (node.textContent || '').trim();
+		// A heading the author has only just opened has no text yet; it earns a
+		// row once there's something to label it with.
+		if (TOC_LEVELS.includes(level) && text) {
+			headings.push({ level, text, pos });
+		}
+		return false;
+	});
+
+	return headings;
+}
+
+function sameOutline(a, b) {
+	if (a.length !== b.length) return false;
+	return a.every(
+		(entry, i) =>
+			entry.pos === b[i].pos &&
+			entry.level === b[i].level &&
+			entry.text === b[i].text,
+	);
+}
+
+/**
+ * Reactive heading outline of a TipTap editor, refreshed as the doc changes.
+ */
+export function useDocumentOutline(editor) {
+	const outline = ref([]);
+	let frame = null;
+	let attached = null;
+
+	function refresh() {
+		frame = null;
+		const next = extractOutline(attached?.state?.doc);
+		// Typing body text changes the doc on every keystroke without touching a
+		// single heading; bailing here keeps the rail from re-rendering for it.
+		if (sameOutline(next, outline.value)) return;
+		outline.value = next;
+	}
+
+	// Coalesce to the next frame: bursts of keystrokes each fire a transaction,
+	// but the rail only needs to be right once per paint.
+	function schedule() {
+		if (frame) return;
+		frame = requestAnimationFrame(refresh);
+	}
+
+	// `transaction` rather than `update`, because loading a page swaps content
+	// via `setContent(..., { emitUpdate: false })` — an update-only listener
+	// would show the previous page's outline until the first keystroke.
+	function onTransaction({ transaction }) {
+		if (transaction.docChanged) schedule();
+	}
+
+	function detach() {
+		attached?.off('transaction', onTransaction);
+		attached = null;
+	}
+
+	watch(
+		() => toValue(editor),
+		(instance) => {
+			detach();
+			attached = instance || null;
+			if (!attached) {
+				outline.value = [];
+				return;
+			}
+			attached.on('transaction', onTransaction);
+			refresh();
+		},
+		{ immediate: true },
+	);
+
+	onBeforeUnmount(() => {
+		if (frame) cancelAnimationFrame(frame);
+		detach();
+	});
+
+	return { outline };
+}

--- a/frontend/src/composables/useDocumentOutline.test.js
+++ b/frontend/src/composables/useDocumentOutline.test.js
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { extractOutline } from './useDocumentOutline.js';
+
+// A stand-in for a ProseMirror doc: `descendants` walks a flat node list and
+// honours the callback's "skip my children" return value the same way.
+function docOf(nodes) {
+	return {
+		descendants(callback) {
+			let pos = 1;
+			for (const node of nodes) {
+				callback(node, pos);
+				pos += (node.textContent?.length || 0) + 2;
+			}
+		},
+	};
+}
+
+function heading(level, textContent) {
+	return {
+		type: { name: 'heading' },
+		attrs: { level },
+		textContent,
+		isBlock: true,
+	};
+}
+
+function paragraph(textContent) {
+	return { type: { name: 'paragraph' }, textContent, isBlock: true };
+}
+
+test('collects h2 and h3 in document order', () => {
+	const outline = extractOutline(
+		docOf([
+			heading(2, 'Install'),
+			paragraph('Run the installer.'),
+			heading(3, 'Requirements'),
+			heading(2, 'Usage'),
+		]),
+	);
+
+	assert.deepEqual(
+		outline.map((entry) => [entry.level, entry.text]),
+		[
+			[2, 'Install'],
+			[3, 'Requirements'],
+			[2, 'Usage'],
+		],
+	);
+});
+
+test('ignores h1 and h4+, matching the published TOC', () => {
+	const outline = extractOutline(
+		docOf([
+			heading(1, 'Page Title'),
+			heading(2, 'Kept'),
+			heading(4, 'Too deep'),
+			heading(6, 'Deeper still'),
+		]),
+	);
+
+	assert.deepEqual(
+		outline.map((entry) => entry.text),
+		['Kept'],
+	);
+});
+
+test('skips a heading with no text yet', () => {
+	const outline = extractOutline(
+		docOf([heading(2, ''), heading(2, '   '), heading(2, 'Real')]),
+	);
+
+	assert.deepEqual(
+		outline.map((entry) => entry.text),
+		['Real'],
+	);
+});
+
+test('trims heading text', () => {
+	const [entry] = extractOutline(docOf([heading(2, '  Spaced  ')]));
+	assert.equal(entry.text, 'Spaced');
+});
+
+test('reports the position of each heading', () => {
+	const outline = extractOutline(
+		docOf([heading(2, 'One'), paragraph('body'), heading(2, 'Two')]),
+	);
+
+	assert.deepEqual(
+		outline.map((entry) => entry.pos),
+		[1, 12],
+	);
+});
+
+test('returns an empty outline for an empty or missing doc', () => {
+	assert.deepEqual(extractOutline(docOf([])), []);
+	assert.deepEqual(extractOutline(null), []);
+	assert.deepEqual(extractOutline({}), []);
+});


### PR DESCRIPTION
## Why?

The public reader has a table of contents on the right. The editor has an empty column in the same place, so the page reads lopsided and the author can't see the heading structure they are building.

## What?

An "On this page" outline next to the editor content, built from the live ProseMirror document. It updates as you type, and clicking an entry scrolls to that heading.

Below 900px of editor width — which includes every phone — the rail is replaced by the reader's collapsible strip under the toolbar.

## How?

- `useDocumentOutline` walks the editor doc for h2/h3, mirroring `_apply_heading_slugs_and_toc` so the rail previews what the published page will show.
- Entries carry the heading's document position rather than a slug, so scrolling resolves the position back to its DOM node instead of reimplementing the reader's slugify rules in JS.
- The breakpoint is measured on the editor element, not the viewport: the editor loses width to the app nav and the resizable page tree, so a media query would measure the wrong box.

Note: the content column is now centred in the space left over by the rail, so it is ~70px narrower on a 1440px screen. Collapsing the app nav gets that back.

Unit tests cover the outline extraction; e2e covers live updates while typing, click-to-scroll, the rail/strip fallback, and the strip on a phone viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)