### PR TITLE
fix: keep a page deleted in a draft visible until the merge

### DIFF
--- a/e2e/tests/pending-delete-visible.spec.ts
+++ b/e2e/tests/pending-delete-visible.spec.ts
@@ -1,0 +1,134 @@
+import { expect, test } from '@playwright/test';
+import { destroySpacesByRoute, uniqueRoute } from '../helpers/factory';
+import { getList } from '../helpers/frappe';
+import { SPACE_URL_RE, appUrl } from '../helpers/routes';
+import { openNewPageDialog } from '../helpers/wiki';
+
+/**
+ * A page deleted in an unmerged change request keeps its row, struck through
+ * and flagged, until the change request is merged (#762).
+ *
+ * The live `Wiki Document` only goes on merge, so hiding the row told the
+ * author the page was gone while everyone else still saw it.
+ */
+test.describe('Pending deletion stays visible', () => {
+	let route = '';
+
+	test.afterEach(async ({ request }) => {
+		if (route) await destroySpacesByRoute(request, route);
+		route = '';
+	});
+
+	test('deleted page keeps a struck-through row until the merge, and can be restored', async ({
+		page,
+		request,
+	}) => {
+		const timestamp = Date.now();
+		route = uniqueRoute('pending-delete');
+		const pageTitle = `pending-delete-page-${timestamp}`;
+
+		await page.goto(appUrl('spaces'));
+		await page.waitForLoadState('networkidle');
+		await page.getByRole('button', { name: 'New Space' }).click();
+		await page.waitForSelector('[role="dialog"]', { state: 'visible' });
+		await page.getByLabel('Space Name').fill(`Pending Delete ${timestamp}`);
+		await page.getByLabel('Route').fill(route);
+		await page
+			.getByRole('dialog')
+			.getByRole('button', { name: 'Create' })
+			.click();
+		await expect(page).toHaveURL(SPACE_URL_RE);
+		const spaceUrl = page.url();
+
+		await openNewPageDialog(page);
+		await page.getByLabel('Title').fill(pageTitle);
+		await page
+			.getByRole('dialog')
+			.getByRole('button', { name: 'Save' })
+			.click();
+
+		const liveDocs = async () =>
+			getList<{ name: string }>(request, 'Wiki Document', {
+				fields: ['name'],
+				filters: { title: pageTitle },
+				limit: 0,
+			});
+
+		// Merge, so the page exists as a live Wiki Document that other readers see.
+		await mergeChangeRequest(page, spaceUrl);
+		expect(await liveDocs()).toHaveLength(1);
+
+		await deleteFromTree(page, spaceUrl, pageTitle);
+
+		// The row stays, flagged, and survives a reload — the deletion is staged,
+		// not done, and the live document is still there.
+		const row = page.locator('aside').getByText(pageTitle, { exact: true });
+		await expect(row).toHaveClass(/line-through/);
+		await page.reload();
+		await page.waitForLoadState('networkidle');
+		await expect(
+			page.locator('aside').getByText(pageTitle, { exact: true }),
+		).toHaveClass(/line-through/);
+		await expect(
+			page.locator('aside').getByRole('status', { name: 'Deleted' }),
+		).toBeVisible();
+		expect(await liveDocs()).toHaveLength(1);
+
+		// Restore puts it back as an ordinary row.
+		await openRowMenu(page, pageTitle);
+		await page.getByRole('menuitem', { name: 'Restore' }).click();
+		await expect(
+			page.locator('aside').getByText(pageTitle, { exact: true }),
+		).not.toHaveClass(/line-through/);
+
+		// Delete again and merge: only then does the live document go.
+		await deleteFromTree(page, spaceUrl, pageTitle);
+		await mergeChangeRequest(page, spaceUrl);
+		expect(await liveDocs()).toHaveLength(0);
+		await expect(
+			page.locator('aside').getByText(pageTitle, { exact: true }),
+		).toHaveCount(0);
+	});
+});
+
+/** Open the row's three-dots menu in the sidebar tree. */
+async function openRowMenu(
+	page: import('@playwright/test').Page,
+	title: string,
+) {
+	const row = page.locator('aside').getByText(title, { exact: true });
+	await row.hover();
+	await page.locator('aside').getByRole('button').last().click();
+}
+
+async function deleteFromTree(
+	page: import('@playwright/test').Page,
+	spaceUrl: string,
+	title: string,
+) {
+	await page.goto(spaceUrl);
+	await page.waitForLoadState('networkidle');
+	await openRowMenu(page, title);
+	await page.getByRole('menuitem', { name: 'Delete' }).click();
+	await page
+		.getByRole('dialog')
+		.getByRole('button', { name: /Delete/ })
+		.click();
+	await expect(page.getByRole('dialog')).toHaveCount(0);
+}
+
+async function mergeChangeRequest(
+	page: import('@playwright/test').Page,
+	spaceUrl: string,
+) {
+	await page.goto(spaceUrl);
+	await page.waitForLoadState('networkidle');
+	await page.getByRole('button', { name: 'Merge' }).first().click();
+	const dialog = page.getByRole('dialog');
+	if (await dialog.isVisible({ timeout: 2000 }).catch(() => false)) {
+		await dialog.getByRole('button', { name: /Merge/ }).first().click();
+	}
+	await expect(page.locator('text=Change request merged').first()).toBeVisible({
+		timeout: 15000,
+	});
+}

