### PR TITLE
fix: reveal the current page in the editor tree

### DIFF
--- a/e2e/tests/change-request-flow.spec.ts
+++ b/e2e/tests/change-request-flow.spec.ts
@@ -521,8 +521,10 @@ test.describe('Change Request Flow', () => {
 		await page.reload();
 		await page.waitForLoadState('networkidle');
 
-		// Ensure the group is expanded for assertions
-		await page.locator('aside').getByText(groupTitle, { exact: true }).click();
+		// The space opens its first page, so the tree has already revealed the group.
+		await expect(
+			page.locator('aside').getByText(pageTitles[0], { exact: true }),
+		).toBeVisible();
 
 		const sidebarText = await page.locator('aside').innerText();
 		expect(sidebarText.indexOf(pageTitles[1])).toBeLessThan(

--- a/e2e/tests/editor-tree-reveal.spec.ts
+++ b/e2e/tests/editor-tree-reveal.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from '../fixtures';
+import type { SeededPage, SeededSpace } from '../helpers/factory';
+
+/**
+ * The editor tree must reveal the page being edited when it is opened from
+ * outside the tree (the reader's Edit link, a reload, a deep link): expand its
+ * ancestor groups and scroll its row into view, as the reader sidebar does
+ * (see issue #521).
+ */
+test.describe('Editor tree reveals the current page', () => {
+	let space: SeededSpace;
+	let deepPage: SeededPage;
+	let lastFiller: SeededPage;
+
+	const FILLER_COUNT = 30;
+
+	test.beforeAll(async ({ wikiSuite }) => {
+		const fillerTitles = Array.from(
+			{ length: FILLER_COUNT },
+			(_, i) => `Filler Page ${String(i).padStart(2, '0')}`,
+		);
+		space = await wikiSuite.space({
+			pages: [
+				{ title: 'Top Page' },
+				// Two collapsed levels above the page the tree has to reveal.
+				{
+					title: 'Outer Group',
+					is_group: true,
+					children: [
+						{
+							title: 'Inner Group',
+							is_group: true,
+							children: [{ title: 'Deep Page' }],
+						},
+					],
+				},
+				// Enough siblings to push the last one below the fold.
+				...fillerTitles.map((title) => ({ title })),
+			],
+		});
+		deepPage = space.page('Deep Page');
+		lastFiller = space.page(fillerTitles[fillerTitles.length - 1]);
+	});
+
+	test('Edit from the reader expands the ancestor groups', async ({ page }) => {
+		await page.goto(`/${deepPage.route}`);
+		await page.locator('.wiki-edit-link:visible').first().click();
+		await page.waitForURL(`**${space.url('page', deepPage.name)}`);
+
+		const selected = page.locator('aside [data-selected]');
+		await expect(selected).toHaveText('Deep Page');
+		await expect(selected).toBeInViewport();
+	});
+
+	test('loading the editor scrolls a far-down page into view', async ({
+		page,
+	}) => {
+		await page.goto(space.url('page', lastFiller.name));
+
+		const selected = page.locator('aside [data-selected]');
+		await expect(selected).toHaveText(lastFiller.title);
+		await expect(selected).toBeInViewport();
+	});
+});

--- a/e2e/tests/stale-tab-flags.spec.ts
+++ b/e2e/tests/stale-tab-flags.spec.ts
@@ -194,8 +194,10 @@ test.describe('A space carrying legacy tab flags', () => {
 		).toBeVisible();
 		await expect(page.getByRole('tablist')).toHaveCount(0);
 
-		// And they expand like any other group.
-		await tree.getByText('Accounting', { exact: true }).click();
-		await expect(tree.getByText('Receivables', { exact: true })).toBeVisible();
+		// And they expand like any other group. Not Accounting: the space opens a
+		// page inside it, so the tree has already revealed that one.
+		await expect(tree.getByText('Production', { exact: true })).toHaveCount(0);
+		await tree.getByText('Manufacturing', { exact: true }).click();
+		await expect(tree.getByText('Production', { exact: true })).toBeVisible();
 	});
 });

--- a/frontend/src/components/WikiDocumentList.vue
+++ b/frontend/src/components/WikiDocumentList.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="flex h-full min-h-0 flex-col">
+	<div ref="rootEl" class="flex h-full min-h-0 flex-col">
 		<!-- Search sits above the scroller, so it stays put while results move. -->
 		<div v-if="hasPages" class="shrink-0 px-2 pb-2">
 			<TextInput
@@ -258,7 +258,7 @@ import {
 	TextInput,
 	Tooltip,
 } from 'frappe-ui';
-import { computed, onBeforeUnmount, ref, toRef, watch } from 'vue';
+import { computed, nextTick, onBeforeUnmount, ref, toRef, watch } from 'vue';
 import SpaceIcon from './SpaceIcon.vue';
 import WikiTree from './WikiTree.vue';
 
@@ -328,6 +328,50 @@ function revealGroup(node) {
 	expandedNodes.value[node.doc_key] = true;
 	searchQuery.value = '';
 }
+
+// Reveal a page opened from outside the tree (Edit link, reload, deep link).
+const rootEl = ref(null);
+
+function findAncestorKeys(nodes, isTarget) {
+	for (const node of nodes || []) {
+		if (isTarget(node)) return [];
+		const path = findAncestorKeys(node.children, isTarget);
+		if (path) return [node.doc_key, ...path];
+	}
+	return null;
+}
+
+const selectedAncestorKeys = computed(() => {
+	const { selectedPageId, selectedDraftKey } = props;
+	if (!selectedPageId && !selectedDraftKey) return null;
+	return findAncestorKeys(props.treeData?.children, (node) =>
+		selectedPageId
+			? !node.is_group && node.document_name === selectedPageId
+			: !node.document_name && node.doc_key === selectedDraftKey,
+	);
+});
+
+// Keyed on the selection, not the tree, so unrelated edits don't re-expand or re-scroll.
+watch(
+	() =>
+		selectedAncestorKeys.value &&
+		[
+			props.selectedPageId,
+			props.selectedDraftKey,
+			...selectedAncestorKeys.value,
+		].join('/'),
+	async () => {
+		if (!selectedAncestorKeys.value) return;
+		for (const key of selectedAncestorKeys.value) {
+			expandedNodes.value[key] = true;
+		}
+		await nextTick();
+		rootEl.value
+			?.querySelector('[data-selected]')
+			?.scrollIntoView({ block: 'nearest' });
+	},
+	{ immediate: true },
+);
 
 const {
 	showCreateDialog,


### PR DESCRIPTION
## Problem
Opening a page in the editor from the reader's Edit link, a reload or a deep link leaves its parent groups collapsed and the page off screen in the tree (#521).

## Solution
Expand the page's ancestor groups and scroll its row into view when the selection changes, as the reader sidebar already does. Adds an e2e spec.

Fixes #521

## Screenshots

**Edit from the reader**

| Before | After |
|---|---|
| ![before-edit-from-reader.png](https://github.com/user-attachments/assets/914b2dd8-f7e3-4c59-a574-5af134e9004b) | ![after-edit-from-reader.png](https://github.com/user-attachments/assets/5be39c90-04d2-46e1-9ac7-04d93b931b64) |

**Reload the editor**

| Before | After |
|---|---|
| ![before-reload.png](https://github.com/user-attachments/assets/f1b12bff-d991-4e8d-9392-677e06489d4d) | ![after-reload.png](https://github.com/user-attachments/assets/b77aaec6-1ff5-4c27-9496-f1c98c731c77) |