### PR TITLE
fix: uploaded image overwrites an earlier one with the same filename

### DIFF
--- a/wiki/api/__init__.py
+++ b/wiki/api/__init__.py
@@ -67,7 +67,8 @@ def convert_file_to_webp(file_doc) -> str:
 	file_url. Returns the new (or unchanged, if not convertible) file_url.
 	"""
 	from frappe.core.doctype.file.file import get_local_image
-	from frappe.core.doctype.file.utils import delete_file
+	from frappe.core.doctype.file.utils import delete_file, generate_file_name
+	from frappe.utils import get_files_path
 
 	if not file_doc:
 		return ""
@@ -77,9 +78,11 @@ def convert_file_to_webp(file_doc) -> str:
 	if not file_url.startswith("/files") or not file_url.lower().endswith(CONVERTIBLE_IMAGE_EXTENSIONS):
 		return file_url
 
+	webp_name = generate_file_name(_to_webp(file_doc.file_name or os.path.basename(file_url)))
+
 	try:
 		image, _, _ = get_local_image(file_url)
-		image.save(_to_webp(file_doc.get_full_path()), "WEBP")
+		image.save(get_files_path(webp_name), "WEBP")
 	except Exception:
 		# Corrupt or unsupported image — keep the original upload rather than
 		# failing the whole request and losing the author's image.
@@ -90,9 +93,8 @@ def convert_file_to_webp(file_doc) -> str:
 	# must be given the /files/... url — not the absolute filesystem path.
 	delete_file(file_url)
 
-	file_doc.file_url = _to_webp(file_url)
-	if file_doc.file_name:
-		file_doc.file_name = _to_webp(file_doc.file_name)
+	file_doc.file_url = f"/files/{webp_name}"
+	file_doc.file_name = webp_name
 	file_doc.save()
 	return file_doc.file_url
 

--- a/wiki/test_api.py
+++ b/wiki/test_api.py
@@ -2,6 +2,8 @@
 # See license.txt
 
 import json
+import os
+from io import BytesIO
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
@@ -1083,3 +1085,43 @@ class TestWikiSpacePermissions(FrappeTestCase):
 		space.space_name = "Hacked Space Name"
 		with self.assertRaises(frappe.PermissionError):
 			space.save()
+
+
+class TestWikiWebpConversion(FrappeTestCase):
+	"""Tests for convert_file_to_webp."""
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		self.webp_paths = []
+
+	def tearDown(self):
+		for path in self.webp_paths:
+			if os.path.exists(path):
+				os.remove(path)
+		frappe.db.rollback()
+
+	def upload_png(self, color):
+		from PIL import Image
+
+		buffer = BytesIO()
+		Image.new("RGB", (8, 8), color).save(buffer, "PNG")
+		return frappe.get_doc(
+			{
+				"doctype": "File",
+				"file_name": "image.png",
+				"is_private": 0,
+				"content": buffer.getvalue(),
+			}
+		).insert()
+
+	def test_same_named_upload_does_not_overwrite_earlier_webp(self):
+		"""Clipboard pastes all arrive as `image.png`, so their `.webp` names must not collide."""
+		from frappe.utils import get_files_path
+
+		from wiki.api import convert_file_to_webp
+
+		first_url = convert_file_to_webp(self.upload_png((255, 0, 0)))
+		second_url = convert_file_to_webp(self.upload_png((0, 0, 255)))
+		self.webp_paths = [get_files_path(url.split("/files/")[-1]) for url in (first_url, second_url)]
+
+		self.assertNotEqual(first_url, second_url)


### PR DESCRIPTION
## Description

Pasted clipboard images were all saved as `image.png`, so their WebP versions were saved to the same `/files/image.webp` and overwrote previous images. One site had 26 File records pointing to the same URL.

The WebP filename now goes through `generate_file_name`, like normal Frappe uploads, to ensure each image gets a unique name. `file_url` and `file_name` are also updated to match the file actually saved.

Previously overwritten images cannot be recovered and need to be re-uploaded.

https://github.com/user-attachments/assets/43a087fb-5e83-4fd9-8d59-e7f429109ef5

---

Ref: https://support.frappe.io/helpdesk/tickets/76287?view=VIEW-HD+Ticket-1252