### PR TITLE
fix: load translations before mounting app

### DIFF
--- a/e2e/tests/translations.spec.ts
+++ b/e2e/tests/translations.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test } from '../fixtures';
+import { APP_BASE } from '../helpers/routes';
+
+const TRANSLATIONS_URL = '**/api/method/wiki.api.get_translations';
+
+test.describe('Translations', () => {
+	test('loads translations before the first render', async ({ page }) => {
+		await page.route(TRANSLATIONS_URL, async (route) => {
+			await new Promise((resolve) => setTimeout(resolve, 500));
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({
+					message: {
+						Settings: 'Configuración de prueba',
+						Spaces: 'Espacios de prueba',
+						'Change Requests': 'Solicitudes de prueba',
+						'Toggle Theme': 'Cambiar tema de prueba',
+						'Log out': 'Salir de prueba',
+					},
+				}),
+			});
+		});
+
+		const translationsLoaded = page.waitForResponse(TRANSLATIONS_URL);
+		await page.goto(APP_BASE);
+		await translationsLoaded;
+
+		await expect(
+			page.getByRole('link', { name: 'Espacios de prueba', exact: true }),
+		).toBeVisible();
+		await expect(
+			page.getByRole('link', {
+				name: 'Solicitudes de prueba',
+				exact: true,
+			}),
+		).toBeVisible();
+
+		await page
+			.getByRole('button', { name: /Frappe Wiki/ })
+			.first()
+			.click();
+		await expect(
+			page.getByText('Configuración de prueba', { exact: true }),
+		).toBeVisible();
+		await expect(
+			page.getByText('Cambiar tema de prueba', { exact: true }),
+		).toBeVisible();
+		await expect(
+			page.getByText('Salir de prueba', { exact: true }),
+		).toBeVisible();
+	});
+
+	test('falls back to source strings when translations fail', async ({
+		page,
+	}) => {
+		await page.route(TRANSLATIONS_URL, (route) =>
+			route.fulfill({
+				status: 500,
+				contentType: 'application/json',
+				body: JSON.stringify({ exc_type: 'TranslationError' }),
+			}),
+		);
+
+		await page.goto(APP_BASE);
+
+		await expect(
+			page.getByRole('link', { name: 'Spaces', exact: true }),
+		).toBeVisible();
+		await expect(
+			page.getByRole('link', { name: 'Change Requests', exact: true }),
+		).toBeVisible();
+	});
+});

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -31,22 +31,26 @@ const globalComponents = {
 	Badge,
 };
 
-const app = createApp(App);
-
 setConfig('resourceFetcher', frappeRequest);
 
-await loadTranslations();
+async function bootstrap() {
+	await loadTranslations();
 
-app.use(pinia);
-app.use(router);
-app.use(translationPlugin);
-app.use(resourcesPlugin);
+	const app = createApp(App);
 
-const socket = initSocket();
-app.config.globalProperties.$socket = socket;
+	app.use(pinia);
+	app.use(router);
+	app.use(translationPlugin);
+	app.use(resourcesPlugin);
 
-for (const key in globalComponents) {
-	app.component(key, globalComponents[key]);
+	const socket = initSocket();
+	app.config.globalProperties.$socket = socket;
+
+	for (const key in globalComponents) {
+		app.component(key, globalComponents[key]);
+	}
+
+	app.mount('#app');
 }
 
-app.mount('#app');
+bootstrap();

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -5,7 +5,7 @@ import router from './router';
 import { initSocket } from './socket';
 import { pinia } from './stores';
 
-import translationPlugin from './translation';
+import translationPlugin, { loadTranslations } from './translation';
 
 import {
 	Badge,
@@ -34,6 +34,8 @@ const globalComponents = {
 const app = createApp(App);
 
 setConfig('resourceFetcher', frappeRequest);
+
+await loadTranslations();
 
 app.use(pinia);
 app.use(router);

--- a/frontend/src/translation.js
+++ b/frontend/src/translation.js
@@ -1,9 +1,21 @@
-import { createResource } from 'frappe-ui';
+import { frappeRequest } from 'frappe-ui';
+
+export async function loadTranslations() {
+	if (window.translatedMessages) return;
+
+	try {
+		window.translatedMessages = await frappeRequest({
+			url: 'wiki.api.get_translations',
+		});
+	} catch (error) {
+		console.error('Failed to load translations', error);
+		window.translatedMessages = {};
+	}
+}
 
 export default function translationPlugin(app) {
 	app.config.globalProperties.__ = translate;
 	window.__ = translate;
-	if (!window.translatedMessages) fetchTranslations();
 }
 
 function format(message, replace) {
@@ -33,14 +45,4 @@ function translate(message, replace, context = null) {
 	}
 
 	return format(translatedMessage, replace);
-}
-
-function fetchTranslations() {
-	createResource({
-		url: 'wiki.api.get_translations',
-		auto: true,
-		transform: (data) => {
-			window.translatedMessages = data;
-		},
-	});
 }


### PR DESCRIPTION
## Problem
Wiki mounts Vue before translations are available. Labels evaluated during setup remain in English, while views mounted after the translations arrive render in the selected language.

Downstream apps can provide translation catalogs, but they cannot control Wiki's mounting lifecycle without patching its frontend.

## Solution
Load translations before mounting the app. If loading fails or stalls, continue with source strings as a safe fallback.

## Demo

### Before
Persistent navigation remains in English while newly mounted content is translated.

<img width="1200" height="772" alt="Before: persistent navigation remains in English while newly mounted content is translated" src="https://github.com/user-attachments/assets/b14b1133-16a3-4abd-a892-9f94dd93e4fc" />

### After
Persistent and newly mounted UI use the same translation catalog.

<img width="1200" height="772" alt="After: persistent and newly mounted UI are translated" src="https://github.com/user-attachments/assets/eaf7f82a-7879-41d5-9733-742aa8439ecd" />