### PR TITLE
feat(change-request): let authors submit part of a draft

### DIFF
--- a/e2e/tests/partial-submit.spec.ts
+++ b/e2e/tests/partial-submit.spec.ts
@@ -1,0 +1,150 @@
+import { expect, test } from '@playwright/test';
+import { callMethod, getList } from '../helpers/frappe';
+import { CHANGE_REQUEST_URL_RE, SPACE_URL_RE, appUrl } from '../helpers/routes';
+import { openNewPageDialog } from '../helpers/wiki';
+
+const CR_METHOD =
+	'wiki.frappe_wiki.doctype.wiki_change_request.wiki_change_request';
+
+interface ChangeRequestRow {
+	name: string;
+	status: string;
+}
+
+/**
+ * A change request is space-level: everything edited before submitting rides
+ * along with it. The submit dialog is where an author splits that
+ * apart — send one page for review, keep working on the others.
+ */
+test.describe('Partial submit', () => {
+	test('submits the ticked pages and leaves the rest as a draft', async ({
+		page,
+		request,
+	}) => {
+		await page.goto(appUrl('spaces'));
+		await page.waitForLoadState('networkidle');
+
+		await page.getByRole('button', { name: 'New Space' }).click();
+		await page.waitForSelector('[role="dialog"]', { state: 'visible' });
+
+		const timestamp = Date.now();
+		await page.getByLabel('Space Name').fill(`Partial Submit ${timestamp}`);
+		await page.getByLabel('Route').fill(`partial-submit-${timestamp}`);
+		await page
+			.getByRole('dialog')
+			.getByRole('button', { name: 'Create' })
+			.click();
+		await page.waitForLoadState('networkidle');
+		await expect(page).toHaveURL(SPACE_URL_RE);
+
+		const spaceUrl = page.url();
+		const spaceId = decodeURIComponent(spaceUrl.split('/').pop() as string);
+		const pageTitles = [0, 1, 2].map(
+			(index) => `partial-page-${index}-${timestamp}`,
+		);
+
+		// Three page drafts on one change request.
+		for (const title of pageTitles) {
+			await page.goto(spaceUrl);
+			await page.waitForLoadState('networkidle');
+			await openNewPageDialog(page);
+			await page.getByLabel('Title').fill(title);
+			await page
+				.getByRole('dialog')
+				.getByRole('button', { name: 'Save' })
+				.click();
+			await page.waitForTimeout(500);
+
+			await page.locator('aside').getByText(title, { exact: true }).click();
+			await page.waitForURL(/\/draft\/[^/?#]+/);
+			const editor = page
+				.locator('.ProseMirror, [contenteditable="true"]')
+				.first();
+			await expect(editor).toBeVisible({ timeout: 10000 });
+			await page.waitForFunction(() => window.wikiEditor !== undefined, {
+				timeout: 10000,
+			});
+			await page.evaluate((content) => {
+				window.wikiEditor.commands.setContent(content, {
+					contentType: 'markdown',
+				});
+			}, `Body of ${title}`);
+			await editor.click();
+			await page.getByRole('button', { name: 'Save' }).click();
+			await page.waitForTimeout(500);
+		}
+
+		await page.getByRole('button', { name: 'Submit for Review' }).click();
+		const dialog = page.getByRole('dialog');
+		await expect(dialog.getByText('3 of 3 selected')).toBeVisible();
+
+		// Untick the last two — only the first page goes for review.
+		for (const title of pageTitles.slice(1)) {
+			await dialog
+				.locator('label', { hasText: title })
+				.getByRole('checkbox')
+				.uncheck();
+		}
+		await expect(dialog.getByText('1 of 3 selected')).toBeVisible();
+		await page.screenshot({ path: 'test-results/partial-submit-dialog.png' });
+
+		await dialog.getByRole('button', { name: 'Submit', exact: true }).click();
+		await expect(page).toHaveURL(CHANGE_REQUEST_URL_RE, { timeout: 10000 });
+		await expect(page.getByText('2 changes stayed in your draft')).toBeVisible({
+			timeout: 10000,
+		});
+
+		// The review page carries one page; the other two are back in a draft.
+		await expect(page.getByText('Changes (1)')).toBeVisible({ timeout: 10000 });
+		const crs = await getList<ChangeRequestRow>(
+			request,
+			'Wiki Change Request',
+			{
+				fields: ['name', 'status'],
+				filters: { wiki_space: spaceId },
+				limit: 10,
+			},
+		);
+		expect(crs.filter((cr) => cr.status === 'In Review')).toHaveLength(1);
+
+		// The two unticked pages live on a draft the author can keep editing.
+		// (Opening the space editor also leaves empty drafts behind, so match on
+		// the one that actually carries changes.)
+		const draftChangeCounts: number[] = [];
+		for (const cr of crs.filter((row) => row.status === 'Draft')) {
+			const changes = await callMethod<{ doc_key: string }[]>(
+				request,
+				`${CR_METHOD}.diff_change_request`,
+				{ name: cr.name },
+			);
+			draftChangeCounts.push(changes.length);
+		}
+		expect(draftChangeCounts.filter((count) => count > 0)).toEqual([2]);
+
+		// Merging the submitted one publishes only its page.
+		await page.getByRole('button', { name: 'Approve', exact: true }).click();
+		await expect(page.getByText('Change request approved')).toBeVisible({
+			timeout: 15000,
+		});
+		await page.getByRole('button', { name: 'Merge', exact: true }).click();
+		await expect(page.getByText('Change request merged')).toBeVisible({
+			timeout: 20000,
+		});
+
+		const live = await getList<{ title: string }>(request, 'Wiki Document', {
+			fields: ['title'],
+			filters: { title: ['like', `partial-page-%-${timestamp}`] },
+			limit: 10,
+		});
+		expect(live.map((doc) => doc.title)).toEqual([pageTitles[0]]);
+
+		// The held-back pages are still editable in the space.
+		await page.goto(spaceUrl);
+		await page.waitForLoadState('networkidle');
+		for (const title of pageTitles.slice(1)) {
+			await expect(
+				page.locator('aside').getByText(title, { exact: true }),
+			).toBeVisible({ timeout: 10000 });
+		}
+	});
+});

--- a/frontend/src/components/ContributionBanner.vue
+++ b/frontend/src/components/ContributionBanner.vue
@@ -161,7 +161,7 @@
 			</template>
 		</Dialog>
 
-		<Dialog v-model:open="showSubmitConfirmDialog" size="sm">
+		<Dialog v-model:open="showSubmitConfirmDialog" size="md">
 			<template #title>
 				<div class="flex items-center gap-2">
 					<span class="lucide-git-branch size-5 text-ink-gray-5" aria-hidden="true" />
@@ -172,10 +172,45 @@
 			</template>
 			<template #default>
 				<p class="text-ink-gray-7">
-					{{ __('Are you sure you want to submit your changes for review?') }}
+					{{ __('Pick the changes to send for review. The rest stay in your draft.') }}
 				</p>
+
+				<div class="mt-4 border border-outline-gray-2 rounded-lg overflow-hidden">
+					<label
+						class="flex items-center gap-2 px-3 py-2 border-b border-outline-gray-2 bg-surface-gray-1 cursor-pointer"
+					>
+						<Checkbox
+							:model-value="allSelected"
+							:indeterminate="someSelected && !allSelected"
+							@update:model-value="toggleAll"
+						/>
+						<span class="text-sm-medium text-ink-gray-7">
+							{{ __('{0} of {1} selected', [submitSelection.length, crStore.changeCount]) }}
+						</span>
+					</label>
+
+					<div class="max-h-[40vh] overflow-y-auto divide-y divide-outline-gray-2">
+						<label
+							v-for="change in crStore.changes"
+							:key="change.doc_key"
+							class="flex items-center gap-3 px-3 py-2 cursor-pointer hover:bg-surface-gray-1"
+						>
+							<Checkbox
+								:model-value="submitSelection.includes(change.doc_key)"
+								@update:model-value="toggleChange(change.doc_key, $event)"
+							/>
+							<span class="flex-1 min-w-0 truncate text-ink-gray-8">
+								{{ change.title || __('Untitled') }}
+							</span>
+							<Badge variant="subtle" :theme="getChangeTheme(change.change_type)" size="sm">
+								{{ getChangeLabel(change.change_type) }}
+							</Badge>
+						</label>
+					</div>
+				</div>
+
 				<p class="text-sm text-ink-gray-5 mt-2">
-					{{ __('You have {0} pending {1}.', [crStore.changeCount, crStore.changeCount === 1 ? __('change') : __('changes')]) }}
+					{{ __('A page inside a new or deleted group is submitted along with it.') }}
 				</p>
 			</template>
 			<template #actions="{ close }">
@@ -184,6 +219,7 @@
 					<Button
 						variant="solid"
 						:loading="crStore.isSubmitting"
+						:disabled="submitSelection.length === 0"
 						@click="confirmSubmit(close)"
 					>
 						{{ __('Submit') }}
@@ -198,7 +234,7 @@ import { useChangeTypeDisplay } from '@/composables/useChangeTypeDisplay';
 import { useChangeRequestStore } from '@/stores/changeRequest';
 import { useDraftWorkspaceStore } from '@/stores/draftWorkspace';
 import { useUserStore } from '@/stores/user';
-import { Badge, Button, Dialog, Dropdown, toast } from 'frappe-ui';
+import { Badge, Button, Checkbox, Dialog, Dropdown, toast } from 'frappe-ui';
 import { computed, ref, watch } from 'vue';
 import SpaceChromeBar from './SpaceChromeBar.vue';
 
@@ -355,9 +391,43 @@ watch(
 const showChangesDialog = ref(false);
 const showSubmitConfirmDialog = ref(false);
 
+// The dialog opens with everything ticked, so the default stays "submit my
+// whole draft"; unticking is how an author splits one page out of it.
+const submitSelection = ref([]);
+
+watch(showSubmitConfirmDialog, (open) => {
+	if (open) {
+		submitSelection.value = crStore.changes.map((change) => change.doc_key);
+	}
+});
+
+const allSelected = computed(
+	() =>
+		crStore.changeCount > 0 &&
+		submitSelection.value.length === crStore.changeCount,
+);
+const someSelected = computed(() => submitSelection.value.length > 0);
+
+function toggleAll(checked) {
+	submitSelection.value = checked
+		? crStore.changes.map((change) => change.doc_key)
+		: [];
+}
+
+function toggleChange(docKey, checked) {
+	if (checked) {
+		if (!submitSelection.value.includes(docKey)) {
+			submitSelection.value = [...submitSelection.value, docKey];
+		}
+		return;
+	}
+	submitSelection.value = submitSelection.value.filter((key) => key !== docKey);
+}
+
 function confirmSubmit(closeDialog) {
+	const selected = [...submitSelection.value];
 	closeDialog();
-	emit('submit');
+	emit('submit', selected);
 }
 
 const canShowMerge = computed(() => {

--- a/frontend/src/components/ContributionBanner.vue
+++ b/frontend/src/components/ContributionBanner.vue
@@ -181,11 +181,16 @@
 					>
 						<Checkbox
 							:model-value="allSelected"
+							:disabled="loadingSubmitChanges"
 							:indeterminate="someSelected && !allSelected"
 							@update:model-value="toggleAll"
 						/>
 						<span class="text-sm-medium text-ink-gray-7">
-							{{ __('{0} of {1} selected', [submitSelection.length, crStore.changeCount]) }}
+							{{
+								loadingSubmitChanges
+									? __('Loading changes…')
+									: __('{0} of {1} selected', [submitSelection.length, crStore.changeCount])
+							}}
 						</span>
 					</label>
 
@@ -219,7 +224,7 @@
 					<Button
 						variant="solid"
 						:loading="crStore.isSubmitting"
-						:disabled="submitSelection.length === 0"
+						:disabled="loadingSubmitChanges || submitSelection.length === 0"
 						@click="confirmSubmit(close)"
 					>
 						{{ __('Submit') }}
@@ -394,10 +399,20 @@ const showSubmitConfirmDialog = ref(false);
 // The dialog opens with everything ticked, so the default stays "submit my
 // whole draft"; unticking is how an author splits one page out of it.
 const submitSelection = ref([]);
+const loadingSubmitChanges = ref(false);
 
-watch(showSubmitConfirmDialog, (open) => {
-	if (open) {
-		submitSelection.value = crStore.changes.map((change) => change.doc_key);
+// Re-read the summary before ticking anything: a change the dialog never
+// listed would otherwise be treated as one the author deliberately left out,
+// and quietly held back from the review.
+watch(showSubmitConfirmDialog, async (open) => {
+	if (!open) return;
+	submitSelection.value = [];
+	loadingSubmitChanges.value = true;
+	try {
+		const changes = await crStore.loadChanges();
+		submitSelection.value = changes.map((change) => change.doc_key);
+	} finally {
+		loadingSubmitChanges.value = false;
 	}
 });
 

--- a/frontend/src/pages/SpaceDetails.vue
+++ b/frontend/src/pages/SpaceDetails.vue
@@ -845,15 +845,15 @@ function finalizationError(action) {
 	return null;
 }
 
-async function handleSubmitChangeRequest() {
+async function handleSubmitChangeRequest(docKeys = null) {
 	const blockerMessage = finalizationError(__('submitting'));
 	if (blockerMessage) {
 		toast.error(blockerMessage);
 		return;
 	}
 	try {
-		const result = await crStore.submitForReview();
-		toast.success(__('Change request submitted for review'));
+		const result = await crStore.submitForReview(docKeys);
+		toast.success(submitToastMessage(result));
 		if (result?.name) {
 			router.push({
 				name: 'ChangeRequestReview',
@@ -863,6 +863,24 @@ async function handleSubmitChangeRequest() {
 	} catch (error) {
 		toast.error(error.messages?.[0] || __('Error submitting for review'));
 	}
+}
+
+function submitToastMessage(result) {
+	const heldBack = result?.held_back?.length || 0;
+	const autoIncluded = result?.auto_included?.length || 0;
+	if (!heldBack && !autoIncluded) {
+		return __('Change request submitted for review');
+	}
+	if (!heldBack) {
+		return __('Submitted for review with {0} related {1}', [
+			autoIncluded,
+			autoIncluded === 1 ? __('page') : __('pages'),
+		]);
+	}
+	return __('Submitted for review. {0} {1} stayed in your draft.', [
+		heldBack,
+		heldBack === 1 ? __('change') : __('changes'),
+	]);
 }
 
 async function handleArchiveChangeRequest() {

--- a/frontend/src/stores/changeRequest.js
+++ b/frontend/src/stores/changeRequest.js
@@ -142,12 +142,14 @@ export const useChangeRequestStore = defineStore('changeRequest', () => {
 		return loadChangesPromise;
 	}
 
-	async function submitForReview() {
+	async function submitForReview(docKeys = null) {
 		if (!currentChangeRequest.value) return null;
-		await submitReviewResource.submit({
-			name: currentChangeRequest.value.name,
+		const name = currentChangeRequest.value.name;
+		const result = await submitReviewResource.submit({
+			name,
+			...(docKeys ? { doc_keys: docKeys } : {}),
 		});
-		return currentChangeRequest.value;
+		return { name, ...(result || {}) };
 	}
 
 	async function archiveChangeRequest() {

--- a/specs/partial_change_request_submit.md
+++ b/specs/partial_change_request_submit.md
@@ -1,0 +1,109 @@
+# Partial Change Request Submit — split the draft on submit
+
+Date: 2026-09-07
+Status: **Implemented (2026-09-07).** As-built notes inline.
+Issue: [frappe/wiki#761](https://github.com/frappe/wiki/issues/761)
+
+## Problem
+
+A change request is space-level: `get_or_create_draft_change_request` reuses the author's
+single open draft per space (`_find_existing_draft`), so every page edited before submitting
+lands on one CR's head revision. Approve and Merge act on the CR, so they take every page in
+it. #761 reports this as "approving one draft merges the others" — reproduced, and confirmed
+to be the model rather than a status cascade: three *separate* CRs stay independent.
+
+The author has no way to send one page for review and keep working on the rest. Their only
+option today is to submit after every page.
+
+## Goal
+
+Let the author choose which changes go into review. Unselected changes stay behind in a draft
+they can keep editing.
+
+**Non-goal:** per-page approval on the reviewer side. Once submitted, a CR is still reviewed
+and merged as one unit. Splitting at submit gives the same outcome with a much smaller blast
+radius than teaching approve/merge to work on a subset.
+
+## Model
+
+Submit takes an optional set of `doc_keys`.
+
+- Omitted (or covering every change) → today's behaviour exactly.
+- A subset → the **unselected** changes are moved out into a new `Draft` CR off the *same
+  base revision*, and the original CR is submitted with what is left. The submitted CR keeps
+  its name, so the review route and the author's local draft store are unaffected.
+
+Moving a change means re-pointing its `Wiki Revision Item` row from the old head revision to
+the new one. Content blobs are shared and immutable, so nothing is copied. Both revisions are
+marked `hashes_stale`; `has_revision_changes` recomputes on next read.
+
+### Dependency closure
+
+A selection is expanded so neither CR is left referencing a page its base does not have:
+
+- **Up** — for a selected key, every ancestor in the head tree that is *new in this CR*
+  (changed and absent from the base) comes along. Otherwise the submitted tree has a
+  `parent_key` pointing at a page that does not exist yet.
+- **Down** — a selected key that is new, or deleted, pulls its changed descendants. A new
+  group travels with its new pages; a deleted group travels with the descendants the delete
+  cascade already marked (`_delete_cr_item`).
+
+The closure runs server-side and the response reports what it added, so the UI can say so.
+
+## Implementation
+
+### Backend — `wiki/frappe_wiki/doctype/wiki_change_request/wiki_change_request.py`
+
+- `submit_change_request(name, doc_keys=None)` — unchanged guards (`write` permission,
+  `Draft` / `Changes Requested`, has-changes). With `doc_keys`: intersect with the CR's actual
+  changed keys, throw `ValidationError` on an empty selection, expand the closure, split off
+  the rest, then flip to `In Review`.
+  Returns `{change_request, submitted, auto_included, held_back, held_back_change_request}`
+  (it returned `None` before; no caller depended on that).
+- `_expand_selection(cr, selected, changed)` — the closure above.
+- `_split_off_changes(cr, doc_keys)` — new overlay off `cr.base_revision`, new `Draft` CR with
+  the same title/space/description, re-point the rows, mark both revisions stale. Returns the
+  new CR name, or `None` when there is nothing to move.
+
+### Frontend
+
+- `stores/changeRequest.js`: `submitForReview(docKeys)` passes `doc_keys` and returns the
+  server payload merged with the CR name.
+- `components/ContributionBanner.vue`: the Submit-for-Review dialog becomes a checkbox list of
+  pending changes (all selected by default, Submit disabled with none selected), reusing
+  `useChangeTypeDisplay` for the icon/label so it matches the Pending Changes dialog.
+- `pages/SpaceDetails.vue`: pass the selection through; when the server held changes back, the
+  toast says how many stayed in the draft, and when the closure pulled extra pages in, it says
+  that too.
+
+### Tests
+
+- Unit (`test_wiki_change_request.py`): subset submit leaves the rest in a new draft CR;
+  merging the submitted CR publishes only its pages; closure pulls an added parent group;
+  closure pulls a deleted group's descendants; empty selection throws; a full selection creates
+  no second CR.
+- E2E (`e2e/tests/partial-submit.spec.ts`): three page drafts, submit one, the other two are
+  still editable in the space, and merging publishes one page.
+
+## Notes / limitations
+
+- **Reorders.** A reorder renumbers siblings, so splitting a reorder can move a page's
+  `order_index` into a CR whose base has different neighbours. The merge already reconciles
+  sort order (`_reconcile_sort_order`); we accept the fuzz rather than forcing the whole
+  sibling set into one CR.
+- **Local-first drafts.** Submit is already blocked while local mutations are unsynced or the
+  editor has unsaved content (`finalizationBlocker`), so no IndexedDB draft can be stranded on
+  the wrong CR by the split.
+- **Held-back CR is the next draft.** `_find_existing_draft` prefers an open draft with
+  changes, so returning to the space picks up the leftover automatically. Verified in
+  `test_leftover_draft_is_what_the_author_gets_back`.
+- **Merge from the banner is still whole-CR.** A manager's self-serve Merge in the editor
+  publishes the entire change request; only submit takes a selection. Splitting first, then
+  merging, is the path if they want part of it live.
+
+## As-built
+
+Shipped as specced. Both halves of the backend were verified by temp-revert: dropping the
+split fails 3 tests, dropping the closure fails the other 3. Full module: 113 unit tests pass.
+E2E `partial-submit.spec.ts` plus the 15 existing `change-request-flow.spec.ts` tests pass
+against the built frontend.

--- a/wiki/frappe_wiki/doctype/wiki_change_request/test_wiki_change_request.py
+++ b/wiki/frappe_wiki/doctype/wiki_change_request/test_wiki_change_request.py
@@ -2681,6 +2681,15 @@ class TestPartialSubmit(FrappeTestCase):
 
 		self.assertEqual(frappe.db.get_value("Wiki Change Request", cr.name, "status"), "Draft")
 
+	def test_non_list_selection_is_rejected(self):
+		_space, _root_key, cr, keys = self._space_with_three_pages()
+
+		for bad in ('"not-a-list"', 5, {"doc_key": keys[0]}, [keys[0], 7]):
+			with self.assertRaises(frappe.ValidationError):
+				submit_change_request(cr.name, doc_keys=bad)
+
+		self.assertEqual(frappe.db.get_value("Wiki Change Request", cr.name, "status"), "Draft")
+
 	def test_selection_pulls_in_a_new_parent_group(self):
 		space = create_test_wiki_space()
 		root_key = frappe.get_value("Wiki Document", space.root_group, "doc_key")

--- a/wiki/frappe_wiki/doctype/wiki_change_request/test_wiki_change_request.py
+++ b/wiki/frappe_wiki/doctype/wiki_change_request/test_wiki_change_request.py
@@ -2598,6 +2598,174 @@ class TestWikiChangeRequestTabs(FrappeTestCase):
 # Helpers
 
 
+class TestPartialSubmit(FrappeTestCase):
+	"""Submitting a subset of a draft's changes.
+
+	A change request is space-level, so everything the author edited before
+	submitting rides along. These cover the split that lets them send one page
+	for review and keep the rest as a draft.
+	"""
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def _space_with_three_pages(self):
+		space = create_test_wiki_space()
+		root_key = frappe.get_value("Wiki Document", space.root_group, "doc_key")
+		cr = create_change_request(space.name, "Partial submit CR")
+		keys = [
+			create_cr_page(
+				cr.name,
+				parent_key=root_key,
+				title=f"Page {index}",
+				slug=f"page-{index}",
+				is_group=0,
+				is_published=1,
+				content=f"Body {index}",
+			)
+			for index in range(3)
+		]
+		return space, root_key, cr, keys
+
+	def test_subset_submit_leaves_the_rest_in_a_new_draft(self):
+		space, _root_key, cr, keys = self._space_with_three_pages()
+
+		result = submit_change_request(cr.name, doc_keys=[keys[0]])
+
+		self.assertEqual(frappe.db.get_value("Wiki Change Request", cr.name, "status"), "In Review")
+		leftover = result["held_back_change_request"]
+		self.assertIsNotNone(leftover)
+		self.assertEqual(frappe.db.get_value("Wiki Change Request", leftover, "status"), "Draft")
+		self.assertEqual(result["submitted"], [keys[0]])
+		self.assertEqual(sorted(result["held_back"]), sorted(keys[1:]))
+
+		submitted_keys = {change["doc_key"] for change in diff_change_request(cr.name)}
+		leftover_keys = {change["doc_key"] for change in diff_change_request(leftover)}
+		self.assertEqual(submitted_keys, {keys[0]})
+		self.assertEqual(leftover_keys, set(keys[1:]))
+
+		# The leftover draft branches off the same base, not off the live tree.
+		self.assertEqual(
+			frappe.db.get_value("Wiki Change Request", leftover, "base_revision"), cr.base_revision
+		)
+
+	def test_merging_a_subset_publishes_only_its_pages(self):
+		space, _root_key, cr, keys = self._space_with_three_pages()
+		submit_change_request(cr.name, doc_keys=[keys[0]])
+
+		_approve_and_merge(cr.name)
+
+		live = frappe.get_all(
+			"Wiki Document",
+			filters={"parent_wiki_document": space.root_group},
+			pluck="title",
+		)
+		self.assertEqual(live, ["Page 0"])
+
+	def test_full_selection_does_not_split(self):
+		_space, _root_key, cr, keys = self._space_with_three_pages()
+
+		result = submit_change_request(cr.name, doc_keys=keys)
+
+		self.assertIsNone(result["held_back_change_request"])
+		self.assertEqual(result["held_back"], [])
+		self.assertEqual(
+			frappe.db.count("Wiki Change Request", {"wiki_space": cr.wiki_space, "status": "Draft"}), 0
+		)
+
+	def test_empty_selection_is_rejected(self):
+		_space, _root_key, cr, _keys = self._space_with_three_pages()
+
+		with self.assertRaises(frappe.ValidationError):
+			submit_change_request(cr.name, doc_keys=[])
+
+		self.assertEqual(frappe.db.get_value("Wiki Change Request", cr.name, "status"), "Draft")
+
+	def test_selection_pulls_in_a_new_parent_group(self):
+		space = create_test_wiki_space()
+		root_key = frappe.get_value("Wiki Document", space.root_group, "doc_key")
+		cr = create_change_request(space.name, "Nested CR")
+		group_key = create_cr_page(
+			cr.name,
+			parent_key=root_key,
+			title="New Group",
+			slug="new-group",
+			is_group=1,
+			is_published=1,
+			content="",
+		)
+		child_key = create_cr_page(
+			cr.name,
+			parent_key=group_key,
+			title="Nested Page",
+			slug="nested-page",
+			is_group=0,
+			is_published=1,
+			content="Nested body",
+		)
+
+		result = submit_change_request(cr.name, doc_keys=[child_key])
+
+		# The group is new in this CR, so it cannot stay behind.
+		self.assertEqual(sorted(result["submitted"]), sorted([group_key, child_key]))
+		self.assertEqual(result["auto_included"], [group_key])
+		self.assertIsNone(result["held_back_change_request"])
+
+	def test_selecting_a_new_group_keeps_its_pages_with_it(self):
+		space = create_test_wiki_space()
+		root_key = frappe.get_value("Wiki Document", space.root_group, "doc_key")
+		cr = create_change_request(space.name, "Group CR")
+		group_key = create_cr_page(
+			cr.name,
+			parent_key=root_key,
+			title="New Group",
+			slug="new-group",
+			is_group=1,
+			is_published=1,
+			content="",
+		)
+		child_key = create_cr_page(
+			cr.name,
+			parent_key=group_key,
+			title="Nested Page",
+			slug="nested-page",
+			is_group=0,
+			is_published=1,
+			content="Nested body",
+		)
+
+		result = submit_change_request(cr.name, doc_keys=[group_key])
+
+		self.assertEqual(result["auto_included"], [child_key])
+		self.assertIsNone(result["held_back_change_request"])
+
+	def test_selecting_a_deleted_group_keeps_its_deleted_pages_with_it(self):
+		space = create_test_wiki_space()
+		group = create_test_wiki_document(space.root_group, title="Live Group", is_group=1)
+		child = create_test_wiki_document(group.name, title="Live Child")
+		other = create_test_wiki_document(space.root_group, title="Other Page")
+		group_key = frappe.get_value("Wiki Document", group.name, "doc_key")
+		child_key = frappe.get_value("Wiki Document", child.name, "doc_key")
+		other_key = frappe.get_value("Wiki Document", other.name, "doc_key")
+
+		cr = create_change_request(space.name, "Delete CR")
+		delete_cr_page(cr.name, group_key)
+		update_cr_page(cr.name, other_key, {"content": "Edited elsewhere"})
+
+		result = submit_change_request(cr.name, doc_keys=[group_key])
+
+		self.assertEqual(sorted(result["submitted"]), sorted([group_key, child_key]))
+		self.assertEqual(result["held_back"], [other_key])
+
+	def test_leftover_draft_is_what_the_author_gets_back(self):
+		space, _root_key, cr, keys = self._space_with_three_pages()
+		result = submit_change_request(cr.name, doc_keys=[keys[0]])
+
+		draft = get_or_create_draft_change_request(space.name)
+
+		self.assertEqual(draft["name"], result["held_back_change_request"])
+
+
 def create_test_wiki_space():
 	root_group = frappe.new_doc("Wiki Document")
 	root_group.title = f"Root {frappe.generate_hash(length=6)}"

--- a/wiki/frappe_wiki/doctype/wiki_change_request/wiki_change_request.py
+++ b/wiki/frappe_wiki/doctype/wiki_change_request/wiki_change_request.py
@@ -1435,7 +1435,10 @@ def submit_change_request(name: str, doc_keys: list[str] | str | None = None) ->
 	`doc_keys` submits a subset: everything else is split off into a new draft
 	the author keeps editing. Omit it to submit the whole change request.
 	"""
-	cr = frappe.get_doc("Wiki Change Request", name)
+	# Same row lock the mutation endpoints take: a save landing between the diff
+	# below and the split would either miss the selection or end up on a
+	# revision that is already in review.
+	cr = _lock_and_load_cr(name)
 	cr.check_permission("write")
 	_assert_status(cr, {"Draft", "Changes Requested"})
 
@@ -1448,7 +1451,12 @@ def submit_change_request(name: str, doc_keys: list[str] | str | None = None) ->
 	auto_included: set[str] = set()
 
 	if doc_keys is not None:
-		requested = set(frappe.parse_json(doc_keys) if isinstance(doc_keys, str) else doc_keys) & set(changed)
+		if isinstance(doc_keys, str):
+			doc_keys = frappe.parse_json(doc_keys)
+		if not isinstance(doc_keys, list | tuple) or not all(isinstance(key, str) for key in doc_keys):
+			frappe.throw(_("doc_keys must be a list of document keys."), frappe.ValidationError)
+
+		requested = set(doc_keys) & set(changed)
 		if not requested:
 			frappe.throw(_("Select at least one change to submit for review."), frappe.ValidationError)
 		submitted = _expand_selection(cr, requested, changed)

--- a/wiki/frappe_wiki/doctype/wiki_change_request/wiki_change_request.py
+++ b/wiki/frappe_wiki/doctype/wiki_change_request/wiki_change_request.py
@@ -1350,13 +1350,90 @@ def diff_change_request(name: str, scope: str = "summary", doc_key: str | None =
 	return changes
 
 
+def _expand_selection(cr: Document, selected: set[str], changed: dict[str, str]) -> set[str]:
+	"""Grow a partial selection until neither half of the split is left dangling.
+
+	Up: an ancestor that is new in this CR travels with its descendants, or the
+	submitted tree points at a parent that does not exist yet. Down: a new or
+	deleted node takes its changed descendants, so a new group keeps its pages
+	and a deleted group keeps the descendants the delete cascade marked.
+	"""
+	base_items = get_revision_item_map(cr.base_revision)
+	head_items = get_effective_revision_item_map(cr.head_revision)
+
+	children: dict[str | None, list[str]] = {}
+	for key, item in head_items.items():
+		children.setdefault(item.get("parent_key"), []).append(key)
+
+	expanded = set(selected)
+	queue = list(selected)
+	while queue:
+		key = queue.pop()
+
+		parent = (head_items.get(key) or {}).get("parent_key")
+		while parent and parent in changed and parent not in base_items:
+			if parent not in expanded:
+				expanded.add(parent)
+				queue.append(parent)
+			parent = (head_items.get(parent) or {}).get("parent_key")
+
+		if key in changed and (key not in base_items or changed[key] == "deleted"):
+			for child in children.get(key, []):
+				if child in changed and child not in expanded:
+					expanded.add(child)
+					queue.append(child)
+
+	return expanded
+
+
+def _split_off_changes(cr: Document, doc_keys: set[str]) -> str | None:
+	"""Move the given changes out of `cr` into a fresh draft off the same base.
+
+	Only the overlay rows move — content blobs are immutable and shared, so
+	nothing is copied. Returns the new change request, or None if there was
+	nothing to move.
+	"""
+	if not doc_keys:
+		return None
+
+	rows = frappe.get_all(
+		"Wiki Revision Item",
+		filters={"revision": cr.head_revision, "doc_key": ("in", list(doc_keys))},
+		pluck="name",
+	)
+	if not rows:
+		return None
+
+	head_revision = create_overlay_revision(cr.base_revision, is_working=1)
+
+	leftover = frappe.new_doc("Wiki Change Request")
+	leftover.title = cr.title
+	leftover.wiki_space = cr.wiki_space
+	leftover.status = "Draft"
+	leftover.description = cr.description
+	leftover.base_revision = cr.base_revision
+	leftover.head_revision = head_revision.name
+	leftover.insert()
+
+	frappe.db.set_value("Wiki Revision", head_revision.name, "change_request", leftover.name)
+	for row in rows:
+		frappe.db.set_value("Wiki Revision Item", row, "revision", head_revision.name)
+
+	mark_hashes_stale(cr.head_revision)
+	mark_hashes_stale(head_revision.name)
+	return leftover.name
+
+
 @frappe.whitelist()
-def submit_change_request(name: str) -> None:
+def submit_change_request(name: str, doc_keys: list[str] | str | None = None) -> dict[str, Any]:
 	"""Send a Draft / Changes-Requested CR into review.
 
 	The author submits their own work; no reviewer is picked here (reviewer
 	discovery is native assignment, see the review-flow spec). We re-check
 	server-side that the CR actually has changes — the UI gate is not enough.
+
+	`doc_keys` submits a subset: everything else is split off into a new draft
+	the author keeps editing. Omit it to submit the whole change request.
 	"""
 	cr = frappe.get_doc("Wiki Change Request", name)
 	cr.check_permission("write")
@@ -1365,8 +1442,31 @@ def submit_change_request(name: str) -> None:
 	if not has_revision_changes(cr.base_revision, cr.head_revision):
 		frappe.throw(_("There are no changes to submit for review."), frappe.ValidationError)
 
+	changed = {change["doc_key"]: change["change_type"] for change in diff_change_request(name)}
+	held_back: set[str] = set()
+	submitted = set(changed)
+	auto_included: set[str] = set()
+
+	if doc_keys is not None:
+		requested = set(frappe.parse_json(doc_keys) if isinstance(doc_keys, str) else doc_keys) & set(changed)
+		if not requested:
+			frappe.throw(_("Select at least one change to submit for review."), frappe.ValidationError)
+		submitted = _expand_selection(cr, requested, changed)
+		auto_included = submitted - requested
+		held_back = set(changed) - submitted
+
+	leftover = _split_off_changes(cr, held_back)
+
 	cr.status = "In Review"
 	cr.save()
+
+	return {
+		"change_request": cr.name,
+		"submitted": sorted(submitted),
+		"auto_included": sorted(auto_included),
+		"held_back": sorted(held_back),
+		"held_back_change_request": leftover,
+	}
 
 
 @frappe.whitelist()


### PR DESCRIPTION
closes #761 

## Why?

A change request is space-level: every page an author edits before submitting rides along on the same one, so approving it merges all of them. Reported as #761, where three page drafts turned out to be a single change request.

Approving one change request does not affect other in-review ones, so there is no status cascade. The limitation is that an author has no way to send one page for review and keep working on the rest.

## What?

The Submit for Review dialog now lists the pending changes with checkboxes, all ticked by default. Unticked changes stay in a draft the author keeps editing; the ticked ones go for review on the existing change request.

## How?

`submit_change_request` takes an optional `doc_keys`. Everything left out moves to a new draft off the same base revision by re-pointing its `Wiki Revision Item` rows, so no content is copied.

The selection is expanded first, or one side of the split ends up pointing at a page its base does not have: a new ancestor travels with its descendants, and a new or deleted node takes its changed descendants.

Reviewer-side partial approval is out of scope. A submitted change request is still reviewed and merged as one unit.

Spec: `specs/partial_change_request_submit.md`.

## Before / after

**Before** — three page drafts, the dialog only confirms, and one Approve + Merge publishes all three.

[Screencast from 2026-09-08 01-08-48.webm](https://github.com/user-attachments/assets/d2ad71e6-fbcd-4f00-b660-e7eaf08264d0)


**After** — the same three drafts, two unticked, only the ticked page is submitted and merged. The other two stay in the draft.

[Screencast from 2026-09-08 01-12-55.webm](https://github.com/user-attachments/assets/0dcdbf93-9794-486c-a2d8-d0c5c35bcb0f)


## Tests

- 8 unit tests for the split and the closure. Both halves verified by temp-revert: dropping the split fails three, dropping the closure fails the other three. Full module (113 tests) passes.
- `e2e/tests/partial-submit.spec.ts`: three page drafts, submit one, the other two stay editable and unpublished after the merge. The existing `change-request-flow.spec.ts` suite still passes.
