### PR TITLE
fix: PDF and video embeds break on filenames with spaces and parens

### DIFF
--- a/e2e/tests/embed-filename-parens.spec.ts
+++ b/e2e/tests/embed-filename-parens.spec.ts
@@ -1,0 +1,162 @@
+import { expect, test } from '@playwright/test';
+import { APP_BASE, spaceLinkSelector } from '../helpers/routes';
+import { openNewPageDialog } from '../helpers/wiki';
+
+/**
+ * Covers frappe/wiki#757.
+ *
+ * Frappe keeps the uploaded filename, so a second upload of the same file
+ * lands at `/files/name (2).pdf` — spaces and parens both. The tokenizers used
+ * to match the URL with `([^)]+)`, which stops at the inner `)`, and the
+ * truncated URL then failed the `.pdf` / video extension sniff. Nothing
+ * claimed the line, marked's default link rule rejected the unescaped spaces,
+ * and the embed showed up as raw markdown text.
+ */
+const PDF_URL = '/files/VIEW QUICK 2X5L (2).pdf';
+const PDF_MARKDOWN = `![VIEW QUICK 2X5L (2).pdf](${PDF_URL})`;
+
+const VIDEO_URL = '/files/my clip (1).mp4';
+const VIDEO_MARKDOWN = `![my clip (1).mp4](${VIDEO_URL})`;
+
+declare global {
+	interface Window {
+		wikiEditor: {
+			commands: {
+				setContent: (
+					content: string,
+					options?: { contentType?: string },
+				) => void;
+			};
+			getMarkdown: () => string;
+			getJSON: () => {
+				type: string;
+				content: { type: string; attrs?: Record<string, unknown> }[];
+			};
+		};
+	}
+}
+
+/**
+ * Create a draft page and open the editor. Mirrors the helper in
+ * iframe-embed.spec.ts — duplicated here rather than exported so changes
+ * to one test don't ripple into others.
+ */
+async function createDraftAndOpenEditor(
+	page: import('@playwright/test').Page,
+	title: string,
+) {
+	await page.goto(APP_BASE);
+	await page.waitForLoadState('networkidle');
+
+	const spaceLink = page.locator(spaceLinkSelector()).first();
+	await expect(spaceLink).toBeVisible({ timeout: 5000 });
+	await spaceLink.click();
+	await page.waitForLoadState('networkidle');
+
+	await openNewPageDialog(page);
+
+	await page.getByLabel('Title').fill(title);
+	await page.getByRole('dialog').getByRole('button', { name: 'Save' }).click();
+	await page.waitForLoadState('networkidle');
+
+	await page.locator('aside').getByText(title, { exact: true }).click();
+
+	const editor = page.locator('.ProseMirror, [contenteditable="true"]');
+	await expect(editor).toBeVisible({ timeout: 10000 });
+
+	await page.waitForFunction(() => window.wikiEditor !== undefined, {
+		timeout: 10000,
+	});
+	return editor;
+}
+
+test.describe('Embed filenames with spaces and parens', () => {
+	test('parses a PDF whose filename has spaces and parens into a node', async ({
+		page,
+	}) => {
+		await createDraftAndOpenEditor(page, `pdf-parens-parse-${Date.now()}`);
+
+		const result = await page.evaluate((markdown) => {
+			window.wikiEditor.commands.setContent(markdown, {
+				contentType: 'markdown',
+			});
+			const json = window.wikiEditor.getJSON();
+			const block = json.content?.find((n) => n.type === 'pdfBlock');
+			return {
+				hasBlock: !!block,
+				src: block?.attrs?.src as string | undefined,
+				filename: block?.attrs?.filename as string | undefined,
+			};
+		}, PDF_MARKDOWN);
+
+		// The whole point: the URL survives past the inner ")".
+		expect(result.hasBlock).toBe(true);
+		expect(result.src).toBe(PDF_URL);
+		expect(result.filename).toBe('VIEW QUICK 2X5L (2).pdf');
+	});
+
+	test('renders the PDF card rather than the raw markdown', async ({
+		page,
+	}) => {
+		const editor = await createDraftAndOpenEditor(
+			page,
+			`pdf-parens-render-${Date.now()}`,
+		);
+
+		await page.evaluate((markdown) => {
+			window.wikiEditor.commands.setContent(markdown, {
+				contentType: 'markdown',
+			});
+		}, PDF_MARKDOWN);
+
+		const card = page.locator('.wiki-pdf-wrapper .wiki-pdf-card');
+		await expect(card).toBeVisible({ timeout: 5000 });
+		await expect(card.locator('.wiki-pdf-name')).toHaveText(
+			'VIEW QUICK 2X5L (2).pdf',
+		);
+		// The reported symptom, asserted directly.
+		await expect(editor).not.toContainText('![VIEW QUICK');
+	});
+
+	test('round-trips the PDF markdown without truncating the URL', async ({
+		page,
+	}) => {
+		await createDraftAndOpenEditor(page, `pdf-parens-roundtrip-${Date.now()}`);
+
+		const { md1, md2 } = await page.evaluate((markdown) => {
+			window.wikiEditor.commands.setContent(markdown, {
+				contentType: 'markdown',
+			});
+			const md1 = window.wikiEditor.getMarkdown();
+			// Second pass: re-parse what we serialized. A page that degrades to
+			// text does it here, on the load after the save.
+			window.wikiEditor.commands.setContent(md1, { contentType: 'markdown' });
+			const md2 = window.wikiEditor.getMarkdown();
+			return { md1, md2 };
+		}, PDF_MARKDOWN);
+
+		expect(md1).toContain(PDF_MARKDOWN);
+		expect(md2).toContain(PDF_MARKDOWN);
+	});
+
+	test('parses a video whose filename has spaces and parens into a node', async ({
+		page,
+	}) => {
+		await createDraftAndOpenEditor(page, `video-parens-parse-${Date.now()}`);
+
+		const result = await page.evaluate((markdown) => {
+			window.wikiEditor.commands.setContent(markdown, {
+				contentType: 'markdown',
+			});
+			const json = window.wikiEditor.getJSON();
+			const block = json.content?.find((n) => n.type === 'videoBlock');
+			return {
+				hasBlock: !!block,
+				src: block?.attrs?.src as string | undefined,
+			};
+		}, VIDEO_MARKDOWN);
+
+		expect(result.hasBlock).toBe(true);
+		expect(result.src).toBe(VIDEO_URL);
+	});
+});

