### PR TITLE
fix: re-index merged wiki documents via index_doc

### DIFF
--- a/wiki/frappe_wiki/doctype/wiki_change_request/test_wiki_change_request.py
+++ b/wiki/frappe_wiki/doctype/wiki_change_request/test_wiki_change_request.py
@@ -51,6 +51,20 @@ def _cached_cards(doc_key: str) -> list[str]:
 	return sorted(os.path.basename(p) for p in glob.glob(os.path.join(_cache_dir(), f"{doc_key}-*.jpg")))
 
 
+def drain_search_index_queue():
+	"""Flush the framework search-index queue, where that queue exists.
+
+	Frappe develop queues re-indexes and drains them from a scheduled job;
+	version-16 indexes inline and has no queue at all.
+	"""
+	try:
+		from frappe.search.sqlite_search import index_docs_in_queue
+	except ImportError:
+		return
+
+	index_docs_in_queue()
+
+
 def _approve_and_merge(name: str):
 	"""Force a CR to Approved, then merge — for tests that exercise the merge
 	machinery directly without walking the full submit → approve flow.
@@ -336,8 +350,6 @@ class TestWikiChangeRequest(FrappeTestCase):
 		"""Content-only merges write via raw db.set_value, which skips the
 		on_update hook — the merge must queue the re-index itself, or search
 		keeps serving the pre-merge content."""
-		from frappe.search.sqlite_search import index_docs_in_queue
-
 		from wiki.frappe_wiki.doctype.wiki_document.wiki_sqlite_search import WikiSQLiteSearch
 
 		space = create_test_wiki_space()
@@ -352,12 +364,37 @@ class TestWikiChangeRequest(FrappeTestCase):
 		update_cr_page(cr.name, page_key, {"content": "freshtermv2zzz"})
 		_approve_and_merge(cr.name)
 
-		index_docs_in_queue()
+		drain_search_index_queue()
 
 		stale_names = [r["name"] for r in search.search("staletermv1zzz")["results"]]
 		fresh_names = [r["name"] for r in search.search("freshtermv2zzz")["results"]]
 		self.assertNotIn(page.name, stale_names)
 		self.assertIn(page.name, fresh_names)
+
+	def test_content_only_merge_reindexes_through_index_doc(self):
+		"""`add_to_queue` and the search index queue only exist on Frappe
+		develop, so reaching for them loses the re-index on version-16
+		(issue #740). `index_doc` is the API both branches ship."""
+		from unittest.mock import patch
+
+		from wiki.frappe_wiki.doctype.wiki_document.wiki_sqlite_search import WikiSQLiteSearch
+
+		space = create_test_wiki_space()
+		page = create_test_wiki_document(space.root_group, title="V16 Page", content="stalev16zzz")
+
+		WikiSQLiteSearch().build_index()
+
+		cr = create_change_request(space.name, "CR V16 Reindex")
+		page_key = frappe.get_value("Wiki Document", page.name, "doc_key")
+		update_cr_page(cr.name, page_key, {"content": "freshv16zzz"})
+
+		with patch.object(WikiSQLiteSearch, "index_doc", autospec=True) as index_doc:
+			_approve_and_merge(cr.name)
+
+		self.assertIn(
+			("Wiki Document", page.name),
+			[call.args[1:] for call in index_doc.call_args_list],
+		)
 
 	def test_content_only_merge_clears_rendered_content_cache(self):
 		"""Same raw-set_value path skips on_update, so the merge must drop the

--- a/wiki/frappe_wiki/doctype/wiki_document/wiki_sqlite_search.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/wiki_sqlite_search.py
@@ -90,11 +90,15 @@ class WikiSQLiteSearch(SQLiteSearch):
 
 
 def enqueue_reindex(docnames: list[str]):
-	"""Queue Wiki Documents for search re-indexing.
+	"""Re-index Wiki Documents after a merge.
 
 	Merge fast paths write content with raw ``frappe.db.set_value``, which
-	skips the framework's on_update hook that normally queues the re-index —
-	without this, the search index keeps serving the pre-merge content.
+	skips the framework's on_update hook that normally triggers the re-index,
+	so without this the search index keeps serving the pre-merge content.
+
+	Goes through ``index_doc`` rather than the framework's queue table: the
+	queue only exists on Frappe develop, while ``index_doc`` is present on
+	version-16 too (indexing inline there, queueing on develop).
 	"""
 	search = WikiSQLiteSearch()
 	if not (search.is_search_enabled() and search.index_exists()):
@@ -102,11 +106,11 @@ def enqueue_reindex(docnames: list[str]):
 
 	try:
 		for docname in docnames:
-			search.add_to_queue(f"Wiki Document:{docname}")
+			search.index_doc("Wiki Document", docname)
 	except Exception:
 		frappe.log_error(
-			title="Wiki Search Reindex Queue Error",
-			message=f"Failed to queue Wiki Documents for re-indexing: {docnames}",
+			title="Wiki Search Reindex Error",
+			message=f"Failed to re-index Wiki Documents: {docnames}",
 		)
 
 


### PR DESCRIPTION
## Problem

On Frappe `version-16`, merging a change request logs `Failed to queue Wiki Documents for re-indexing: [...]` and the page is never re-indexed, so search keeps serving pre-merge content until a full rebuild. `enqueue_reindex()` called `SQLiteSearch.add_to_queue()`, which (along with the `search_index_queue` table and `index_docs_in_queue`) only exists on Frappe `develop`. The resulting `AttributeError` was swallowed by the surrounding `except Exception`.

Fixes #740

## Solution

Use `index_doc("Wiki Document", docname)` instead. Both branches ship it: it queues on `develop` (unchanged behaviour) and indexes inline on `version-16`. No version sniffing.

The test suite hit the same mismatch, so the queue drain now goes through a helper that no-ops when `index_docs_in_queue` is not importable.

New regression test `test_content_only_merge_reindexes_through_index_doc` asserts a content-only merge routes through `index_doc`; verified it fails with the old `add_to_queue` call restored.