### PR TITLE
fix(mermaid): cache-bust the shared loader asset in the SPA

### DIFF
--- a/frontend/src/components/tiptap-extensions/mermaid-block.test.js
+++ b/frontend/src/components/tiptap-extensions/mermaid-block.test.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { getMermaid } from './mermaid-loader.js';
+import { getLoaderUrl, getMermaid } from './mermaid-loader.js';
 import { parseMermaidFence, renderMermaidFence } from './mermaid-markdown.js';
 import { SLASH_COMMANDS } from './slash-commands.js';
 
@@ -32,7 +32,7 @@ test('exposes a slash command for inserting mermaid diagrams', () => {
 test('loads mermaid through the shared public loader', async () => {
 	const originalWindow = global.window;
 	const mermaid = {};
-	let receivedOptions;
+	let receivedOptions = 'not called';
 
 	global.window = {
 		wikiGetMermaid(options) {
@@ -43,10 +43,33 @@ test('loads mermaid through the shared public loader', async () => {
 
 	try {
 		assert.equal(await getMermaid(), mermaid);
-		assert.equal(
-			receivedOptions.assetUrl,
-			'/assets/wiki/js/vendor/mermaid/mermaid.min.js',
-		);
+		// The shared loader owns (and versions) the vendor URL.
+		assert.equal(receivedOptions, undefined);
+	} finally {
+		global.window = originalWindow;
+	}
+});
+
+test('cache-busts the shared loader with the hash from boot', () => {
+	const originalWindow = global.window;
+
+	try {
+		global.window = { asset_hashes: { mermaid_loader: 'abc123' } };
+		assert.equal(getLoaderUrl(), '/assets/wiki/js/mermaid-loader.js?v=abc123');
+	} finally {
+		global.window = originalWindow;
+	}
+});
+
+test('falls back to the bare loader path when no hash is booted', () => {
+	const originalWindow = global.window;
+
+	try {
+		global.window = {};
+		assert.equal(getLoaderUrl(), '/assets/wiki/js/mermaid-loader.js');
+
+		global.window = { asset_hashes: {} };
+		assert.equal(getLoaderUrl(), '/assets/wiki/js/mermaid-loader.js');
 	} finally {
 		global.window = originalWindow;
 	}

--- a/frontend/src/components/tiptap-extensions/mermaid-loader.js
+++ b/frontend/src/components/tiptap-extensions/mermaid-loader.js
@@ -1,7 +1,16 @@
-const MERMAID_ASSET_URL = '/assets/wiki/js/vendor/mermaid/mermaid.min.js';
-const MERMAID_LOADER_URL = '/assets/wiki/js/mermaid-loader.js';
+const MERMAID_LOADER_PATH = '/assets/wiki/js/mermaid-loader.js';
 
 let loaderPromise = null;
+
+// `/assets` is served with far-future `immutable` caching, so requesting the
+// bare path pins whichever copy the browser fetched first — a pre-fix loader
+// keeps throwing for up to a year after the fix ships. The published reader
+// versions its own <script> tag server-side (layout.html); do the same here
+// with the hash the server puts on boot.
+export function getLoaderUrl() {
+	const hash = window.asset_hashes?.mermaid_loader;
+	return hash ? `${MERMAID_LOADER_PATH}?v=${hash}` : MERMAID_LOADER_PATH;
+}
 
 function loadSharedMermaidLoader() {
 	if (window.wikiGetMermaid) {
@@ -10,7 +19,7 @@ function loadSharedMermaidLoader() {
 	if (!loaderPromise) {
 		loaderPromise = new Promise((resolve, reject) => {
 			const script = document.createElement('script');
-			script.src = MERMAID_LOADER_URL;
+			script.src = getLoaderUrl();
 			script.onload = () => resolve(window.wikiGetMermaid);
 			script.onerror = () =>
 				reject(new Error('Unable to load Mermaid loader asset'));
@@ -28,7 +37,9 @@ function loadSharedMermaidLoader() {
 
 export async function getMermaid() {
 	const wikiGetMermaid = await loadSharedMermaidLoader();
-	return wikiGetMermaid({ assetUrl: MERMAID_ASSET_URL });
+	// No assetUrl override: the shared loader owns the Mermaid vendor URL, and
+	// versions it so a library bump isn't masked by the same immutable cache.
+	return wikiGetMermaid();
 }
 
 // Mermaid theme config derived from the live Frappe UI tokens (defined in the

--- a/wiki/public/js/mermaid-loader.js
+++ b/wiki/public/js/mermaid-loader.js
@@ -1,5 +1,10 @@
 (function () {
-  const defaultMermaidUrl = "/assets/wiki/js/vendor/mermaid/mermaid.min.js";
+  // The vendored bundle is served with far-future `immutable` caching, so the
+  // bare path would keep serving the previously fetched copy after a version
+  // bump. Bump this alongside the file in vendor/mermaid/.
+  const MERMAID_VERSION = "11.15.0";
+  const defaultMermaidUrl =
+    "/assets/wiki/js/vendor/mermaid/mermaid.min.js?v=" + MERMAID_VERSION;
 
   // Build a Mermaid theme config from the live Frappe UI design tokens so
   // diagrams match the wiki's look instead of Mermaid's stock palette. We read

--- a/wiki/www/wiki_app.py
+++ b/wiki/www/wiki_app.py
@@ -4,6 +4,8 @@
 import frappe
 from frappe.utils import get_system_timezone
 
+from wiki.utils import get_asset_hash
+
 no_cache = 1
 sitemap = 0
 
@@ -34,5 +36,17 @@ def get_boot():
 			"site_name": frappe.local.site,
 			"read_only_mode": frappe.flags.read_only,
 			"system_timezone": get_system_timezone(),
+			"asset_hashes": get_asset_hashes(),
 		}
 	)
+
+
+def get_asset_hashes() -> dict:
+	"""Content hashes for the app assets the SPA pulls in at runtime.
+
+	Those are served with far-future `immutable` caching, so a bare URL pins
+	whichever copy the browser fetched first — a stale one keeps failing long
+	after the fix ships. The SPA appends these hashes so a changed file is
+	always a new URL.
+	"""
+	return {"mermaid_loader": get_asset_hash("public/js/mermaid-loader.js")}


### PR DESCRIPTION
## Problem

The editor's Mermaid preview fails with `Unsupported color format: "oklch(.946 0 0)"` for anyone whose browser fetched the loader before the oklch normalization fix (294c642) shipped.

`/assets` is served with `Cache-Control: max-age=31536000, immutable`. The published reader versions its script tag (`layout.html` → `?v=<content hash>`), but the SPA requested the bare path, so the stale pre-fix copy is pinned for up to a year.

## Solution

- Put the loader's content hash on boot (`asset_hashes.mermaid_loader`) and append it to the URL in the SPA.
- Version the vendored `mermaid.min.js` URL too, so a library bump isn't masked by the same cache.

Covered by unit tests for the hash-present, hash-missing, and no-override cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)