--- a/e2e/tests/pending-delete-visible.spec.ts
+++ b/e2e/tests/pending-delete-visible.spec.ts
@@ -96,9 +96,9 @@ async function openRowMenu(
 	page: import('@playwright/test').Page,
 	title: string,
 ) {
-	const row = page.locator('aside').getByText(title, { exact: true });
+	const row = page.locator('aside div.group', { hasText: title }).last();
 	await row.hover();
-	await page.locator('aside').getByRole('button').last().click();
+	await row.getByRole('button').last().click();
 }
 
 async function deleteFromTree(

--- a/frontend/src/components/WikiDocumentList.vue
+++ b/frontend/src/components/WikiDocumentList.vue
@@ -141,6 +141,9 @@
 						{{ __('Are you sure you want to delete this') }}
 						{{ deleteNode?.is_group ? __('group') : __('page') }}?
 					</p>
+					<p class="text-sm text-ink-gray-5">
+						{{ __('It stays in your draft, marked as deleted, until the change request is merged.') }}
+					</p>
 					<div v-if="deleteNode?.is_group && deleteChildCount > 0"
 						class="bg-surface-orange-1 border border-outline-orange-2 rounded-6 p-4">
 						<div class="flex items-start gap-3">
@@ -162,7 +165,7 @@
 					<Button variant="outline" @click="close">{{ __('Cancel') }}</Button>
 					<Button variant="solid" theme="gray" :loading="isDeleting"
 						@click="deleteDocument(close)">
-						{{ __('Save Delete Draft') }}
+						{{ __('Delete') }}
 					</Button>
 				</div>
 			</template>

--- a/frontend/src/components/WikiTree.vue
+++ b/frontend/src/components/WikiTree.vue
@@ -57,6 +57,15 @@
 					:aria-label="__('Syncing…')"
 					role="status"
 				/>
+				<!-- Deleted in this draft: struck through in the row, and a red
+				     dot for the same reason every other change type has one. -->
+				<span
+					v-else-if="isDeleted(node)"
+					class="size-1.5 shrink-0 rounded-full bg-surface-red-5"
+					:title="__('Deleted in this draft. Merge to remove it for everyone.')"
+					:aria-label="__('Deleted')"
+					role="status"
+				/>
 				<span
 					v-else-if="changeTypeMap.get(node.doc_key)"
 					class="size-1.5 shrink-0 rounded-full"
@@ -206,8 +215,16 @@ function navigateToTreePage(to) {
 	}
 }
 
