### PR TITLE
fix: only validate route uniqueness when the route changes

### DIFF
--- a/wiki/frappe_wiki/doctype/wiki_change_request/test_wiki_change_request.py
+++ b/wiki/frappe_wiki/doctype/wiki_change_request/test_wiki_change_request.py
@@ -281,6 +281,32 @@ class TestWikiChangeRequest(FrappeTestCase):
 		item1 = get_revision_item(cr.head_revision, page1_key)
 		self.assertEqual(item1.parent_key, group_key)
 
+	def test_merge_reorder_with_preexisting_duplicate_route(self):
+		"""A reorder merge must not trip over duplicate routes it didn't create.
+
+		Merging re-saves every document in the space, so pre-existing invalid data
+		(two leaves sharing a route) used to block an unrelated reorder.
+		"""
+		space = create_test_wiki_space()
+		page_a = create_test_wiki_document(space.root_group, title="Page A")
+		page_b = create_test_wiki_document(space.root_group, title="Page B")
+		page_c = create_test_wiki_document(space.root_group, title="Page C")
+		frappe.db.set_value("Wiki Document", page_c.name, "route", page_a.route)
+
+		cr = create_change_request(space.name, "CR reorder duplicate route")
+		root_key = frappe.get_value("Wiki Document", space.root_group, "doc_key")
+		reorder_cr_children(cr.name, root_key, [page_b.doc_key, page_a.doc_key, page_c.doc_key])
+
+		_approve_and_merge(cr.name)
+
+		order = frappe.get_all(
+			"Wiki Document",
+			filters={"parent_wiki_document": space.root_group},
+			fields=["title", "sort_order"],
+			order_by="sort_order",
+		)
+		self.assertEqual([row.title for row in order], ["Page B", "Page A", "Page C"])
+
 	def test_diff_reorder_reports_location_and_position(self):
 		"""A reorder is classified as such and carries before/after position so the
 		review UI can show a structural move instead of an empty content diff."""

--- a/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
@@ -1429,6 +1429,57 @@ class TestSetRoute(WikiDocumentTestBase):
 		self.assertEqual(child.route, "single/child-page")
 
 
