### PR TITLE
fix: keep the space logo picker inside the viewport

### DIFF
--- a/frontend/src/components/IconGrid.vue
+++ b/frontend/src/components/IconGrid.vue
@@ -1,6 +1,6 @@
 <template>
-	<div class="relative">
-		<div class="max-h-72 overflow-y-auto p-2 pb-5">
+	<div class="relative flex min-h-0 flex-1 flex-col">
+		<div class="min-h-0 max-h-72 flex-1 overflow-y-auto p-2 pb-5">
 			<div
 				class="grid grid-cols-8 gap-1"
 				role="listbox"

--- a/frontend/src/components/IconPicker.vue
+++ b/frontend/src/components/IconPicker.vue
@@ -29,8 +29,11 @@
 				@open-auto-focus.prevent
 			>
 				<div
-					class="max-w-[calc(100vw-2rem)] overflow-hidden rounded-6 bg-surface-elevation-2 text-base shadow-2xl ring-1 ring-black ring-opacity-5"
-				 	style="transform-origin: var(--reka-popover-content-transform-origin)"
+					class="flex max-w-[calc(100vw-2rem)] flex-col overflow-hidden rounded-6 bg-surface-elevation-2 text-base shadow-2xl ring-1 ring-black ring-opacity-5"
+					style="
+						transform-origin: var(--reka-popover-content-transform-origin);
+						max-height: var(--reka-popper-available-height, 100vh);
+					"
 				>
 					<IconGrid
 						:model-value="modelValue"

--- a/frontend/src/components/SpaceIdentityPicker.vue
+++ b/frontend/src/components/SpaceIdentityPicker.vue
@@ -17,7 +17,10 @@
 		</template>
 
 		<template #default>
-			<div class="w-64 space-y-3 p-3">
+			<div
+				class="flex w-64 flex-col gap-3 p-3"
+				style="max-height: var(--reka-popper-available-height, 100vh)"
+			>
 				<!-- An upload and a generated mark are alternatives, not layers,
 				     so the control that picks between them is a value control
 				     and the panels follow — hence TabButtons rather than Tabs.
@@ -70,9 +73,7 @@
 
 					<!-- No wrapper surface: the grid's own bottom fade is drawn
 					     `from-surface-elevation-2`, which is the panel. -->
-					<div class="-mx-3">
-						<IconGrid :model-value="icon" @select="pickIcon" />
-					</div>
+					<IconGrid class="-mx-3" :model-value="icon" @select="pickIcon" />
 				</template>
 
 				<template v-else>


### PR DESCRIPTION
## Problem

Opening the Space Logo picker on a short window pushes the popover off the top of the screen. The colour swatches and the Icon/Upload tabs cannot be reached.

**Before**

<img width="2880" height="1658" alt="image" src="https://github.com/user-attachments/assets/3f3754e3-b8c5-4479-adc6-6f65bacfe6a1" />

**After**

<img width="2880" height="1658" alt="image" src="https://github.com/user-attachments/assets/6c56970e-9bab-4ee6-9147-2db07558e078" />

## Solution

reka's popover defaults to `sticky: "partial"`, so `shift()` gets `limitShift()` and keeps the panel attached to its trigger rather than clamping it to the viewport. A panel taller than the room on its side has to cap itself.

Both icon popovers now cap at `--reka-popper-available-height`, and the icon grid shrinks into what is left: its scroller is a flex child rather than a percentage height, which a flex item's auto height leaves indefinite. Without that the grid kept its full 18rem, spilled past the panel and was chopped mid-row by the shell's overflow, taking the bottom padding and the fade with it.

`IconPicker`'s tab-icon popover had the same bug and got the same fix.