+// A staged deletion (this change request's own, or one the diff reports) keeps
+// its row until the change request is merged, struck through and inert.
+function isDeleted(node) {
+	return (
+		!!node.is_deleted || props.changeTypeMap.get(node.doc_key) === 'deleted'
+	);
+}
+
 function handleRowClick(node) {
-	if (props.changeTypeMap.get(node.doc_key) === 'deleted') {
+	if (isDeleted(node)) {
 		return;
 	}
 
@@ -253,14 +270,14 @@ function isSelected(node) {
 }
 
 function getRowClasses(node) {
-	if (props.changeTypeMap.get(node.doc_key) === 'deleted') {
+	if (isDeleted(node)) {
 		return 'cursor-not-allowed opacity-60';
 	}
 	return 'cursor-pointer';
 }
 
 function getTitleClass(node) {
-	if (props.changeTypeMap.get(node.doc_key) === 'deleted') {
+	if (isDeleted(node)) {
 		return 'text-ink-gray-4 line-through';
 	}
 	if (node.is_published || node.is_group) {
@@ -323,8 +340,26 @@ async function togglePublish(node) {
 	}
 }
 
+async function restore(node) {
+	try {
+		await draftStore.restoreNode(node.doc_key);
+	} catch (error) {
+		toast.error(error.messages?.[0] || __('Error restoring page'));
+	}
+}
+
 function getDropdownOptions(node) {
 	const options = [];
+
+	if (isDeleted(node)) {
+		return [
+			{
+				label: __('Restore'),
+				icon: 'rotate-ccw',
+				onClick: () => restore(node),
+			},
+		];
+	}
 
 	if (node.is_group) {
 		options.push(

--- a/frontend/src/lib/spaceTree.js
+++ b/frontend/src/lib/spaceTree.js
@@ -27,6 +27,8 @@ export function trailToNode(nodes, matches, trail = []) {
 /** The first readable page in a subtree, depth first. Groups hold no content. */
 export function firstPageIn(nodes) {
 	for (const node of nodes || []) {
+		// A page staged for deletion still has a row, but nothing should open it.
+		if (node.is_deleted) continue;
 		if (!node.is_group && node.document_name) return node.document_name;
 		if (node.is_group) {
 			const found = firstPageIn(node.children);

--- a/frontend/src/pages/SpaceDetails.vue
+++ b/frontend/src/pages/SpaceDetails.vue
@@ -323,10 +323,14 @@ function autoOpenPage() {
 	if (!tree) return;
 
 	const remembered = localStorage.getItem(lastPageKey());
+	// A page staged for deletion is still in the tree, so the remembered one has
+	// to be checked for that too, or the space reopens on a page nothing can load.
+	const rememberedNode = remembered
+		? findNodeByDocumentName(tree.children, remembered)
+		: null;
 	const target =
-		(remembered && findNodeByDocumentName(tree.children, remembered)
-			? remembered
-			: null) || firstPageIn(tree.children);
+		(rememberedNode && !rememberedNode.is_deleted ? remembered : null) ||
+		firstPageIn(tree.children);
 
 	if (target) {
 		autoOpening = true;
@@ -346,4 +350,23 @@ function autoOpenPage() {
 watch([() => spaceStore.treeData, () => route.name], autoOpenPage, {
 	immediate: true,
 });
+
+// The open page can be deleted from under the reader: by this tab (the row is
+// struck through but the panel stays put) or by a bookmark to a page already
+// deleted in the draft. Its overlay is gone, so the editor would sit on a
+// skeleton forever. Fall back to the space, which opens the first live page.
+watch(
+	[
+		() => spaceStore.treeData,
+		() => route.name,
+		() => route.params.pageId,
+	],
+	([tree, name, pageId]) => {
+		if (name !== 'SpacePage' || !tree || !pageId) return;
+		const node = findNodeByDocumentName(tree.children, pageId);
+		if (!node?.is_deleted) return;
+		router.replace({ name: 'SpaceDetails', params: { spaceId: props.spaceId } });
+	},
+	{ immediate: true },
+);
 </script>

--- a/frontend/src/stores/changeRequest.js
+++ b/frontend/src/stores/changeRequest.js
@@ -78,6 +78,10 @@ export const useChangeRequestStore = defineStore('changeRequest', () => {
 		url: 'wiki.frappe_wiki.doctype.wiki_change_request.wiki_change_request.delete_cr_page',
 	});
 
+	const restorePageResource = createResource({
+		url: 'wiki.frappe_wiki.doctype.wiki_change_request.wiki_change_request.restore_cr_page',
+	});
+
 	const movePageResource = createResource({
 		url: 'wiki.frappe_wiki.doctype.wiki_change_request.wiki_change_request.move_cr_page',
 	});
@@ -262,6 +266,13 @@ export const useChangeRequestStore = defineStore('changeRequest', () => {
 		});
 	}
 
+	async function restorePage(changeRequestName, docKey) {
+		return await restorePageResource.submit({
+			name: changeRequestName,
+			doc_key: docKey,
+		});
+	}
+
 	async function movePage(
 		changeRequestName,
 		docKey,
@@ -326,6 +337,7 @@ export const useChangeRequestStore = defineStore('changeRequest', () => {
 		createPage,
 		updatePage,
 		deletePage,
+		restorePage,
 		movePage,
 		reorderChildren,
 		applyOperations,

--- a/frontend/src/stores/draftWorkspace.js
+++ b/frontend/src/stores/draftWorkspace.js
@@ -906,11 +906,12 @@ export const useDraftWorkspaceStore = defineStore('draftWorkspace', () => {
 		persistEditorDraft(realKey, title, { immediate: true });
 	}
 
-	// Mark pending_delete locally (treeAsLegacy hides those). On failure
-	// the flag is cleared so the row reappears in the sidebar. For temp
-	// nodes whose create never reached the server, just drop the local
-	// node and the failed-create mutation rather than calling
-	// delete_cr_page with a tmp_* key.
+	// Mark pending_delete locally, which strikes the row through. The page only
+	// leaves the live tree once the change request is merged, so it stays on
+	// screen until then (#762). On failure the flag is cleared so the row
+	// reads as normal again. For temp nodes whose create never reached the
+	// server, just drop the local node and the failed-create mutation rather
+	// than calling delete_cr_page with a tmp_* key.
 	async function deleteNode(docKey) {
 		const node = treeModel.findNode(docKey);
 		if (!node) return;
@@ -949,11 +950,46 @@ export const useDraftWorkspaceStore = defineStore('draftWorkspace', () => {
 			} else {
 				await crStore.deletePage(crName.value, resolvedKey);
 			}
+			const synced = treeModel.findNode(docKey);
+			if (synced) {
+				synced.isDeleted = true;
+				synced.localStatus = null;
+			}
 			queue.clear(mutation.id);
 			scheduleSummaryRefresh();
 		} catch (err) {
 			const fresh = treeModel.findNode(docKey);
 			if (fresh) fresh.localStatus = null;
+			queue.setStatus(mutation.id, 'failed', errorMessage(err));
+			throw err;
+		}
+	}
+
+	// Undo a deletion that is still staged in this change request. Optimistic
+	// like the delete it reverses: the row un-strikes right away.
+	async function restoreNode(docKey) {
+		const node = treeModel.findNode(docKey);
+		if (!node?.isDeleted) return;
+		node.isDeleted = false;
+
+		queue.supersedeFailedFor(`delete:${docKey}`);
+		const mutation = queue.enqueue('restore_node', { docKey });
+		queue.setStatus(mutation.id, 'syncing');
+		try {
+			const resolvedKey = resolver.resolveKey(docKey) || docKey;
+			if (!(await ensureCr())) throw new Error('No change request');
+			if (useBatchOperations) {
+				await transport.applyBatchOps([
+					{ id: mutation.id, type: 'restore_node', doc_key: resolvedKey },
+				]);
+			} else {
+				await crStore.restorePage(crName.value, resolvedKey);
+			}
+			queue.clear(mutation.id);
+			scheduleSummaryRefresh();
+		} catch (err) {
+			const fresh = treeModel.findNode(docKey);
+			if (fresh) fresh.isDeleted = true;
 			queue.setStatus(mutation.id, 'failed', errorMessage(err));
 			throw err;
 		}
@@ -997,6 +1033,7 @@ export const useDraftWorkspaceStore = defineStore('draftWorkspace', () => {
 		updateNode,
 		renameNode,
 		deleteNode,
+		restoreNode,
 		moveNode,
 		saveContent,
 		flushDirtyPages,

--- a/frontend/src/stores/draftWorkspace.js
+++ b/frontend/src/stores/draftWorkspace.js
@@ -916,6 +916,7 @@ export const useDraftWorkspaceStore = defineStore('draftWorkspace', () => {
 		const node = treeModel.findNode(docKey);
 		if (!node) return;
 		node.localStatus = 'pending_delete';
+		treeModel.setSubtreeDeleted(docKey, true);
 
 		const isTempKey = resolver.isTempKey(docKey);
 		queue.supersedeFailedFor(`delete:${docKey}`);
@@ -951,15 +952,13 @@ export const useDraftWorkspaceStore = defineStore('draftWorkspace', () => {
 				await crStore.deletePage(crName.value, resolvedKey);
 			}
 			const synced = treeModel.findNode(docKey);
-			if (synced) {
-				synced.isDeleted = true;
-				synced.localStatus = null;
-			}
+			if (synced) synced.localStatus = null;
 			queue.clear(mutation.id);
 			scheduleSummaryRefresh();
 		} catch (err) {
 			const fresh = treeModel.findNode(docKey);
 			if (fresh) fresh.localStatus = null;
+			treeModel.setSubtreeDeleted(docKey, false);
 			queue.setStatus(mutation.id, 'failed', errorMessage(err));
 			throw err;
 		}
@@ -970,7 +969,7 @@ export const useDraftWorkspaceStore = defineStore('draftWorkspace', () => {
 	async function restoreNode(docKey) {
 		const node = treeModel.findNode(docKey);
 		if (!node?.isDeleted) return;
-		node.isDeleted = false;
+		treeModel.setSubtreeDeleted(docKey, false);
 
 		queue.supersedeFailedFor(`delete:${docKey}`);
 		const mutation = queue.enqueue('restore_node', { docKey });
@@ -988,8 +987,7 @@ export const useDraftWorkspaceStore = defineStore('draftWorkspace', () => {
 			queue.clear(mutation.id);
 			scheduleSummaryRefresh();
 		} catch (err) {
-			const fresh = treeModel.findNode(docKey);
-			if (fresh) fresh.isDeleted = true;
+			treeModel.setSubtreeDeleted(docKey, true);
 			queue.setStatus(mutation.id, 'failed', errorMessage(err));
 			throw err;
 		}

--- a/frontend/src/stores/draftWorkspace/operationQueue.js
+++ b/frontend/src/stores/draftWorkspace/operationQueue.js
@@ -55,7 +55,8 @@ export function createOperationQueue({ resolveKey }) {
 		const r = (k) => resolveKey(k) || k;
 		if (type === 'create_node') return `create:${payload?.tempKey}`;
 		if (type === 'update_node') return `update:${r(payload?.docKey)}`;
-		if (type === 'delete_node') return `delete:${r(payload?.docKey)}`;
+		if (type === 'delete_node' || type === 'restore_node')
+			return `delete:${r(payload?.docKey)}`;
 		if (type === 'move_node') return `move:${r(payload?.docKey)}`;
 		if (type === 'update_content') return `content:${r(payload?.docKey)}`;
 		return null;

--- a/frontend/src/stores/draftWorkspace/treeModel.js
+++ b/frontend/src/stores/draftWorkspace/treeModel.js
@@ -22,6 +22,7 @@ export function normalizeNode(serverNode, parentKey = null) {
 		isPublished: toPublished(serverNode.is_published),
 		isExternalLink: !!serverNode.is_external_link,
 		externalUrl: serverNode.external_url || null,
+		isDeleted: !!serverNode.is_deleted,
 		children,
 		localStatus: null,
 	};
@@ -42,6 +43,7 @@ export function denormalizeNode(node) {
 		is_external_link: node.isExternalLink,
 		external_url: node.externalUrl,
 		order_index: node.orderIndex,
+		is_deleted: node.isDeleted || node.localStatus === 'pending_delete',
 		children: node.children.map(denormalizeNode),
 		local_status: node.localStatus,
 	};
@@ -93,19 +95,16 @@ export function createTreeModel() {
 		);
 	}
 
-	// Filter pending_delete nodes out of the legacy view so deletion feels
-	// immediate. They're restored if the backend call fails.
+	// A deleted node stays in the view, flagged, until the merge.
 	const treeAsLegacy = computed(() => {
-		const filterDeleted = (nodes) =>
-			nodes
-				.filter((n) => n.localStatus !== 'pending_delete')
-				.map((n) => ({
-					...denormalizeNode(n),
-					children: filterDeleted(n.children),
-				}));
+		const toLegacy = (nodes) =>
+			nodes.map((n) => ({
+				...denormalizeNode(n),
+				children: toLegacy(n.children),
+			}));
 		return {
 			root_group: rootKey.value,
-			children: filterDeleted(tree.value),
+			children: toLegacy(tree.value),
 		};
 	});
 

--- a/frontend/src/stores/draftWorkspace/treeModel.js
+++ b/frontend/src/stores/draftWorkspace/treeModel.js
@@ -88,6 +88,18 @@ export function createTreeModel() {
 		return removeFrom(tree.value);
 	}
 
+	// Delete and restore cascade over the subtree server-side, so the local
+	// flags have to move together with them.
+	function setSubtreeDeleted(docKey, isDeleted) {
+		const node = findNode(docKey);
+		if (!node) return;
+		const mark = (n) => {
+			n.isDeleted = isDeleted;
+			for (const child of n.children) mark(child);
+		};
+		mark(node);
+	}
+
 	function applyServerTree(serverTree) {
 		rootKey.value = serverTree?.root_group || null;
 		tree.value = (serverTree?.children || []).map((c) =>
@@ -121,6 +133,7 @@ export function createTreeModel() {
 		getChildList,
 		insertNode,
 		removeNodeByKey,
+		setSubtreeDeleted,
 		applyServerTree,
 		reset,
 	};

--- a/wiki/frappe_wiki/doctype/wiki_change_request/test_wiki_change_request.py
+++ b/wiki/frappe_wiki/doctype/wiki_change_request/test_wiki_change_request.py
@@ -33,6 +33,7 @@ from wiki.frappe_wiki.doctype.wiki_change_request.wiki_change_request import (
 	reorder_cr_children,
 	request_changes,
 	resolve_merge_conflict,
+	restore_cr_page,
 	retry_merge_after_resolution,
 	submit_change_request,
 	update_change_request,
@@ -547,6 +548,57 @@ class TestWikiChangeRequest(FrappeTestCase):
 		child_item = get_revision_item(cr.head_revision, child_key)
 		self.assertEqual(group_item.is_deleted, 1)
 		self.assertEqual(child_item.is_deleted, 1)
+
+	def test_get_cr_tree_keeps_deleted_page_flagged(self):
+		"""A staged deletion stays in the tree until the merge, or the author
+		reads the empty row as "already deleted" and never publishes it (#762)."""
+		space = create_test_wiki_space()
+		page = create_test_wiki_document(space.root_group, title="Page A")
+		cr = create_change_request(space.name, "CR Delete Visible")
+
+		page_key = frappe.get_value("Wiki Document", page.name, "doc_key")
+		delete_cr_page(cr.name, page_key)
+
+		node = next(node for node in get_cr_tree(cr.name)["children"] if node["doc_key"] == page_key)
+		self.assertTrue(node["is_deleted"])
+
+	def test_get_cr_tree_drops_page_created_and_deleted_in_same_cr(self):
+		space = create_test_wiki_space()
+		cr = create_change_request(space.name, "CR Create Then Delete")
+		root_key = frappe.get_value("Wiki Document", space.root_group, "doc_key")
+
+		page_key = create_cr_page(cr.name, parent_key=root_key, title="Never Lived")
+		delete_cr_page(cr.name, page_key)
+
+		keys = {node["doc_key"] for node in get_cr_tree(cr.name)["children"]}
+		self.assertNotIn(page_key, keys)
+
+	def test_restore_cr_page_clears_deletion(self):
+		space = create_test_wiki_space()
+		group = create_test_wiki_document(space.root_group, title="Group", is_group=1)
+		child = create_test_wiki_document(group.name, title="Child")
+		cr = create_change_request(space.name, "CR Restore")
+
+		group_key = frappe.get_value("Wiki Document", group.name, "doc_key")
+		child_key = frappe.get_value("Wiki Document", child.name, "doc_key")
+		delete_cr_page(cr.name, group_key)
+		restore_cr_page(cr.name, group_key)
+
+		self.assertEqual(get_revision_item(cr.head_revision, group_key).is_deleted, 0)
+		self.assertEqual(get_revision_item(cr.head_revision, child_key).is_deleted, 0)
+		self.assertFalse(has_revision_changes(cr.base_revision, cr.head_revision))
+
+	def test_restore_node_operation_clears_deletion(self):
+		space = create_test_wiki_space()
+		page = create_test_wiki_document(space.root_group, title="Page A")
+		cr = create_change_request(space.name, "CR Restore Batch")
+
+		page_key = frappe.get_value("Wiki Document", page.name, "doc_key")
+		apply_cr_operations(cr.name, operations=[{"type": "delete_node", "doc_key": page_key}])
+		result = apply_cr_operations(cr.name, operations=[{"type": "restore_node", "doc_key": page_key}])
+
+		self.assertEqual(get_revision_item(cr.head_revision, page_key).is_deleted, 0)
+		self.assertEqual([item["doc_key"] for item in result["items"]], [page_key])
 
 	def test_diff_summary_returns_changed_pages(self):
 		space = create_test_wiki_space()

--- a/wiki/frappe_wiki/doctype/wiki_change_request/wiki_change_request.py
+++ b/wiki/frappe_wiki/doctype/wiki_change_request/wiki_change_request.py
@@ -426,16 +426,23 @@ def _update_cr_item(
 	return item.doc_key
 
 
-def _delete_cr_item(cr: Document, doc_key: str) -> list[str]:
+def _set_cr_item_deleted(cr: Document, doc_key: str, is_deleted: bool) -> list[str]:
+	"""Flag (or unflag) doc_key and everything under it as deleted in the overlay.
+
+	Restoring walks the same subtree, so a child deleted on its own before its
+	parent comes back with the parent. That is the behaviour the tree shows: the
+	subtree went away as one row, it returns as one row.
+	"""
 	item_name = ensure_overlay_item(cr.head_revision, doc_key)
 	if not item_name:
 		frappe.throw(_("Document not found in change request"))
 
+	flag = 1 if is_deleted else 0
 	item = frappe.get_doc("Wiki Revision Item", item_name)
-	item.is_deleted = 1
+	item.is_deleted = flag
 	item.save()
 
-	deleted = [doc_key]
+	affected = [doc_key]
 	effective_items = get_effective_revision_item_map(cr.head_revision)
 	children: dict[str | None, list[str]] = {}
 	for key, item_data in effective_items.items():
@@ -451,10 +458,10 @@ def _delete_cr_item(cr: Document, doc_key: str) -> list[str]:
 			seen.add(child_key)
 			child_item_name = ensure_overlay_item(cr.head_revision, child_key)
 			if child_item_name:
-				frappe.db.set_value("Wiki Revision Item", child_item_name, "is_deleted", 1)
-				deleted.append(child_key)
+				frappe.db.set_value("Wiki Revision Item", child_item_name, "is_deleted", flag)
+				affected.append(child_key)
 			to_visit.append(child_key)
-	return deleted
+	return affected
 
 
 def _move_cr_item(
@@ -650,10 +657,15 @@ def get_cr_tree(name: str) -> dict[str, Any]:
 	root_key = frappe.get_value("Wiki Document", root_group, "doc_key")
 	effective_items = get_effective_revision_item_map(cr.head_revision)
 
+	base_items = get_revision_item_map(cr.base_revision) if cr.base_revision else {}
+
 	doc_map: dict[str, dict[str, Any]] = {}
 	for item in effective_items.values():
-		if item.get("is_deleted"):
-			continue
+		is_deleted = bool(item.get("is_deleted"))
+		if is_deleted:
+			base_item = base_items.get(item["doc_key"])
+			if not base_item or base_item.get("is_deleted"):
+				continue
 		doc_map[item["doc_key"]] = {
 			"doc_key": item.get("doc_key"),
 			"document_name": None,
@@ -669,6 +681,7 @@ def get_cr_tree(name: str) -> dict[str, Any]:
 			"parent_key": item.get("parent_key"),
 			"order_index": item.get("order_index") or 0,
 			"label": item.get("title"),
+			"is_deleted": is_deleted,
 			"children": [],
 		}
 
@@ -962,7 +975,19 @@ def delete_cr_page(name: str, doc_key: str) -> None:
 	cr = _lock_and_load_cr(name)
 	cr.check_permission("write")
 	_assert_editable(cr)
-	_delete_cr_item(cr, doc_key)
+	_set_cr_item_deleted(cr, doc_key, True)
+	mark_hashes_stale(cr.head_revision)
+	touch_change_request(cr.name)
+	_bump_operation_version(cr)
+
+
+@frappe.whitelist()
+def restore_cr_page(name: str, doc_key: str) -> None:
+	"""Undo a deletion still staged in this change request."""
+	cr = _lock_and_load_cr(name)
+	cr.check_permission("write")
+	_assert_editable(cr)
+	_set_cr_item_deleted(cr, doc_key, False)
 	mark_hashes_stale(cr.head_revision)
 	touch_change_request(cr.name)
 	_bump_operation_version(cr)
@@ -1043,8 +1068,15 @@ def _apply_operation(
 		doc_key = _resolve_temp_key(op.get("doc_key"), temp_key_map)
 		if not doc_key:
 			frappe.throw(_("delete_node operation requires doc_key"))
-		deleted = _delete_cr_item(cr, doc_key)
+		deleted = _set_cr_item_deleted(cr, doc_key, True)
 		deleted_doc_keys.update(deleted)
+		return
+
+	if op_type == "restore_node":
+		doc_key = _resolve_temp_key(op.get("doc_key"), temp_key_map)
+		if not doc_key:
+			frappe.throw(_("restore_node operation requires doc_key"))
+		affected_doc_keys.update(_set_cr_item_deleted(cr, doc_key, False))
 		return
 
 	if op_type == "move_node":


### PR DESCRIPTION
## Problem

Deleting a page in the editor makes it vanish from the tree, but the live `Wiki Document` is only removed when the change request is merged. The author sees an empty space, assumes the delete is done, never publishes it, and everyone else still sees the page.

## Solution

Keep the deleted row in the tree until the merge, struck through with a red `Deleted` status dot, and offer `Restore` in its menu. A page created *and* deleted inside the same change request still disappears for good.

- `get_cr_tree` keeps `is_deleted` items that exist in the base revision, flagged
- `treeAsLegacy` stops filtering `pending_delete`
- `restore_cr_page` and a `restore_node` batch operation clear the flag on the row and its subtree
- navigation skips deleted rows (first page, remembered page); an open page that gets deleted falls back to the space instead of waiting forever on an overlay that is gone
- the delete dialog says the removal happens on merge, and its button reads `Delete`

## Before / after

Deleting a published page, after a reload.

**Before** (page gone from the tree, still live for everyone else, editor stuck on skeletons)

[Screencast from 2026-09-11 11-31-41.webm](https://github.com/user-attachments/assets/f49f686b-246a-46cd-8e55-79195b7223b8)


**After** (row stays, struck through with a red dot, until the change request is merged)

[Screencast from 2026-09-11 11-37-02.webm](https://github.com/user-attachments/assets/2ec9ff9a-9f02-4e9a-9755-77a5ab03a2a7)


## Tests

- 4 unit tests on `get_cr_tree` (kept vs dropped) and restore (endpoint + batch op)
- `e2e/tests/pending-delete-visible.spec.ts`: the row survives a reload struck through, the live document is still there, Restore brings it back, the merge finally removes it
- both fail against a temporary revert of the fix

Fixes #762
