### PR TITLE
fix(ui): prevent flash while switching theme

### DIFF
--- a/frontend/src/composables/useTheme.js
+++ b/frontend/src/composables/useTheme.js
@@ -4,8 +4,18 @@ import { computed } from 'vue';
 // Module-level so desktop Sidebar and mobile top nav share one theme value.
 const userTheme = useStorage('wiki-theme', 'dark');
 
+// Suppress transitions for the swap itself: without this, every element with a
+// colour transition animates independently and the page flashes on its way to
+// the new theme. Two rAFs so the class survives the style + paint of the swap.
 function applyTheme(theme) {
-	document.documentElement.setAttribute('data-theme', theme);
+	const root = document.documentElement;
+	root.classList.add('no-transition');
+	root.setAttribute('data-theme', theme);
+	requestAnimationFrame(() => {
+		requestAnimationFrame(() => {
+			root.classList.remove('no-transition');
+		});
+	});
 }
 
 export function useTheme() {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -19,6 +19,15 @@ html[data-theme="light"] {
 	color-scheme: light;
 }
 
+/* Added by the theme switcher for the duration of one swap — many frappe-ui
+   components transition their colours, and letting them all animate at once
+   flashes the page. */
+.no-transition *,
+.no-transition *::before,
+.no-transition *::after {
+	transition: none !important;
+}
+
 /* Dialog open/close animations are disabled: reka-ui's Presence unmounts the
    overlay only after the leave animation's end event, and rapid open/close
    cycles (create dialog reused back-to-back) can lose that event — leaving a

--- a/wiki/public/css/theme.css
+++ b/wiki/public/css/theme.css
@@ -51,6 +51,14 @@ html, body, button, p, span, div {
     -moz-osx-font-smoothing: grayscale;
 }
 
+/* Added by the theme toggle for the duration of one swap — letting every
+   element with a colour transition animate at once flashes the page. */
+.no-transition *,
+.no-transition *::before,
+.no-transition *::after {
+    transition: none !important;
+}
+
 /* Native Select Styling */
 select {
     background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="%237C7C7C" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" aria-hidden="true" viewBox="0 0 24 24" ><path d="m6 9 6 6 6-6" /></svg>');

--- a/wiki/templates/wiki/includes/sidebar.html
+++ b/wiki/templates/wiki/includes/sidebar.html
@@ -93,8 +93,18 @@
             toggle() {
                 this.isDark = !this.isDark;
                 const newTheme = this.isDark ? 'dark' : 'light';
-                document.documentElement.setAttribute('data-theme', newTheme);
+                const root = document.documentElement;
+                // Suppress transitions for the swap itself, else every element
+                // with a colour transition animates and the page flashes. Two
+                // rAFs so the class survives the style + paint of the swap.
+                root.classList.add('no-transition');
+                root.setAttribute('data-theme', newTheme);
                 localStorage.setItem('wiki-theme', newTheme);
+                requestAnimationFrame(() => {
+                    requestAnimationFrame(() => {
+                        root.classList.remove('no-transition');
+                    });
+                });
             }
         });
 


### PR DESCRIPTION
## Problem

Switching light/dark strobes the page — the theme swap flips `data-theme` while every element with a colour transition is still animating, so each one lands at a different time.

## Solution

Suppress transitions for the duration of one swap, then release after two `requestAnimationFrame`s (so the class survives the style + paint of the swap). Applied to both surfaces:

- SPA editor: `frontend/src/composables/useTheme.js` + `.no-transition` rule in `frontend/src/index.css`
- Public reader: Alpine `theme` store in `sidebar.html` + `.no-transition` rule in `wiki/public/css/theme.css`

Ported from https://github.com/frappe/pilot/pull/367.