--- a/frontend/src/components/tiptap-extensions/pdf-block.js
+++ b/frontend/src/components/tiptap-extensions/pdf-block.js
@@ -132,14 +132,16 @@ export const PdfBlock = Node.create({
 		},
 
 		tokenize(src) {
-			const match = /^!\[([^\]]*)\]\(([^)]+)\)/.exec(src);
+			const imagePattern =
+				/^!\[([^\]]*)\]\(((?:[^()"]|\([^()"]*\))+?)(?:\s+"([^"]*)")?\)/;
+			const match = imagePattern.exec(src);
 
 			if (!match) {
 				return undefined;
 			}
 
 			const filename = match[1];
-			const url = match[2];
+			const url = (match[2] || '').trim();
 
 			// Only tokenize when it's a PDF URL — otherwise let the image/video
 			// tokenizers handle it.

--- a/frontend/src/components/tiptap-extensions/video-block.js
+++ b/frontend/src/components/tiptap-extensions/video-block.js
@@ -162,14 +162,16 @@ export const VideoBlock = Node.create({
 
 		tokenize(src) {
 			// Match markdown image syntax: ![alt](url)
-			const match = /^!\[([^\]]*)\]\(([^)]+)\)/.exec(src);
+			const imagePattern =
+				/^!\[([^\]]*)\]\(((?:[^()"]|\([^()"]*\))+?)(?:\s+"([^"]*)")?\)/;
+			const match = imagePattern.exec(src);
 
 			if (!match) {
 				return undefined;
 			}
 
 			const alt = match[1];