+class TestUniqueRouteValidation(WikiDocumentTestBase):
+	"""Route uniqueness only guards saves that actually touch the route."""
+
+	def test_save_with_untouched_route_ignores_preexisting_duplicate(self):
+		space = create_test_wiki_space(self, "Dup Route Space", "dup-route", None)
+		page_a = create_test_wiki_document(self, "Page A", parent=space.root_group, slug="page-a")
+		page_c = create_test_wiki_document(self, "Page C", parent=space.root_group, slug="page-c")
+
+		# Pre-existing invalid data: two leaves sharing a route.
+		frappe.db.set_value("Wiki Document", page_c.name, "route", page_a.route)
+
+		page_a.reload()
+		page_a.sort_order = 5
+		page_a.save()
+
+		self.assertEqual(frappe.db.get_value("Wiki Document", page_a.name, "sort_order"), 5)
+
+	def test_changing_route_to_an_existing_one_still_throws(self):
+		space = create_test_wiki_space(self, "Clash Space", "clash", None)
+		page_a = create_test_wiki_document(self, "Page A", parent=space.root_group, slug="page-a")
+		page_b = create_test_wiki_document(self, "Page B", parent=space.root_group, slug="page-b")
+
+		page_b.route = page_a.route
+		self.assertRaises(frappe.ValidationError, page_b.save)
+
+	def test_new_document_with_duplicate_route_still_throws(self):
+		space = create_test_wiki_space(self, "New Clash Space", "new-clash", None)
+		page_a = create_test_wiki_document(self, "Page A", parent=space.root_group, slug="page-a")
+
+		duplicate = frappe.get_doc(
+			{
+				"doctype": "Wiki Document",
+				"title": "Page A Copy",
+				"parent_wiki_document": space.root_group,
+				"route": page_a.route,
+				"content": "Content",
+			}
+		)
+		self.assertRaises(frappe.ValidationError, duplicate.insert)
+
+	def test_group_turning_into_leaf_still_throws(self):
+		space = create_test_wiki_space(self, "Group Clash Space", "group-clash", None)
+		page_a = create_test_wiki_document(self, "Page A", parent=space.root_group, slug="page-a")
+		group = create_test_wiki_document(self, "Group", parent=space.root_group, is_group=True, slug="group")
+
+		frappe.db.set_value("Wiki Document", group.name, "route", page_a.route)
+		group.reload()
+		group.is_group = 0
+		self.assertRaises(frappe.ValidationError, group.save)
+
+
 class TestExternalLinkExclusions(WikiDocumentTestBase):
 	"""
 	Tests that external link documents are excluded from search indexing

--- a/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
@@ -1469,6 +1469,36 @@ class TestUniqueRouteValidation(WikiDocumentTestBase):
 		)
 		self.assertRaises(frappe.ValidationError, duplicate.insert)
 
+	def test_publishing_a_duplicate_route_still_throws(self):
+		space = create_test_wiki_space(self, "Publish Clash Space", "publish-clash", None)
+		page_a = create_test_wiki_document(self, "Page A", parent=space.root_group, slug="page-a")
+		draft = create_test_wiki_document(
+			self, "Draft", parent=space.root_group, slug="draft", is_published=False
+		)
+
+		frappe.db.set_value("Wiki Document", draft.name, "route", page_a.route)
+		draft.reload()
+		draft.is_published = 1
+		self.assertRaises(frappe.ValidationError, draft.save)
+
+	def test_external_link_becoming_local_page_still_throws(self):
+		space = create_test_wiki_space(self, "Link Clash Space", "link-clash", None)
+		page_a = create_test_wiki_document(self, "Page A", parent=space.root_group, slug="page-a")
+		link = create_test_wiki_document(
+			self,
+			"Link",
+			parent=space.root_group,
+			slug="link",
+			is_external_link=True,
+			external_url="https://example.com",
+		)
+
+		frappe.db.set_value("Wiki Document", link.name, "route", page_a.route)
+		link.reload()
+		link.is_external_link = 0
+		link.external_url = None
+		self.assertRaises(frappe.ValidationError, link.save)
+
 	def test_group_turning_into_leaf_still_throws(self):
 		space = create_test_wiki_space(self, "Group Clash Space", "group-clash", None)
 		page_a = create_test_wiki_document(self, "Page A", parent=space.root_group, slug="page-a")

--- a/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/test_wiki_document.py
@@ -1464,6 +1464,7 @@ class TestUniqueRouteValidation(WikiDocumentTestBase):
 				"title": "Page A Copy",
 				"parent_wiki_document": space.root_group,
 				"route": page_a.route,
+				"is_published": 1,
 				"content": "Content",
 			}
 		)
@@ -1498,6 +1499,31 @@ class TestUniqueRouteValidation(WikiDocumentTestBase):
 		link.is_external_link = 0
 		link.external_url = None
 		self.assertRaises(frappe.ValidationError, link.save)
+
+	def test_unpublishing_a_duplicate_route_is_allowed(self):
+		space = create_test_wiki_space(self, "Unpublish Space", "unpublish", None)
+		page_a = create_test_wiki_document(self, "Page A", parent=space.root_group, slug="page-a")
+		page_b = create_test_wiki_document(self, "Page B", parent=space.root_group, slug="page-b")
+
+		frappe.db.set_value("Wiki Document", page_b.name, "route", page_a.route)
+		page_b.reload()
+		page_b.is_published = 0
+		page_b.save()
+
+		self.assertEqual(frappe.db.get_value("Wiki Document", page_b.name, "is_published"), 0)
+
+	def test_local_page_becoming_external_link_is_allowed(self):
+		space = create_test_wiki_space(self, "To Link Space", "to-link", None)
+		page_a = create_test_wiki_document(self, "Page A", parent=space.root_group, slug="page-a")
+		page_b = create_test_wiki_document(self, "Page B", parent=space.root_group, slug="page-b")
+
+		frappe.db.set_value("Wiki Document", page_b.name, "route", page_a.route)
+		page_b.reload()
+		page_b.is_external_link = 1
+		page_b.external_url = "https://example.com"
+		page_b.save()
+
+		self.assertEqual(frappe.db.get_value("Wiki Document", page_b.name, "is_external_link"), 1)
 
 	def test_group_turning_into_leaf_still_throws(self):
 		space = create_test_wiki_space(self, "Group Clash Space", "group-clash", None)

--- a/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
@@ -177,8 +177,13 @@ class WikiDocument(NestedSet):
 		if self.is_group or not self.route:
 			return
 
-		# Only a save that changes where the page is served can introduce a clash, and
-		# merges re-save every document in the space.
+		# The route resolver only serves published local pages, so a draft or an
+		# external link can't take a route from anyone.
+		if not self.is_published or self.is_external_link:
+			return
+
+		# Of the rest, only a save that moves the page onto a route it wasn't already
+		# serving can introduce a clash, and merges re-save every document in the space.
 		if not any(
 			self.has_value_changed(field)
 			for field in ("route", "is_group", "is_published", "is_external_link")

--- a/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
@@ -177,6 +177,10 @@ class WikiDocument(NestedSet):
 		if self.is_group or not self.route:
 			return
 
+		# An unchanged route can't introduce a clash, and merges re-save every document.
+		if not self.has_value_changed("route") and not self.has_value_changed("is_group"):
+			return
+
 		filters = {
 			"route": self.route,
 			"is_group": 0,

--- a/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
+++ b/wiki/frappe_wiki/doctype/wiki_document/wiki_document.py
@@ -177,8 +177,12 @@ class WikiDocument(NestedSet):
 		if self.is_group or not self.route:
 			return
 
-		# An unchanged route can't introduce a clash, and merges re-save every document.
-		if not self.has_value_changed("route") and not self.has_value_changed("is_group"):
+		# Only a save that changes where the page is served can introduce a clash, and
+		# merges re-save every document in the space.
+		if not any(
+			self.has_value_changed(field)
+			for field in ("route", "is_group", "is_published", "is_external_link")
+		):
 			return
 
 		filters = {


### PR DESCRIPTION
## Problem

Merging a change request that only reorders pages fails with `Another page with the route '...' already exists` when an unrelated duplicate route already exists in the space. The merge re-saves every document, so route uniqueness was validated on documents the change request never touched.

Fixes #753

## Solution

Only validate the route when the save can actually cause a collision:

- Skip pages that won't be served. The route resolver only serves published local pages, so a draft or an external link can't take a route from anyone.
- Of the rest, skip saves that don't move the page onto a route it wasn't already serving: no change to `route`, `is_group`, `is_published`, or `is_external_link`.

`has_value_changed` returns `True` for new documents, so inserts are still checked.

One consequence: an unpublished duplicate route can be inserted, and publishing it is what throws. Drafts don't reserve routes.

Tests cover the reorder merge with a pre-existing duplicate route, the transitions that must still throw (changing a route onto an existing one, inserting a duplicate, publishing a draft onto an occupied route, turning a group or an external link into a live page there), and the deactivations that must be allowed (unpublishing, turning a live page into an external link).