### PR TITLE
fix(wiki-space): clear tree cache when a space route is renamed

### DIFF
--- a/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
@@ -2448,6 +2448,32 @@ class TestWikiTreeCache(WikiDocumentTestBase):
 		tree = get_public_wiki_tree(root.name)
 		self.assertEqual([n["title"] for n in tree], ["Reorder B", "Reorder A"])
 
+	def test_tree_cache_busted_on_space_route_rename(self):
+		"""Wiki Space.update_routes() rewrites routes with raw SQL (no per-doc
+		save hooks), so it must bust the tree cache itself. Before this fix the
+		space URL kept redirecting to the pre-rename route forever, since
+		get_public_wiki_tree(root_group) is keyed by root_group name, which a
+		route rename never changes."""
+		from wiki.frappe_wiki.doctype.wiki_document.wiki_document import (
+			WIKI_TREE_CACHE_KEY,
+			get_public_wiki_tree,
+		)
+
+		root = create_test_wiki_document(self, "TreeCache RnRoot", is_group=True)
+		space = create_test_wiki_space(self, "TreeCache RnSpace", "tcrn-space", root.name)
+		create_test_wiki_document(self, "Rename Page", parent=root.name, slug="tcrn-page")
+
+		tree = get_public_wiki_tree(root.name)
+		self.assertEqual(tree[0]["route"], "tcrn-space/tcrn-page")
+		self.assertIsNotNone(frappe.cache().hget(WIKI_TREE_CACHE_KEY, root.name))
+
+		space.reload()
+		space.update_routes("tcrn-space-renamed")
+
+		self.assertIsNone(frappe.cache().hget(WIKI_TREE_CACHE_KEY, root.name))
+		tree = get_public_wiki_tree(root.name)
+		self.assertEqual(tree[0]["route"], "tcrn-space-renamed/tcrn-page")
+
 
 class TestSearchPublishGating(WikiDocumentTestBase):
 	"""

--- a/wiki/wiki/doctype/wiki_space/wiki_space.py
+++ b/wiki/wiki/doctype/wiki_space/wiki_space.py
@@ -261,6 +261,15 @@ class WikiSpace(Document):
 		clear_website_cache()
 		frappe.db.after_commit.add(clear_website_cache)
 
+		# The raw SQL above also bypasses the per-doc save hooks that normally
+		# bust the sidebar/landing-page tree cache, so the root group's cached
+		# tree keeps naming pre-rename routes — the space URL then 301s forever
+		# to a dead link until the cache expires or is cleared by hand.
+		# (clear_wiki_tree_cache re-clears after commit on its own.)
+		from wiki.frappe_wiki.doctype.wiki_document.wiki_document import clear_wiki_tree_cache
+
+		clear_wiki_tree_cache()
+
 		return {"updated_count": updated_count}
 
 	def _batch_update_document_routes(self, doc_names: list, old_route: str, new_route: str) -> int:


### PR DESCRIPTION
## Problem

`Wiki Space.update_routes()` rewrites Wiki Document routes with raw SQL, which
skips the per-doc save hooks that normally bust the sidebar/landing-page tree
cache (`WIKI_TREE_CACHE_KEY`, keyed by `root_group` name — unaffected by a
route rename). After renaming a space's route, the space URL kept
301-redirecting to the stale pre-rename route until the cache expired or was
cleared by hand (`clear_wiki_tree_cache()`).

## Solution

Call `clear_wiki_tree_cache()` in `update_routes()`, next to the existing
`clear_website_cache()` call that already handles the `website_404` cache for
the same rename. Added a regression test in `TestWikiTreeCache` (verified it
fails without the fix, passes with it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y3dqPy55nAtHN7vDA2nSU8