-			const url = match[2];
+			const url = (match[2] || '').trim();
 
 			// Only tokenize if it's a video URL
 			if (!isVideoUrl(url)) {

--- a/wiki/wiki/markdown.py
+++ b/wiki/wiki/markdown.py
@@ -211,7 +211,7 @@ def _remove_script_tags(value: str | None) -> str:
 # Match full-line markdown image syntax with optional title:
 # ![alt](url) or ![alt](url "title")
 VIDEO_MARKDOWN_PATTERN = re.compile(
-	r'^!\[(?P<alt>[^\]]*)\]\((?P<url>[^)"\s]+)(?:\s+"(?P<title>[^"]*)")?\)[ \t]*$',
+	r'^!\[(?P<alt>[^\]]*)\]\((?P<url>(?:[^()"\s]|\([^()"\s]*\))+?)(?:\s+"(?P<title>[^"]*)")?\)[ \t]*$',
 	re.MULTILINE,
 )
 

--- a/wiki/wiki/test_markdown.py
+++ b/wiki/wiki/test_markdown.py
@@ -834,6 +834,17 @@ class TestBlankLinePreservation(unittest.TestCase):
 		self.assertEqual(self._gaps(wide), 2)
 		self.assertIn("wiki-pdf-embed", render_markdown(before))
 
+	def test_embed_filename_with_spaces_and_parens_stays_a_block(self):
+		"""Frappe keeps the uploaded filename, so `(2)` and spaces are routine.
+		The embed must still become a block card, not an inline image inside a <p>."""
+		html = render_markdown("![VIEW QUICK 2X5L (2).pdf](/files/VIEW QUICK 2X5L (2).pdf)")
+		self.assertIn("wiki-pdf-embed", html)
+		self.assertNotIn('<p><div class="wiki-pdf-embed"', html)
+
+		html = render_markdown("![my clip (1).mp4](/files/my clip (1).mp4)")
+		self.assertIn('data-type="video-block"', html)
+		self.assertNotIn('<p><div data-type="video-block"', html)
+
 	def test_adjacent_placeholders_do_not_gain_a_gap(self):
 		"""Two custom blocks one newline apart: each side contributes a newline to
 		break the placeholder out as a block, giving three — still one short of the


### PR DESCRIPTION
Closes #757

### Problem

A PDF embed collapses to its raw markdown once the page is reloaded:

![before: the editor renders the embed as literal markdown text](https://github.com/user-attachments/assets/1813955e-2b3c-4df5-9fe3-a2d8a8cf3f88)

The trigger is the filename, not the merge. Frappe keeps the uploaded name, and
`(2)` is what a duplicate upload gets.

### Cause

`pdf-block.js` and `video-block.js` matched the URL with `([^)]+)`, which stops
at the inner `)`. The URL came back as `/files/VIEW QUICK 2X5L (2`, so the
`.pdf` sniff failed and the tokenizer bailed. `wikiImage` had already declined
the token because its own regex parses the URL correctly and sees a PDF, so
nothing claimed it and marked's default link rule ran. CommonMark forbids
unescaped spaces in a bare destination, so it printed the source verbatim.

`image-extension.js` was fixed for this filename shape already; the two
tokenizers were copies that never got the update.

Server side, `VIDEO_MARKDOWN_PATTERN` had the same flaw. Spaces are escaped
before it runs, so only the parens bit: the placeholder pass missed and the card
was emitted by the inline image renderer, landing inside a `<p>`.

It looks fine while editing because the editor session holds live `pdfBlock`
nodes. The damage shows on the next parse of the stored markdown, which is what
the post-merge load does.

### Fix

- `pdf-block.js`, `video-block.js`: use the URL pattern `image-extension.js`
  already uses, allowing spaces and one level of balanced parens.
- `markdown.py`: same group in `VIDEO_MARKDOWN_PATTERN`, so embeds become block
  cards instead of paragraph-nested inline images.

The same card, after the fix:

![after: the embed renders as a PDF card with filename, page count and thumbnail](https://github.com/user-attachments/assets/e4e370a8-d750-4a55-84d1-fa1d44b5e1f4)

### Testing

Uploaded a real PDF, which Frappe stored as `/files/VIEW QUICK 2X5L (2).pdf`,
and put the embed in a wiki document on a local site.

- Before: the editor shows the literal markdown line, matching the report.
- After: the card renders with filename, page count and first-page thumbnail,
  on both the editor and the public reader.
- Saving from the editor writes the markdown back byte-identical, so content no
  longer degrades on a round-trip.
- `python -m unittest wiki.wiki.test_markdown`: 80 tests, OK.
- `e2e/tests/embed-filename-parens.spec.ts` covers the two JS tokenizers the
  Python suite cannot reach: PDF and video parse into nodes, the card renders
  instead of raw text, and the markdown round-trips. Checked against the
  pre-fix build too, where all four fail, the round-trip one by serializing
  `!\[VIEW QUICK 2X5L (2).pdf\](...)` back to the page.

Loading the page, the card rendering, and the full-screen viewer opening on a
filename with spaces and parens:

https://github.com/user-attachments/assets/abb7fa35-abb2-4ffc-b238-1e6b344b801a

