### PR TITLE
fix: stop the editor TOC rail squashing rows on long pages

### DIFF
--- a/e2e/tests/editor-toc.spec.ts
+++ b/e2e/tests/editor-toc.spec.ts
@@ -31,6 +31,13 @@ const SEED_HTML = [
 	...Array.from({ length: 25 }, (_, i) => `<p>usage note ${i}</p>`),
 ].join('');
 
+// More headings than the rail can show at once. This is the case from #749,
+// where the rail rendered every entry a few pixels tall instead of scrolling.
+const LONG_SEED_HTML = Array.from(
+	{ length: 60 },
+	(_, i) => `<h2>Section ${i}</h2><p>body ${i}</p>`,
+).join('');
+
 async function seedEditor(page: Page, html: string) {
 	const applied = await page.evaluate((content) => {
 		const editor = (
@@ -172,6 +179,28 @@ test.describe('Editor table of contents', () => {
 
 		// The entry you jumped to becomes the active one.
 		await expect(usage).toHaveClass(/text-ink-gray-9/);
+	});
+
+	test('a long outline scrolls the rail instead of squashing its rows', async ({
+		page,
+	}) => {
+		createdRoutes.push(await createSpaceWithPage(page, Date.now()));
+		await seedEditor(page, LONG_SEED_HTML);
+
+		const rail = page.locator('[data-testid="editor-toc-rail"]');
+		const links = rail.locator('[data-testid="editor-toc-link"]');
+		await expect(links).toHaveCount(60);
+
+		// Every row keeps a readable height (one line of text plus py-1)...
+		const box = await links.first().boundingBox();
+		expect(box?.height ?? 0).toBeGreaterThanOrEqual(20);
+
+		// ...and the overflow goes to the rail's own scrollbar.
+		const nav = rail.locator('nav');
+		const scrollable = await nav.evaluate(
+			(el) => el.scrollHeight > el.clientHeight,
+		);
+		expect(scrollable).toBe(true);
 	});
 
 	test('falls back to a collapsible strip when the editor is too narrow', async ({

--- a/frontend/src/components/EditorTableOfContents.vue
+++ b/frontend/src/components/EditorTableOfContents.vue
@@ -21,7 +21,7 @@
 				:key="entry.pos"
 				type="button"
 				data-testid="editor-toc-link"
-				class="truncate border-l py-1 text-left"
+				class="shrink-0 truncate border-l py-1 text-left"
 				:class="[
 					entry.level >= 3 && hasH2 ? 'pl-7' : 'pl-4',
 					index === activeIndex


### PR DESCRIPTION
closes #749 

## Problem

On a page with many headings, the editor's "On this page" rail renders every entry a few pixels tall, so the text is clipped and unreadable. Reported in #749.

**Before:** 60 headings, rows squashed to 12.5px, text clipped

![toc-before.png](https://github.com/user-attachments/assets/33a133ee-7ad0-4fcc-ba0e-4897e9795945)

## Solution

The rail's `nav` is a flex column with a `max-height`, and its entries use `truncate`. `overflow: hidden` zeroes a flex item's automatic minimum size, so the entries shrink to fit instead of the nav scrolling. `shrink-0` on the entries
keeps their content height and sends the overflow to the nav's scrollbar.

**After:** 29px rows, rail scrolls

![toc-after.png](https://github.com/user-attachments/assets/31d4bcdd-b0e3-4e68-94be-bd492dad23e6)

The public reader's TOC uses the same flex column but no `truncate`, so it already scrolls correctly. Not affected.

Covered by a new e2e test in `editor-toc.spec.ts` (60 headings; asserts row height and that the nav overflows). It fails on a temp revert of the fix.